### PR TITLE
Chicoma CPU fix

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,6 +47,27 @@
       }
     },
     {
+      "name": "chicoma-cpu-debug",
+      "cacheVariables": {
+        "CMAKE_MAKE_PROGRAM": "$env{MAKE_PROGRAM}",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "Kokkos_ENABLE_DEBUG_BOUNDS_CHECK": "ON",
+        "CMAKE_CXX_COMPILER": "CC",
+        "HDF5_INCLUDE_DIR": "$env{HDF5_ROOT}/include",
+        "PARTHENON_DISABLE_HDF5_COMPRESSION": "ON"
+      }
+    },
+    {
+      "name": "chicoma-cpu-release",
+      "cacheVariables": {
+        "CMAKE_MAKE_PROGRAM": "$env{MAKE_PROGRAM}",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_CXX_COMPILER": "CC",
+        "HDF5_INCLUDE_DIR": "$env{HDF5_ROOT}/include",
+        "PARTHENON_DISABLE_HDF5_COMPRESSION": "ON"
+      }
+    },
+    {
       "name": "chicoma-gpu-debug",
       "cacheVariables": {
         "CMAKE_MAKE_PROGRAM": "$env{MAKE_PROGRAM}",

--- a/env/bash
+++ b/env/bash
@@ -86,7 +86,7 @@ elif [[ $PARTITION == "chicoma-cpu" ]]; then
     source /usr/projects/hpcsoft/common/x86_64/anaconda/2023.03-python-3.10/bin/activate /usr/projects/jovian/dependencies/python/chicoma-frontend
     shorten_prompt
     module load cmake
-    export ARTEMIS_SUITE=cpu
+    export ARTEMIS_SUITE=chicoma-cpu
     echo "...setup SUCCEEDED"
 elif [[ $PARTITION == "darwin-power9-rhel7" ]]; then
     echo "darwin-power9-rhel7 partition has been decommissioned! Exiting..."


### PR DESCRIPTION
## Background

Gennaro noticed that our chicoma CPU builds are failing, because it can't find HDF5 without help.

## Description of Changes

- [x] Add `chicoma-cpu-debug` and `chicoma-cpu-release` cmake presets
- [x] Set suite to `chicoma-cpu` in `env/bash`

## Checklist

- [x] New features are documented
- [x] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files
