### PR TITLE
Derived test module reloads and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,12 @@ jobs:
             --reuse_build \
             --use_oversubscribe \
             --log_file=ci_cpu_log.txt
-      - name: Upload CPU test log
+      - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ci_cpu_log.txt
-          path: tst/ci_cpu_log.txt
+          name: logs
+          path: tst/logs
           retention-days: 3
       - name: Upload figures
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           python3 run_tests.py regression.suite \
             --save_build \
             --reuse_build \
+            --use_oversubscribe \
             --log_file=ci_cpu_log.txt
       - name: Upload CPU test log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: logs
-          path: tst/logs
+          path: tst/testing/logs
           retention-days: 3
       - name: Upload figures
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: figs
-          path: tst/figs
+          path: tst/testing/figs
           retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@ doc/src/parameters.rst
 
 # CI files
 artemis_ci_*.out
+tst/logs
 tst/figs
+**/testing/
 
 # Visualization package files
 .smhist

--- a/tst/run_tests.py
+++ b/tst/run_tests.py
@@ -166,7 +166,7 @@ def main(**kwargs):
                 # insert arguments for artemis.make()
                 artemis_cmake_args = kwargs.pop("cmake")
                 artemis_make_nproc = kwargs.pop("make_nproc")
-                module.artemis.make(artemis_cmake_args, artemis_make_nproc)
+                artemis.make(artemis_cmake_args, artemis_make_nproc)
             except Exception:
                 logger.error("Exception occurred", exc_info=True)
                 test_errors.append("make()")
@@ -308,7 +308,7 @@ def set_globals(args):
     else:
         # If we are in a directory with an executable, default to using that
         local_path = os.path.join(os.getcwd(), "artemis")
-        if os.path.exists(local_path) and os.access(local_path, os.X_OK):
+        if os.path.isfile(local_path) and os.access(local_path, os.X_OK):
             # If no out_dir was passed, set it to the cwd
             if out_dir is None:
                 out_dir = os.getcwd()

--- a/tst/run_tests.py
+++ b/tst/run_tests.py
@@ -287,9 +287,8 @@ def set_globals(args):
 
     # Set the correct paths
     if exe_path is not None:
-        out_dir = (
-            os.path.join(artemis_dir, "tst/testing") if out_dir is None else out_dir
-        )
+        adir = os.path.join(artemis.get_artemis_dir(), "tst")
+        out_dir = os.path.join(adir, "testing") if out_dir is None else out_dir
         reb_path = os.path.join(os.path.dirname(exe_path), "librebound.so")
 
         if not (os.path.exists(exe_path) and os.access(exe_path, os.X_OK)):

--- a/tst/run_tests.py
+++ b/tst/run_tests.py
@@ -262,6 +262,7 @@ def log_init(args):
     # setup log_file
     log_fn = kwargs.pop("log_file")
     if log_fn:
+        os.makedirs(artemis.get_log_dir(), exist_ok=True)
         f_handler = logging.FileHandler(os.path.join(artemis.get_log_dir(), log_fn))
         f_handler.setLevel(0)  # log everything
         f_format = logging.Formatter(

--- a/tst/scripts/advection/advection.py
+++ b/tst/scripts/advection/advection.py
@@ -19,10 +19,10 @@
 import logging
 import numpy as np
 import os
-import scripts.utils.artemis as artemis
 import sys
+import scripts.utils.artemis as artemis
 
-sys.path.append(os.path.join(artemis.artemis_dir, "analysis"))
+sys.path.append(os.path.join(artemis.get_artemis_dir(), "analysis"))
 from ahistory import ahistory
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
@@ -72,17 +72,16 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    # NOTE(@pdmullen):  In the below, we check the magnitude of the error,
-    # error convergence rates, and error identicality between L- and R-going
-    # advection.
+    # NOTE(@pdmullen):  In the below, we check the magnitude of the error, error
+    # convergence rates, and error identicality between L- and R-going advection.
     logger.debug("Analyzing test " + __name__)
-    err_path = os.path.join(artemis.get_run_directory(), _file_id + "-errs.dat")
+    err_path = os.path.join(artemis.get_data_dir(), _file_id + "-errs.dat")
     data = np.loadtxt(
         err_path,
         dtype=np.float64,
         ndmin=2,
     )
-    hist_path = os.path.join(artemis.get_run_directory(), _file_id + ".out0.hst")
+    hist_path = os.path.join(artemis.get_data_dir(), _file_id + ".out0.hst")
     history = ahistory(hist_path)
     os.system(f"rm {err_path}")
     os.system(f"rm {hist_path}")

--- a/tst/scripts/advection/advection_mpi.py
+++ b/tst/scripts/advection/advection_mpi.py
@@ -16,14 +16,13 @@
 # softwares.
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.advection.advection as advection
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 
+importlib.reload(advection)
 advection._nranks = 4
 advection._file_id = "advection_mpi"
 

--- a/tst/scripts/binary/binary.py
+++ b/tst/scripts/binary/binary.py
@@ -23,10 +23,13 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
+from scipy.interpolate import interp1d
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "binary"
@@ -44,16 +47,12 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     logger.debug("Analyzing test " + __name__)
-    os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
+    os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, r, phi, z, [d, u, v, w, T] = load_level(
-        "final", base="{}.out1".format(_file_id), dir=artemis.get_run_directory()
+    time, r, phi, z, [d, u, v, w, T] = artemis.load_level(
+        "final", base="{}.out1".format(_file_id), dir=artemis.get_data_dir()
     )
     rc = 0.5 * (r[1:] + r[:-1])
     pc = 0.5 * (phi[1:] + phi[:-1])
@@ -69,8 +68,8 @@ def analyze():
     axes[0].pcolormesh(rc, pc, sig, norm=norm)
     ri = np.linspace(r.min(), 1 - 2.0 / 3 * h, 50)
     ro = np.linspace(1 + 2.0 / 3 * h, r.max(), 50)
-    axes[0].plot(ri, [spiral_pos(x) for x in ri], "--w")
-    axes[0].plot(ro, [spiral_pos(x) for x in ro], "--w")
+    axes[0].plot(ri, [artemis.spiral_pos(x) for x in ri], "--w")
+    axes[0].plot(ro, [artemis.spiral_pos(x) for x in ro], "--w")
 
     axes[0].set_xlim(0.6, 1.4)
     axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
@@ -85,8 +84,8 @@ def analyze():
     po = pc[np.argwhere(sig[:, io] == sig[:, io].max())[0][0]]
 
     # the analytic answers
-    p0i = spiral_pos(1 - 0.1)
-    p0o = spiral_pos(1 + 0.1)
+    p0i = artemis.spiral_pos(1 - 0.1)
+    p0o = artemis.spiral_pos(1 + 0.1)
 
     # the errors
     names = ["Inner location", "Outer Location"]
@@ -105,10 +104,10 @@ def analyze():
     axes[1].legend(loc="best", fontsize=12)
     axes[1].set_ylabel("$\\Sigma - \\langle \\Sigma \\rangle$", fontsize=20)
     axes[0].set_ylabel("$\\phi$", fontsize=20)
-    create_colorbar(axes[0], norm=norm)
+    artemis.create_colorbar(axes[0], norm=norm)
     fig.tight_layout()
     fig.savefig(
-        os.path.join(artemis.artemis_fig_dir, _file_id + "_spiral.png"),
+        os.path.join(artemis.get_fig_dir(), _file_id + "_spiral.png"),
         bbox_inches="tight",
     )
 
@@ -140,7 +139,7 @@ def analyze():
     ax.legend(loc="best", fontsize=12)
     fig.tight_layout()
     fig.savefig(
-        os.path.join(artemis.artemis_fig_dir, _file_id + "_temp.png"),
+        os.path.join(artemis.get_fig_dir(), _file_id + "_temp.png"),
         bbox_inches="tight",
     )
 
@@ -154,125 +153,3 @@ def analyze():
             analyze_status = False
 
     return analyze_status
-
-
-def spiral_pos(r, r0=1.0, p0=np.pi, h=0.05):
-    # Analytic spiral position from Ogilvie & Lubow (2002)
-    def mod_2pi(p):
-        while p > 2 * np.pi:
-            p -= 2 * np.pi
-        while p < 0.0:
-            p += 2 * np.pi
-        return p
-
-    if r > r0:
-        return mod_2pi(
-            p0 - mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
-        )
-    if r < r0:
-        return mod_2pi(
-            p0 + mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
-        )
-    return p0
-
-
-def load_level(n, base="binary.out1", dir="./", off=0):
-    # Loads a snapshot and combines the blocks on a single level
-    # This assumes levels are nested properly
-    import h5py
-
-    try:
-        fname = "{}/{}.{:05d}.phdf".format(dir, base, n)
-    except:
-        fname = "{}/{}.{}.phdf".format(dir, base, n)
-
-    with h5py.File(fname, "r") as f:
-        time = f["Info"].attrs["Time"]
-
-        lvl = f["Levels"][...]
-        ind = lvl == max(lvl.max() - off, 0)
-
-        offset = f["LogicalLocations"][...][ind, :]
-        x = f["Locations/x"][...][ind, :]
-        y = f["Locations/y"][...][ind, :]
-        z = f["Locations/z"][...][ind, :]
-        db = f["gas.prim.density_0"][...][ind, :]
-        pb = f["gas.prim.pressure_0"][...][ind, :]
-        ub = f["gas.prim.velocity_0"][...][ind, 0, :]
-        vb = f["gas.prim.velocity_0"][...][ind, 1, :]
-        wb = f["gas.prim.velocity_0"][...][ind, 2, :]
-        sys = f["Params"].attrs["artemis/coord_sys"]
-        time = f["Info"].attrs["Time"]
-
-    nb, bsz, bsy, bsx = db.shape
-
-    offset[:, 0] -= offset[:, 0].min()
-    offset[:, 1] -= offset[:, 1].min()
-    offset[:, 2] -= offset[:, 2].min()
-
-    nx = bsx * (offset[:, 0].max() + 1)
-    ny = bsy * (offset[:, 1].max() + 1)
-    nz = bsz * (offset[:, 2].max() + 1)
-
-    d = np.zeros((nz, ny, nx))
-    p = np.zeros((nz, ny, nx))
-    u = np.zeros((nz, ny, nx))
-    v = np.zeros((nz, ny, nx))
-    w = np.zeros((nz, ny, nx))
-    for n in range(nb):
-        ix = offset[n, 0]
-        iy = offset[n, 1]
-        iz = offset[n, 2]
-        d[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = db[n, :, :, :]
-        p[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = pb[n, :, :, :]
-        u[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = ub[n, :, :, :]
-        v[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = vb[n, :, :, :]
-        w[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = wb[n, :, :, :]
-
-    x = np.linspace(x.min(), x.max(), nx + 1)
-    y = np.linspace(y.min(), y.max(), ny + 1)
-    z = np.linspace(z.min(), z.max(), nz + 1)
-    return time, x, y, z, [d, u, v, w, p / d]
-
-
-def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
-    import matplotlib
-    import matplotlib.cm
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-
-    labelsize = kargs.pop("labelsize", 14)
-    labelsize = kargs.pop("fontsize", 14)
-
-    if cax is None:
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes(where, size="3%", pad=0.05)
-
-    cmap = matplotlib.cm.get_cmap(cmap)
-    cb = matplotlib.colorbar.ColorbarBase(
-        ax=cax, cmap=cmap, norm=norm, orientation="horizontal", **kargs
-    )
-    cb.ax.xaxis.set_ticks_position(where)
-    cb.ax.xaxis.set_label_position(where)
-    cb.ax.tick_params(labelsize=labelsize)
-
-    return cb

--- a/tst/scripts/binary/binary.py
+++ b/tst/scripts/binary/binary.py
@@ -28,6 +28,7 @@ from scipy.interpolate import interp1d
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import scripts.utils.analysis as analysis
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
@@ -51,7 +52,7 @@ def analyze():
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, r, phi, z, [d, u, v, w, T] = artemis.load_level(
+    time, r, phi, z, [d, u, v, w, T] = analysis.load_level(
         "final", base="{}.out1".format(_file_id), dir=artemis.get_data_dir()
     )
     rc = 0.5 * (r[1:] + r[:-1])
@@ -68,8 +69,8 @@ def analyze():
     axes[0].pcolormesh(rc, pc, sig, norm=norm)
     ri = np.linspace(r.min(), 1 - 2.0 / 3 * h, 50)
     ro = np.linspace(1 + 2.0 / 3 * h, r.max(), 50)
-    axes[0].plot(ri, [artemis.spiral_pos(x) for x in ri], "--w")
-    axes[0].plot(ro, [artemis.spiral_pos(x) for x in ro], "--w")
+    axes[0].plot(ri, [analytic.spiral_pos(x) for x in ri], "--w")
+    axes[0].plot(ro, [analytic.spiral_pos(x) for x in ro], "--w")
 
     axes[0].set_xlim(0.6, 1.4)
     axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
@@ -84,8 +85,8 @@ def analyze():
     po = pc[np.argwhere(sig[:, io] == sig[:, io].max())[0][0]]
 
     # the analytic answers
-    p0i = artemis.spiral_pos(1 - 0.1)
-    p0o = artemis.spiral_pos(1 + 0.1)
+    p0i = analytic.spiral_pos(1 - 0.1)
+    p0o = analytic.spiral_pos(1 + 0.1)
 
     # the errors
     names = ["Inner location", "Outer Location"]
@@ -104,7 +105,7 @@ def analyze():
     axes[1].legend(loc="best", fontsize=12)
     axes[1].set_ylabel("$\\Sigma - \\langle \\Sigma \\rangle$", fontsize=20)
     axes[0].set_ylabel("$\\phi$", fontsize=20)
-    artemis.create_colorbar(axes[0], norm=norm)
+    analysis.create_colorbar(axes[0], norm=norm)
     fig.tight_layout()
     fig.savefig(
         os.path.join(artemis.get_fig_dir(), _file_id + "_spiral.png"),

--- a/tst/scripts/binary/binary.py
+++ b/tst/scripts/binary/binary.py
@@ -69,8 +69,8 @@ def analyze():
     axes[0].pcolormesh(rc, pc, sig, norm=norm)
     ri = np.linspace(r.min(), 1 - 2.0 / 3 * h, 50)
     ro = np.linspace(1 + 2.0 / 3 * h, r.max(), 50)
-    axes[0].plot(ri, [analytic.spiral_pos(x) for x in ri], "--w")
-    axes[0].plot(ro, [analytic.spiral_pos(x) for x in ro], "--w")
+    axes[0].plot(ri, [analysis.spiral_pos(x) for x in ri], "--w")
+    axes[0].plot(ro, [analysis.spiral_pos(x) for x in ro], "--w")
 
     axes[0].set_xlim(0.6, 1.4)
     axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
@@ -85,8 +85,8 @@ def analyze():
     po = pc[np.argwhere(sig[:, io] == sig[:, io].max())[0][0]]
 
     # the analytic answers
-    p0i = analytic.spiral_pos(1 - 0.1)
-    p0o = analytic.spiral_pos(1 + 0.1)
+    p0i = analysis.spiral_pos(1 - 0.1)
+    p0o = analysis.spiral_pos(1 + 0.1)
 
     # the errors
     names = ["Inner location", "Outer Location"]

--- a/tst/scripts/binary/binary_mpi.py
+++ b/tst/scripts/binary/binary_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test a binary in a 2D disk
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.binary.binary as binary
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(binary)
 binary._nranks = 16
 binary._file_id = "binary_mpi"
 

--- a/tst/scripts/binary_adi/binary_adi.py
+++ b/tst/scripts/binary_adi/binary_adi.py
@@ -27,6 +27,7 @@ from scipy.interpolate import interp1d
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import scripts.utils.analysis as analysis
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
@@ -67,7 +68,7 @@ def analyze():
         for fv in _flux:
             for dv in _de_switch:
                 problem_id = _file_id + "_{}_de{:d}_{}".format(fv, int(10 * dv), cv)
-                time, r, phi, z, [d, u, v, w, T] = artemis.load_level(
+                time, r, phi, z, [d, u, v, w, T] = analysis.load_level(
                     "final", dir=artemis.get_data_dir(), base=problem_id + ".out1"
                 )
                 rc = 0.5 * (r[1:] + r[:-1])
@@ -84,8 +85,8 @@ def analyze():
                 axes[0].pcolormesh(rc, pc, sig, norm=norm)
                 ri = np.linspace(r.min(), 1 - 2.0 / 3 * h, 50)
                 ro = np.linspace(1 + 2.0 / 3 * h, r.max(), 50)
-                axes[0].plot(ri, [artemis.spiral_pos(x) for x in ri], "--w")
-                axes[0].plot(ro, [artemis.spiral_pos(x) for x in ro], "--w")
+                axes[0].plot(ri, [analysis.spiral_pos(x) for x in ri], "--w")
+                axes[0].plot(ro, [analysis.spiral_pos(x) for x in ro], "--w")
 
                 axes[0].set_xlim(0.6, 1.4)
                 axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
@@ -100,8 +101,8 @@ def analyze():
                 po = pc[np.argwhere(sig[:, io] == sig[:, io].max())[0][0]]
 
                 # the analytic answers
-                p0i = artemis.spiral_pos(1 - 0.1)
-                p0o = artemis.spiral_pos(1 + 0.1)
+                p0i = analysis.spiral_pos(1 - 0.1)
+                p0o = analysis.spiral_pos(1 + 0.1)
 
                 # the errors
                 names = ["Inner location", "Outer Location"]
@@ -120,7 +121,7 @@ def analyze():
                 axes[1].legend(loc="best", fontsize=12)
                 axes[1].set_ylabel("$\\Sigma - \\langle \\Sigma \\rangle$", fontsize=20)
                 axes[0].set_ylabel("$\\phi$", fontsize=20)
-                artemis.create_colorbar(axes[0], norm=norm)
+                analysis.create_colorbar(axes[0], norm=norm)
                 fig.tight_layout()
                 fig.savefig(
                     os.path.join(artemis.get_fig_dir(), problem_id + "_spiral.png"),

--- a/tst/scripts/binary_adi/binary_adi.py
+++ b/tst/scripts/binary_adi/binary_adi.py
@@ -22,13 +22,16 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
+from scipy.interpolate import interp1d
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
-_file_id = "binary"
+_file_id = "binary_adi"
 _cooling = ["adi"]
 _flux = ["llf", "hlle", "hllc"]
 _de_switch = [0.2, 1.0]
@@ -56,20 +59,16 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     logger.debug("Analyzing test " + __name__)
-    os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
+    os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
     for cv in _cooling:
         for fv in _flux:
             for dv in _de_switch:
                 problem_id = _file_id + "_{}_de{:d}_{}".format(fv, int(10 * dv), cv)
-                time, r, phi, z, [d, u, v, w, T] = load_level(
-                    "final", dir=artemis.get_run_directory(), base=problem_id + ".out1"
+                time, r, phi, z, [d, u, v, w, T] = artemis.load_level(
+                    "final", dir=artemis.get_data_dir(), base=problem_id + ".out1"
                 )
                 rc = 0.5 * (r[1:] + r[:-1])
                 pc = 0.5 * (phi[1:] + phi[:-1])
@@ -85,8 +84,8 @@ def analyze():
                 axes[0].pcolormesh(rc, pc, sig, norm=norm)
                 ri = np.linspace(r.min(), 1 - 2.0 / 3 * h, 50)
                 ro = np.linspace(1 + 2.0 / 3 * h, r.max(), 50)
-                axes[0].plot(ri, [spiral_pos(x) for x in ri], "--w")
-                axes[0].plot(ro, [spiral_pos(x) for x in ro], "--w")
+                axes[0].plot(ri, [artemis.spiral_pos(x) for x in ri], "--w")
+                axes[0].plot(ro, [artemis.spiral_pos(x) for x in ro], "--w")
 
                 axes[0].set_xlim(0.6, 1.4)
                 axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
@@ -101,8 +100,8 @@ def analyze():
                 po = pc[np.argwhere(sig[:, io] == sig[:, io].max())[0][0]]
 
                 # the analytic answers
-                p0i = spiral_pos(1 - 0.1)
-                p0o = spiral_pos(1 + 0.1)
+                p0i = artemis.spiral_pos(1 - 0.1)
+                p0o = artemis.spiral_pos(1 + 0.1)
 
                 # the errors
                 names = ["Inner location", "Outer Location"]
@@ -121,10 +120,10 @@ def analyze():
                 axes[1].legend(loc="best", fontsize=12)
                 axes[1].set_ylabel("$\\Sigma - \\langle \\Sigma \\rangle$", fontsize=20)
                 axes[0].set_ylabel("$\\phi$", fontsize=20)
-                create_colorbar(axes[0], norm=norm)
+                artemis.create_colorbar(axes[0], norm=norm)
                 fig.tight_layout()
                 fig.savefig(
-                    os.path.join(artemis.artemis_fig_dir, problem_id + "_spiral.png"),
+                    os.path.join(artemis.get_fig_dir(), problem_id + "_spiral.png"),
                     bbox_inches="tight",
                 )
 
@@ -140,125 +139,3 @@ def analyze():
                         analyze_status = False
 
     return analyze_status
-
-
-def spiral_pos(r, r0=1.0, p0=np.pi, h=0.05):
-    # Analytic spiral position from Ogilvie & Lubow (2002)
-    def mod_2pi(p):
-        while p > 2 * np.pi:
-            p -= 2 * np.pi
-        while p < 0.0:
-            p += 2 * np.pi
-        return p
-
-    if r > r0:
-        return mod_2pi(
-            p0 - mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
-        )
-    if r < r0:
-        return mod_2pi(
-            p0 + mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
-        )
-    return p0
-
-
-def load_level(n, base="binary.out1", dir="./", off=0):
-    # Loads a snapshot and combines the blocks on a single level
-    # This assumes levels are nested properly
-    import h5py
-
-    try:
-        fname = "{}/{}.{:05d}.phdf".format(dir, base, n)
-    except:
-        fname = "{}/{}.{}.phdf".format(dir, base, n)
-
-    with h5py.File(fname, "r") as f:
-        time = f["Info"].attrs["Time"]
-
-        lvl = f["Levels"][...]
-        ind = lvl == max(lvl.max() - off, 0)
-
-        offset = f["LogicalLocations"][...][ind, :]
-        x = f["Locations/x"][...][ind, :]
-        y = f["Locations/y"][...][ind, :]
-        z = f["Locations/z"][...][ind, :]
-        db = f["gas.prim.density_0"][...][ind, :]
-        pb = f["gas.prim.pressure_0"][...][ind, :]
-        ub = f["gas.prim.velocity_0"][...][ind, 0, :]
-        vb = f["gas.prim.velocity_0"][...][ind, 1, :]
-        wb = f["gas.prim.velocity_0"][...][ind, 2, :]
-        sys = f["Params"].attrs["artemis/coord_sys"]
-        time = f["Info"].attrs["Time"]
-
-    nb, bsz, bsy, bsx = db.shape
-
-    offset[:, 0] -= offset[:, 0].min()
-    offset[:, 1] -= offset[:, 1].min()
-    offset[:, 2] -= offset[:, 2].min()
-
-    nx = bsx * (offset[:, 0].max() + 1)
-    ny = bsy * (offset[:, 1].max() + 1)
-    nz = bsz * (offset[:, 2].max() + 1)
-
-    d = np.zeros((nz, ny, nx))
-    p = np.zeros((nz, ny, nx))
-    u = np.zeros((nz, ny, nx))
-    v = np.zeros((nz, ny, nx))
-    w = np.zeros((nz, ny, nx))
-    for n in range(nb):
-        ix = offset[n, 0]
-        iy = offset[n, 1]
-        iz = offset[n, 2]
-        d[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = db[n, :, :, :]
-        p[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = pb[n, :, :, :]
-        u[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = ub[n, :, :, :]
-        v[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = vb[n, :, :, :]
-        w[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = wb[n, :, :, :]
-
-    x = np.linspace(x.min(), x.max(), nx + 1)
-    y = np.linspace(y.min(), y.max(), ny + 1)
-    z = np.linspace(z.min(), z.max(), nz + 1)
-    return time, x, y, z, [d, u, v, w, p / d]
-
-
-def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
-    import matplotlib
-    import matplotlib.cm
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-
-    labelsize = kargs.pop("labelsize", 14)
-    labelsize = kargs.pop("fontsize", 14)
-
-    if cax is None:
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes(where, size="3%", pad=0.05)
-
-    cmap = matplotlib.cm.get_cmap(cmap)
-    cb = matplotlib.colorbar.ColorbarBase(
-        ax=cax, cmap=cmap, norm=norm, orientation="horizontal", **kargs
-    )
-    cb.ax.xaxis.set_ticks_position(where)
-    cb.ax.xaxis.set_label_position(where)
-    cb.ax.tick_params(labelsize=labelsize)
-
-    return cb

--- a/tst/scripts/binary_adi/binary_adi_mpi.py
+++ b/tst/scripts/binary_adi/binary_adi_mpi.py
@@ -14,25 +14,22 @@
 # Regression to test a binary in a 2D adiabatic disk
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
-import scripts.binary_adi.binary_adi as binary
+import scripts.binary_adi.binary_adi as binary_adi
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
-binary._nranks = 16
-binary._file_id = "binary_mpi"
+importlib.reload(binary_adi)
+binary_adi._nranks = 16
+binary_adi._file_id = "binary_adi_mpi"
 
 
 # Run Artemis
 def run(**kwargs):
-    return binary.run(**kwargs)
+    return binary_adi.run(**kwargs)
 
 
 # Analyze outputs
 def analyze():
-    return binary.analyze()
+    return binary_adi.analyze()

--- a/tst/scripts/collisions/collisions.py
+++ b/tst/scripts/collisions/collisions.py
@@ -20,10 +20,13 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
+from scipy.interpolate import interp1d
+
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "collisions"
@@ -53,14 +56,10 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     logger.debug("Analyzing test " + __name__)
 
     fname = os.path.join(
-        artemis.get_run_directory(), "{}_{:d}.reb".format(_file_id, _nranks)
+        artemis.get_data_dir(), "{}_{:d}.reb".format(_file_id, _nranks)
     )
     logger.debug("Reading" + fname)
     d = np.loadtxt(fname)

--- a/tst/scripts/collisions/collisions_mpi.py
+++ b/tst/scripts/collisions/collisions_mpi.py
@@ -14,14 +14,13 @@
 # Regression to test collisions with REBOUND particles and MPI
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.collisions.collisions as collisions
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 
+importlib.reload(collisions)
 collisions._nranks = 16
 collisions._file_id = "collisions_mpi"
 

--- a/tst/scripts/coords/blast.py
+++ b/tst/scripts/coords/blast.py
@@ -18,10 +18,14 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
+from scipy.interpolate import interp1d
+
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import h5py
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "blast"
@@ -92,22 +96,19 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.pyplot as plt
-
     logger.debug("Analyzing test " + __name__)
-    os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
+    os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
     dat2 = np.loadtxt(
         os.path.join(
-            artemis.get_source_directory(), "tst", "scripts", "coords", "sedov2d.dat"
+            artemis.get_artemis_dir(), "tst", "scripts", "coords", "sedov2d.dat"
         ),
         comments="#",
     )
     dat3 = np.loadtxt(
         os.path.join(
-            artemis.get_source_directory(), "tst", "scripts", "coords", "sedov3d.dat"
+            artemis.get_artemis_dir(), "tst", "scripts", "coords", "sedov3d.dat"
         ),
         comments="#",
     )
@@ -128,7 +129,7 @@ def analyze():
         )
         res = load_snap(
             os.path.join(
-                artemis.get_run_directory(),
+                artemis.get_data_dir(),
                 _file_id + "_{}{:d}.out1.final.phdf".format(g, 2),
             )
         )
@@ -166,7 +167,7 @@ def analyze():
         ax.minorticks_on()
     fig.tight_layout()
     fig.savefig(
-        os.path.join(artemis.artemis_fig_dir, _file_id + ".png"), bbox_inches="tight"
+        os.path.join(artemis.get_fig_dir(), _file_id + ".png"), bbox_inches="tight"
     )
 
     # Check failure criterion
@@ -215,8 +216,6 @@ def transform_3d(xc, yc, zc, vx, vy, vz, pos=(0, 0, 0)):
 
 
 def load_snap(fname):
-    import h5py
-
     with h5py.File(fname, "r") as f:
         time = f["Info"].attrs["Time"]
         x = f["Locations/x"][...]
@@ -231,8 +230,6 @@ def load_snap(fname):
 
 
 def sedov_cyl(fcyl_1d, fcart_2d, savefig=None):
-    import matplotlib.pyplot as plt
-
     dat = np.loadtxt("sedov2d.dat")
     fig, axes = plt.subplots(1, 3, figsize=(8 * 3, 6))
 
@@ -312,8 +309,8 @@ def sedov_cyl(fcyl_1d, fcart_2d, savefig=None):
         ax.minorticks_on()
     fig.tight_layout()
     if savefig is not None:
-        os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
-        fig.savefig(os.path.join(artemis.artemis_fig_dir, savefig), bbox_inches="tight")
+        os.makedirs(artemis.get_fig_dir(), exist_ok=True)
+        fig.savefig(os.path.join(artemis.get_fig_dir(), savefig), bbox_inches="tight")
 
 
 def sedov_sph(fsph_1d, faxi_2d, fcart_3d, savefig=None):
@@ -432,5 +429,5 @@ def sedov_sph(fsph_1d, faxi_2d, fcart_3d, savefig=None):
         ax.minorticks_on()
     fig.tight_layout()
     if savefig is not None:
-        os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
-        fig.savefig(os.path.join(artemis.artemis_fig_dir, savefig), bbox_inches="tight")
+        os.makedirs(artemis.get_fig_dir(), exist_ok=True)
+        fig.savefig(os.path.join(artemis.get_fig_dir(), savefig), bbox_inches="tight")

--- a/tst/scripts/coords/blast_mpi.py
+++ b/tst/scripts/coords/blast_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test the sphericity of the blast wave in all coordinate systems
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.coords.blast as blast
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(blast)
 blast._nranks = 8
 blast._file_id = "blast_mpi"
 

--- a/tst/scripts/diffusion/alpha_disk.py
+++ b/tst/scripts/diffusion/alpha_disk.py
@@ -24,6 +24,7 @@ from scipy.interpolate import interp1d
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import scripts.utils.analysis as analysis
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
@@ -81,7 +82,7 @@ def analyze():
     logger.debug("Analyzing test " + __name__ + " {:d}D".format(d))
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
 
-    time, x, y, z, [dens, u, v, w, T] = artemis.load_level(
+    time, x, y, z, [dens, u, v, w, T] = analysis.load_level(
         "final", dir=artemis.get_data_dir(), base=base + ".out1"
     )
     r = 0.5 * (x[1:] + x[:-1])

--- a/tst/scripts/diffusion/alpha_disk.py
+++ b/tst/scripts/diffusion/alpha_disk.py
@@ -18,11 +18,14 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
-import scripts.binary.binary as binary  # loads the
+from scipy.interpolate import interp1d
+
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "alpha_disk"
@@ -72,18 +75,14 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     errors = []
     d = 1
     base = "{}_{:d}d".format(_file_id, d)
     logger.debug("Analyzing test " + __name__ + " {:d}D".format(d))
-    os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
+    os.makedirs(artemis.get_fig_dir(), exist_ok=True)
 
-    time, x, y, z, [dens, u, v, w, T] = binary.load_level(
-        "final", dir=artemis.get_run_directory(), base=base + ".out1"
+    time, x, y, z, [dens, u, v, w, T] = artemis.load_level(
+        "final", dir=artemis.get_data_dir(), base=base + ".out1"
     )
     r = 0.5 * (x[1:] + x[:-1])
 
@@ -116,7 +115,7 @@ def analyze():
 
     fig.tight_layout()
     fig.savefig(
-        os.path.join(artemis.artemis_fig_dir, base + "_res.png"), bbox_inches="tight"
+        os.path.join(artemis.get_fig_dir(), base + "_res.png"), bbox_inches="tight"
     )
 
     errors = [
@@ -127,26 +126,3 @@ def analyze():
     print(errors)
     analyze_status = all([err <= _tol for err in errors])
     return analyze_status
-
-
-def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
-    import matplotlib
-    import matplotlib.cm
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-
-    labelsize = kargs.pop("labelsize", 14)
-    labelsize = kargs.pop("fontsize", 14)
-
-    if cax is None:
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes(where, size="3%", pad=0.05)
-
-    cmap = matplotlib.cm.get_cmap(cmap)
-    cb = matplotlib.colorbar.ColorbarBase(
-        ax=cax, cmap=cmap, norm=norm, orientation="horizontal", **kargs
-    )
-    cb.ax.xaxis.set_ticks_position(where)
-    cb.ax.xaxis.set_label_position(where)
-    cb.ax.tick_params(labelsize=labelsize)
-
-    return cb

--- a/tst/scripts/diffusion/alpha_disk_mpi.py
+++ b/tst/scripts/diffusion/alpha_disk_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test an alpha_disk
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.diffusion.alpha_disk as alpha_disk
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(alpha_disk)
 alpha_disk._nranks = 4
 alpha_disk._file_id = "alpha_disk_mpi"
 

--- a/tst/scripts/diffusion/thermal_diffusion.py
+++ b/tst/scripts/diffusion/thermal_diffusion.py
@@ -18,11 +18,14 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
-import scripts.binary.binary as binary  # loads the
+from scipy.interpolate import interp1d
+
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "thermal_diffusion"
@@ -76,12 +79,8 @@ def Tans(x, f=0.01, T0=0.05, x0=1.2, xi=0.2, d=0, k=0.1):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     logger.debug("Analyzing test " + __name__)
-    os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
+    os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
     fig, axes = plt.subplots(1, 3, figsize=(8 * 3, 6))
@@ -89,8 +88,8 @@ def analyze():
     errors = []
     for ax, g in zip(axes, _geom):
         name = "{}_{}".format(_file_id, g[:3])
-        time, x, y, z, [d, u, v, w, T] = binary.load_level(
-            "final", dir=artemis.get_run_directory(), base="{}.out1".format(name)
+        time, x, y, z, [d, u, v, w, T] = artemis.load_level(
+            "final", dir=artemis.get_data_dir(), base="{}.out1".format(name)
         )
         xc = 0.5 * (x[1:] + x[:-1])
         ans = Tans(xc.ravel(), f=_flux, T0=_gtemp, x0=1.2, xi=0.2, d=dind[g], k=_kcond)
@@ -108,7 +107,7 @@ def analyze():
 
     fig.tight_layout()
     fig.savefig(
-        os.path.join(artemis.artemis_fig_dir, _file_id + "_temp.png"),
+        os.path.join(artemis.get_fig_dir(), _file_id + "_temp.png"),
         bbox_inches="tight",
     )
 

--- a/tst/scripts/diffusion/thermal_diffusion.py
+++ b/tst/scripts/diffusion/thermal_diffusion.py
@@ -24,6 +24,7 @@ from scipy.interpolate import interp1d
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import scripts.utils.analysis as analysis
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
@@ -88,7 +89,7 @@ def analyze():
     errors = []
     for ax, g in zip(axes, _geom):
         name = "{}_{}".format(_file_id, g[:3])
-        time, x, y, z, [d, u, v, w, T] = artemis.load_level(
+        time, x, y, z, [d, u, v, w, T] = analysis.load_level(
             "final", dir=artemis.get_data_dir(), base="{}.out1".format(name)
         )
         xc = 0.5 * (x[1:] + x[:-1])

--- a/tst/scripts/diffusion/thermal_diffusion_mpi.py
+++ b/tst/scripts/diffusion/thermal_diffusion_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test steady-state conduction.
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.diffusion.thermal_diffusion as thermal_diffusion
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(thermal_diffusion)
 thermal_diffusion._nranks = 8
 thermal_diffusion._file_id = "thermal_diffusion_mpi"
 

--- a/tst/scripts/diffusion/viscous_diffusion.py
+++ b/tst/scripts/diffusion/viscous_diffusion.py
@@ -23,6 +23,7 @@ from scipy.interpolate import interp1d
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import scripts.utils.analysis as analysis
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
@@ -87,13 +88,13 @@ def analyze():
         logger.debug("Analyzing test " + __name__ + " {:d}D".format(d))
         os.makedirs(artemis.get_fig_dir(), exist_ok=True)
 
-        time, x, y, z, [dens, u, v, w, T] = artemis.load_level(
+        time, x, y, z, [dens, u, v, w, T] = analysis.load_level(
             "final", dir=artemis.get_data_dir(), base=base + ".out1"
         )
         xc = 0.5 * (x[1:] + x[:-1])
         yc = 0.5 * (y[1:] + y[:-1])
 
-        time0, x0, y0, z0, [dens0, u0, v0, w0, T0] = artemis.load_level(
+        time0, x0, y0, z0, [dens0, u0, v0, w0, T0] = analysis.load_level(
             0, dir=artemis.get_data_dir(), base=base + ".out1"
         )
 
@@ -135,7 +136,7 @@ def analyze():
             axes[1].set_ylabel("$V_3$", fontsize=18)
             axes[0].set_xlabel("x", fontsize=16)
             axes[0].set_ylabel("y", fontsize=16)
-            artemis.create_colorbar(axes[0], norm=norm)
+            analysis.create_colorbar(axes[0], norm=norm)
 
         fig.tight_layout()
         fig.savefig(

--- a/tst/scripts/diffusion/viscous_diffusion.py
+++ b/tst/scripts/diffusion/viscous_diffusion.py
@@ -18,11 +18,13 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
-import scripts.binary.binary as binary  # loads the
+from scipy.interpolate import interp1d
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "viscous_diffusion"
@@ -79,24 +81,20 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     errors = []
     for d in _nd:
         base = "{}_{:d}d".format(_file_id, d)
         logger.debug("Analyzing test " + __name__ + " {:d}D".format(d))
-        os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
+        os.makedirs(artemis.get_fig_dir(), exist_ok=True)
 
-        time, x, y, z, [dens, u, v, w, T] = binary.load_level(
-            "final", dir=artemis.get_run_directory(), base=base + ".out1"
+        time, x, y, z, [dens, u, v, w, T] = artemis.load_level(
+            "final", dir=artemis.get_data_dir(), base=base + ".out1"
         )
         xc = 0.5 * (x[1:] + x[:-1])
         yc = 0.5 * (y[1:] + y[:-1])
 
-        time0, x0, y0, z0, [dens0, u0, v0, w0, T0] = binary.load_level(
-            0, dir=artemis.get_run_directory(), base=base + ".out1"
+        time0, x0, y0, z0, [dens0, u0, v0, w0, T0] = artemis.load_level(
+            0, dir=artemis.get_data_dir(), base=base + ".out1"
         )
 
         vx3 = w[0, :]
@@ -137,11 +135,11 @@ def analyze():
             axes[1].set_ylabel("$V_3$", fontsize=18)
             axes[0].set_xlabel("x", fontsize=16)
             axes[0].set_ylabel("y", fontsize=16)
-            create_colorbar(axes[0], norm=norm)
+            artemis.create_colorbar(axes[0], norm=norm)
 
         fig.tight_layout()
         fig.savefig(
-            os.path.join(artemis.artemis_fig_dir, base + "_vx3.png"),
+            os.path.join(artemis.get_fig_dir(), base + "_vx3.png"),
             bbox_inches="tight",
         )
         errors.append((d, err))
@@ -149,26 +147,3 @@ def analyze():
     print(errors)
     analyze_status = all([err[1] <= _tol for err in errors])
     return analyze_status
-
-
-def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
-    import matplotlib
-    import matplotlib.cm
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-
-    labelsize = kargs.pop("labelsize", 14)
-    labelsize = kargs.pop("fontsize", 14)
-
-    if cax is None:
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes(where, size="3%", pad=0.05)
-
-    cmap = matplotlib.cm.get_cmap(cmap)
-    cb = matplotlib.colorbar.ColorbarBase(
-        ax=cax, cmap=cmap, norm=norm, orientation="horizontal", **kargs
-    )
-    cb.ax.xaxis.set_ticks_position(where)
-    cb.ax.xaxis.set_label_position(where)
-    cb.ax.tick_params(labelsize=labelsize)
-
-    return cb

--- a/tst/scripts/diffusion/viscous_diffusion_mpi.py
+++ b/tst/scripts/diffusion/viscous_diffusion_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test a viscous_diffusion of a gaussian bump
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.diffusion.viscous_diffusion as viscous_diffusion
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(viscous_diffusion)
 viscous_diffusion._nranks = 4
 viscous_diffusion._nd = [2]
 viscous_diffusion._file_id = "viscous_diffusion_mpi"

--- a/tst/scripts/disk/disk.py
+++ b/tst/scripts/disk/disk.py
@@ -19,10 +19,15 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
+from scipy.interpolate import interp1d
+
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import h5py
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "disk"
@@ -90,10 +95,6 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     bad = False
     for b in _bc:
         for g in _geom:
@@ -101,21 +102,21 @@ def analyze():
                 logger.debug("Analyzing test {}_{}".format(__name__, g))
                 logger.debug(
                     os.path.join(
-                        artemis.get_run_directory(),
+                        artemis.get_data_dir(),
                         "disk_{}_{:d}_{}.out1".format(g, int(10 * gam), b),
                     )
                 )
                 _, (x, y, z), (d0, _, _, _, _), sys, _ = loadf(
                     0,
                     base=os.path.join(
-                        artemis.get_run_directory(),
+                        artemis.get_data_dir(),
                         "disk_{}_{:d}_{}.out1".format(g, int(10 * gam), b),
                     ),
                 )
                 time, (x, y, z), (d, T, u, v, w), sys, dt = loadf(
                     "final",
                     base=os.path.join(
-                        artemis.get_run_directory(),
+                        artemis.get_data_dir(),
                         "disk_{}_{:d}_{}.out1".format(g, int(10 * gam), b),
                     ),
                 )
@@ -185,8 +186,6 @@ def analyze():
 
 
 def loadf(n, base="disk.out1"):
-    import h5py
-
     try:
         fname = "{}.{:05d}.phdf".format(base, n)
     except:

--- a/tst/scripts/disk/disk_mpi.py
+++ b/tst/scripts/disk/disk_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test a 3D disk
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.disk.disk as disk
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(disk)
 disk._nranks = 8
 disk._file_id = "disk_mpi"
 

--- a/tst/scripts/disk_nbody/disk_nbody.py
+++ b/tst/scripts/disk_nbody/disk_nbody.py
@@ -19,10 +19,15 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
+from scipy.interpolate import interp1d
+
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import h5py
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "disk_nbody"
@@ -78,10 +83,6 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     bad = False
     for b in _bc:
         for g in _geom:
@@ -89,21 +90,21 @@ def analyze():
                 logger.debug("Analyzing test {}_{}".format(__name__, g))
                 logger.debug(
                     os.path.join(
-                        artemis.get_run_directory(),
+                        artemis.get_data_dir(),
                         "disk_nbody_{}_{:d}_{}.out1".format(g, int(10 * gam), b),
                     )
                 )
                 _, (x, y, z), (d0, _, _, _, _), sys, _ = loadf(
                     0,
                     base=os.path.join(
-                        artemis.get_run_directory(),
+                        artemis.get_data_dir(),
                         "/disk_nbody_{}_{:d}_{}.out1".format(g, int(10 * gam), b),
                     ),
                 )
                 time, (x, y, z), (d, T, u, v, w), sys, dt = loadf(
                     "final",
                     base=os.path.join(
-                        artemis.get_run_directory(),
+                        artemis.get_data_dir(),
                         "disk_nbody_{}_{:d}_{}.out1".format(g, int(10 * gam), b),
                     ),
                 )
@@ -130,8 +131,6 @@ def analyze():
 
 
 def loadf(n, base="disk_nbody.out1"):
-    import h5py
-
     try:
         fname = "{}.{:05d}.phdf".format(base, n)
     except:

--- a/tst/scripts/disk_nbody/disk_nbody_mpi.py
+++ b/tst/scripts/disk_nbody/disk_nbody_mpi.py
@@ -14,25 +14,22 @@
 # Regression to test a 3D disk with REBOUND particles and MPI
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
-import scripts.disk_nbody.disk_nbody as disk
+import scripts.disk_nbody.disk_nbody as disk_nbody
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
-disk._nranks = 8
-disk._file_id = "disk_nbody_mpi"
+importlib.reload(disk_nbody)
+disk_nbody._nranks = 8
+disk_nbody._file_id = "disk_nbody_mpi"
 
 
 # Run Artemis
 def run(**kwargs):
-    return disk.run(**kwargs)
+    return disk_nbody.run(**kwargs)
 
 
 # Analyze outputs
 def analyze():
-    return disk.analyze()
+    return disk_nbody.analyze()

--- a/tst/scripts/drag/drag.py
+++ b/tst/scripts/drag/drag.py
@@ -18,10 +18,15 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
+from scipy.interpolate import interp1d
+
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import h5py
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "drag"
@@ -42,13 +47,8 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    import h5py
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     logger.debug("Analyzing test " + __name__)
-    os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
+    os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
     dv0 = -1.0
@@ -61,7 +61,7 @@ def analyze():
     errors = []
     for n in range(1, int(_tlim / 0.05)):
         fname = os.path.join(
-            artemis.get_run_directory(), "{}.out1.{:05d}.phdf".format(_file_id, n)
+            artemis.get_data_dir(), "{}.out1.{:05d}.phdf".format(_file_id, n)
         )
         with h5py.File(fname, "r") as f:
             t = f["Info"].attrs["Time"]
@@ -117,7 +117,7 @@ def analyze():
     axes[2].set_ylabel("Momentum Error", fontsize=18)
     fig.tight_layout()
     fig.savefig(
-        os.path.join(artemis.artemis_fig_dir, _file_id + "_drag.png"),
+        os.path.join(artemis.get_fig_dir(), _file_id + "_drag.png"),
         bbox_inches="tight",
     )
 

--- a/tst/scripts/drag/drag_mpi.py
+++ b/tst/scripts/drag/drag_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test simple dust-gas drag
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.drag.drag as drag
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(drag)
 drag._nranks = 4
 drag._file_id = "drag_mpi"
 

--- a/tst/scripts/hydro/linwave.py
+++ b/tst/scripts/hydro/linwave.py
@@ -79,7 +79,7 @@ def analyze():
     # sound waves.
     logger.debug("Analyzing test " + __name__)
     data = np.loadtxt(
-        os.path.join(artemis.get_run_directory(), _file_id + "-errs.dat"),
+        os.path.join(artemis.get_data_dir(), _file_id + "-errs.dat"),
         dtype=np.float64,
         ndmin=2,
     )

--- a/tst/scripts/hydro/linwave_mpi.py
+++ b/tst/scripts/hydro/linwave_mpi.py
@@ -16,14 +16,13 @@
 # softwares.
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.hydro.linwave as linwave
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 
+importlib.reload(linwave)
 linwave._nranks = 4
 linwave._file_id = "linear_wave_mpi"
 

--- a/tst/scripts/nbody/nbody.py
+++ b/tst/scripts/nbody/nbody.py
@@ -60,7 +60,7 @@ def analyze():
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, r, phi, z, [d, u, v, w, T] = load_level(
+    time, r, phi, z, [d, u, v, w, T] = artemis.load_level(
         "final", base="{}.out1".format(_file_id), dir=artemis.get_data_dir()
     )
     rc = 0.5 * (r[1:] + r[:-1])

--- a/tst/scripts/nbody/nbody.py
+++ b/tst/scripts/nbody/nbody.py
@@ -78,8 +78,8 @@ def analyze():
     axes[0].pcolormesh(rc, pc, sig, norm=norm)
     ri = np.linspace(r.min(), 1 - 2.0 / 3 * h, 50)
     ro = np.linspace(1 + 2.0 / 3 * h, r.max(), 50)
-    axes[0].plot(ri, [analytic.spiral_pos(x) for x in ri], "--w")
-    axes[0].plot(ro, [analytic.spiral_pos(x) for x in ro], "--w")
+    axes[0].plot(ri, [analysis.spiral_pos(x) for x in ri], "--w")
+    axes[0].plot(ro, [analysis.spiral_pos(x) for x in ro], "--w")
 
     axes[0].set_xlim(0.6, 1.4)
     axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
@@ -94,8 +94,8 @@ def analyze():
     po = pc[np.argwhere(sig[:, io] == sig[:, io].max())[0][0]]
 
     # the analytic answers
-    p0i = analytic.spiral_pos(1 - 0.1)
-    p0o = analytic.spiral_pos(1 + 0.1)
+    p0i = analysis.spiral_pos(1 - 0.1)
+    p0o = analysis.spiral_pos(1 + 0.1)
 
     # the errors
     names = ["Inner location", "Outer Location"]

--- a/tst/scripts/nbody/nbody.py
+++ b/tst/scripts/nbody/nbody.py
@@ -23,10 +23,14 @@ import logging
 import numpy as np
 import os
 import scripts.utils.artemis as artemis
+from scipy.interpolate import interp1d
+
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 
 _nranks = 1
 _file_id = "nbody"
@@ -52,16 +56,12 @@ def run(**kwargs):
 
 # Analyze outputs
 def analyze():
-    from scipy.interpolate import interp1d
-    import matplotlib.colors as colors
-    import matplotlib.pyplot as plt
-
     logger.debug("Analyzing test " + __name__)
-    os.makedirs(artemis.artemis_fig_dir, exist_ok=True)
+    os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
     time, r, phi, z, [d, u, v, w, T] = load_level(
-        "final", base="{}.out1".format(_file_id), dir=artemis.get_run_directory()
+        "final", base="{}.out1".format(_file_id), dir=artemis.get_data_dir()
     )
     rc = 0.5 * (r[1:] + r[:-1])
     pc = 0.5 * (phi[1:] + phi[:-1])
@@ -77,8 +77,8 @@ def analyze():
     axes[0].pcolormesh(rc, pc, sig, norm=norm)
     ri = np.linspace(r.min(), 1 - 2.0 / 3 * h, 50)
     ro = np.linspace(1 + 2.0 / 3 * h, r.max(), 50)
-    axes[0].plot(ri, [spiral_pos(x) for x in ri], "--w")
-    axes[0].plot(ro, [spiral_pos(x) for x in ro], "--w")
+    axes[0].plot(ri, [artemis.spiral_pos(x) for x in ri], "--w")
+    axes[0].plot(ro, [artemis.spiral_pos(x) for x in ro], "--w")
 
     axes[0].set_xlim(0.6, 1.4)
     axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
@@ -93,8 +93,8 @@ def analyze():
     po = pc[np.argwhere(sig[:, io] == sig[:, io].max())[0][0]]
 
     # the analytic answers
-    p0i = spiral_pos(1 - 0.1)
-    p0o = spiral_pos(1 + 0.1)
+    p0i = artemis.spiral_pos(1 - 0.1)
+    p0o = artemis.spiral_pos(1 + 0.1)
 
     # the errors
     names = ["Inner location", "Outer Location"]
@@ -113,15 +113,14 @@ def analyze():
     axes[1].legend(loc="best", fontsize=12)
     axes[1].set_ylabel("$\\Sigma - \\langle \\Sigma \\rangle$", fontsize=20)
     axes[0].set_ylabel("$\\phi$", fontsize=20)
-    create_colorbar(axes[0], norm=norm)
+    artemis.create_colorbar(axes[0], norm=norm)
     fig.tight_layout()
     fig.savefig(
-        os.path.join(artemis.artemis_fig_dir, _file_id + "_spiral.png"),
+        os.path.join(artemis.get_fig_dir(), _file_id + "_spiral.png"),
         bbox_inches="tight",
     )
 
     # Cooling check
-
     Tavg = T.mean(axis=1)[0, :]
     fit = np.polyfit(np.log(rc), np.log(Tavg), 1)
     plaw_ans = -1.0
@@ -148,7 +147,7 @@ def analyze():
     ax.legend(loc="best", fontsize=12)
     fig.tight_layout()
     fig.savefig(
-        os.path.join(artemis.artemis_fig_dir, _file_id + "_temp.png"),
+        os.path.join(artemis.get_fig_dir(), _file_id + "_temp.png"),
         bbox_inches="tight",
     )
 
@@ -162,125 +161,3 @@ def analyze():
             analyze_status = False
 
     return analyze_status
-
-
-def spiral_pos(r, r0=1.0, p0=np.pi, h=0.05):
-    # Analytic spiral position from Ogilvie & Lubow (2002)
-    def mod_2pi(p):
-        while p > 2 * np.pi:
-            p -= 2 * np.pi
-        while p < 0.0:
-            p += 2 * np.pi
-        return p
-
-    if r > r0:
-        return mod_2pi(
-            p0 - mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
-        )
-    if r < r0:
-        return mod_2pi(
-            p0 + mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
-        )
-    return p0
-
-
-def load_level(n, base="nbody.out1", dir="./", off=0):
-    # Loads a snapshot and combines the blocks on a single level
-    # This assumes levels are nested properly
-    import h5py
-
-    try:
-        fname = "{}/{}.{:05d}.phdf".format(dir, base, n)
-    except:
-        fname = "{}/{}.{}.phdf".format(dir, base, n)
-
-    with h5py.File(fname, "r") as f:
-        time = f["Info"].attrs["Time"]
-
-        lvl = f["Levels"][...]
-        ind = lvl == max(lvl.max() - off, 0)
-
-        offset = f["LogicalLocations"][...][ind, :]
-        x = f["Locations/x"][...][ind, :]
-        y = f["Locations/y"][...][ind, :]
-        z = f["Locations/z"][...][ind, :]
-        db = f["gas.prim.density_0"][...][ind, :]
-        pb = f["gas.prim.pressure_0"][...][ind, :]
-        ub = f["gas.prim.velocity_0"][...][ind, 0, :]
-        vb = f["gas.prim.velocity_0"][...][ind, 1, :]
-        wb = f["gas.prim.velocity_0"][...][ind, 2, :]
-        sys = f["Params"].attrs["artemis/coord_sys"]
-        time = f["Info"].attrs["Time"]
-
-    nb, bsz, bsy, bsx = db.shape
-
-    offset[:, 0] -= offset[:, 0].min()
-    offset[:, 1] -= offset[:, 1].min()
-    offset[:, 2] -= offset[:, 2].min()
-
-    nx = bsx * (offset[:, 0].max() + 1)
-    ny = bsy * (offset[:, 1].max() + 1)
-    nz = bsz * (offset[:, 2].max() + 1)
-
-    d = np.zeros((nz, ny, nx))
-    p = np.zeros((nz, ny, nx))
-    u = np.zeros((nz, ny, nx))
-    v = np.zeros((nz, ny, nx))
-    w = np.zeros((nz, ny, nx))
-    for n in range(nb):
-        ix = offset[n, 0]
-        iy = offset[n, 1]
-        iz = offset[n, 2]
-        d[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = db[n, :, :, :]
-        p[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = pb[n, :, :, :]
-        u[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = ub[n, :, :, :]
-        v[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = vb[n, :, :, :]
-        w[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = wb[n, :, :, :]
-
-    x = np.linspace(x.min(), x.max(), nx + 1)
-    y = np.linspace(y.min(), y.max(), ny + 1)
-    z = np.linspace(z.min(), z.max(), nz + 1)
-    return time, x, y, z, [d, u, v, w, p / d]
-
-
-def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
-    import matplotlib
-    import matplotlib.cm
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-
-    labelsize = kargs.pop("labelsize", 14)
-    labelsize = kargs.pop("fontsize", 14)
-
-    if cax is None:
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes(where, size="3%", pad=0.05)
-
-    cmap = matplotlib.cm.get_cmap(cmap)
-    cb = matplotlib.colorbar.ColorbarBase(
-        ax=cax, cmap=cmap, norm=norm, orientation="horizontal", **kargs
-    )
-    cb.ax.xaxis.set_ticks_position(where)
-    cb.ax.xaxis.set_label_position(where)
-    cb.ax.tick_params(labelsize=labelsize)
-
-    return cb

--- a/tst/scripts/nbody/nbody.py
+++ b/tst/scripts/nbody/nbody.py
@@ -29,6 +29,7 @@ from scipy.interpolate import interp1d
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import scripts.utils.analysis as analysis
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
@@ -60,7 +61,7 @@ def analyze():
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, r, phi, z, [d, u, v, w, T] = artemis.load_level(
+    time, r, phi, z, [d, u, v, w, T] = analysis.load_level(
         "final", base="{}.out1".format(_file_id), dir=artemis.get_data_dir()
     )
     rc = 0.5 * (r[1:] + r[:-1])
@@ -77,8 +78,8 @@ def analyze():
     axes[0].pcolormesh(rc, pc, sig, norm=norm)
     ri = np.linspace(r.min(), 1 - 2.0 / 3 * h, 50)
     ro = np.linspace(1 + 2.0 / 3 * h, r.max(), 50)
-    axes[0].plot(ri, [artemis.spiral_pos(x) for x in ri], "--w")
-    axes[0].plot(ro, [artemis.spiral_pos(x) for x in ro], "--w")
+    axes[0].plot(ri, [analytic.spiral_pos(x) for x in ri], "--w")
+    axes[0].plot(ro, [analytic.spiral_pos(x) for x in ro], "--w")
 
     axes[0].set_xlim(0.6, 1.4)
     axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
@@ -93,8 +94,8 @@ def analyze():
     po = pc[np.argwhere(sig[:, io] == sig[:, io].max())[0][0]]
 
     # the analytic answers
-    p0i = artemis.spiral_pos(1 - 0.1)
-    p0o = artemis.spiral_pos(1 + 0.1)
+    p0i = analytic.spiral_pos(1 - 0.1)
+    p0o = analytic.spiral_pos(1 + 0.1)
 
     # the errors
     names = ["Inner location", "Outer Location"]
@@ -113,7 +114,7 @@ def analyze():
     axes[1].legend(loc="best", fontsize=12)
     axes[1].set_ylabel("$\\Sigma - \\langle \\Sigma \\rangle$", fontsize=20)
     axes[0].set_ylabel("$\\phi$", fontsize=20)
-    artemis.create_colorbar(axes[0], norm=norm)
+    analysis.create_colorbar(axes[0], norm=norm)
     fig.tight_layout()
     fig.savefig(
         os.path.join(artemis.get_fig_dir(), _file_id + "_spiral.png"),

--- a/tst/scripts/nbody/nbody_mpi.py
+++ b/tst/scripts/nbody/nbody_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test a nbody in a 2D disk with rebound
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.nbody.nbody as nbody
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(nbody)
 nbody._nranks = 8
 nbody._file_id = "nbody_mpi"
 

--- a/tst/scripts/ssheet/ssheet.py
+++ b/tst/scripts/ssheet/ssheet.py
@@ -26,6 +26,7 @@ from scipy.interpolate import interp1d
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+import scripts.utils.analysis as analysis
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 
@@ -49,7 +50,7 @@ def analyze():
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, x, y, z, [d, u, v, w, T] = artemis.load_level(
+    time, x, y, z, [d, u, v, w, T] = analysis.load_level(
         "final", dir=artemis.get_data_dir(), base="{}.out1".format(_file_id)
     )
     xc = 0.5 * (x[1:] + x[:-1])
@@ -102,7 +103,7 @@ def analyze():
     axes[1].legend(loc="best", fontsize=12)
     axes[1].set_ylabel("$\\Sigma - \\langle \\Sigma \\rangle$", fontsize=20)
     axes[0].set_ylabel("$y$", fontsize=20)
-    artemis.create_colorbar(axes[0], norm=norm)
+    analysis.create_colorbar(axes[0], norm=norm)
     fig.tight_layout()
     fig.savefig(
         os.path.join(artemis.get_fig_dir(), _file_id + "_spiral.png"),

--- a/tst/scripts/ssheet/ssheet_mpi.py
+++ b/tst/scripts/ssheet/ssheet_mpi.py
@@ -14,16 +14,13 @@
 # Regression to test a ssheet in a 2D disk
 
 # Modules
+import importlib
 import logging
-import numpy as np
-import os
-import scripts.utils.artemis as artemis
 import scripts.ssheet.ssheet as ssheet
 
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
-logging.getLogger("h5py").setLevel(logging.WARNING)
-logging.getLogger("matplotlib").setLevel(logging.WARNING)
 
+importlib.reload(ssheet)
 ssheet._nranks = 8
 ssheet._file_id = "ssheet_mpi"
 

--- a/tst/scripts/utils/analysis.py
+++ b/tst/scripts/utils/analysis.py
@@ -1,0 +1,147 @@
+# ========================================================================================
+#  (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+#
+#  This program was produced under U.S. Government contract 89233218CNA000001 for Los
+#  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+#  for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+#  in the program are reserved by Triad National Security, LLC, and the U.S. Department
+#  of Energy/National Nuclear Security Administration. The Government is granted for
+#  itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+#  license in this material to reproduce, prepare derivative works, distribute copies to
+#  the public, perform publicly and display publicly, and to permit others to do so.
+# ========================================================================================
+
+# Functions for test analyses
+
+# Modules
+import h5py
+import logging
+import subprocess
+import matplotlib
+import matplotlib.cm
+import numpy as np
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+
+# Function for reading Artemis data
+def load_level(n, base, dir="./", off=0):
+    # Loads a snapshot and combines the blocks on a single level
+    # This assumes levels are nested properly
+
+    try:
+        fname = "{}/{}.{:05d}.phdf".format(dir, base, n)
+    except:
+        fname = "{}/{}.{}.phdf".format(dir, base, n)
+
+    with h5py.File(fname, "r") as f:
+        time = f["Info"].attrs["Time"]
+
+        lvl = f["Levels"][...]
+        ind = lvl == max(lvl.max() - off, 0)
+
+        offset = f["LogicalLocations"][...][ind, :]
+        x = f["Locations/x"][...][ind, :]
+        y = f["Locations/y"][...][ind, :]
+        z = f["Locations/z"][...][ind, :]
+        db = f["gas.prim.density_0"][...][ind, :]
+        pb = f["gas.prim.pressure_0"][...][ind, :]
+        ub = f["gas.prim.velocity_0"][...][ind, 0, :]
+        vb = f["gas.prim.velocity_0"][...][ind, 1, :]
+        wb = f["gas.prim.velocity_0"][...][ind, 2, :]
+        sys = f["Params"].attrs["artemis/coord_sys"]
+        time = f["Info"].attrs["Time"]
+
+    nb, bsz, bsy, bsx = db.shape
+
+    offset[:, 0] -= offset[:, 0].min()
+    offset[:, 1] -= offset[:, 1].min()
+    offset[:, 2] -= offset[:, 2].min()
+
+    nx = bsx * (offset[:, 0].max() + 1)
+    ny = bsy * (offset[:, 1].max() + 1)
+    nz = bsz * (offset[:, 2].max() + 1)
+
+    d = np.zeros((nz, ny, nx))
+    p = np.zeros((nz, ny, nx))
+    u = np.zeros((nz, ny, nx))
+    v = np.zeros((nz, ny, nx))
+    w = np.zeros((nz, ny, nx))
+    for n in range(nb):
+        ix = offset[n, 0]
+        iy = offset[n, 1]
+        iz = offset[n, 2]
+        d[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = db[n, :, :, :]
+        p[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = pb[n, :, :, :]
+        u[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = ub[n, :, :, :]
+        v[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = vb[n, :, :, :]
+        w[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = wb[n, :, :, :]
+
+    x = np.linspace(x.min(), x.max(), nx + 1)
+    y = np.linspace(y.min(), y.max(), ny + 1)
+    z = np.linspace(z.min(), z.max(), nz + 1)
+    return time, x, y, z, [d, u, v, w, p / d]
+
+
+# Associated functions for plotting Artemis data
+def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
+    labelsize = kargs.pop("labelsize", 14)
+    labelsize = kargs.pop("fontsize", 14)
+
+    if cax is None:
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes(where, size="3%", pad=0.05)
+
+    cmap = matplotlib.cm.get_cmap(cmap)
+    cb = matplotlib.colorbar.ColorbarBase(
+        ax=cax, cmap=cmap, norm=norm, orientation="horizontal", **kargs
+    )
+    cb.ax.xaxis.set_ticks_position(where)
+    cb.ax.xaxis.set_label_position(where)
+    cb.ax.tick_params(labelsize=labelsize)
+
+    return cb
+
+
+# Shared function to compute analytic Ogilvie & Lubow (2002) spiral positions
+def spiral_pos(r, r0=1.0, p0=np.pi, h=0.05):
+    def mod_2pi(p):
+        while p > 2 * np.pi:
+            p -= 2 * np.pi
+        while p < 0.0:
+            p += 2 * np.pi
+        return p
+
+    if r > r0:
+        return mod_2pi(
+            p0 - mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
+        )
+    if r < r0:
+        return mod_2pi(
+            p0 + mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
+        )
+    return p0
+
+
+# General exception class for these functions
+class ArtemisError(RuntimeError):
+    pass

--- a/tst/scripts/utils/artemis.py
+++ b/tst/scripts/utils/artemis.py
@@ -47,6 +47,8 @@ def set_mpi_oversubscribe(use_oversubscribe):
 def set_supplied_exe(use_exe):
     global use_supplied_exe
     use_supplied_exe = use_exe
+    custom_msg = "use pre-existing" if use_exe else "build"
+    print("...Regression will " + custom_msg + " executable...\n")
 
 
 # Optionally set custom path for executable, and update other variables related to where
@@ -252,7 +254,6 @@ def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
 
 # Shared function to compute analytic Ogilvie & Lubow (2002) spiral positions
 def spiral_pos(r, r0=1.0, p0=np.pi, h=0.05):
-    # Analytic spiral position from
     def mod_2pi(p):
         while p > 2 * np.pi:
             p -= 2 * np.pi

--- a/tst/scripts/utils/artemis.py
+++ b/tst/scripts/utils/artemis.py
@@ -18,6 +18,7 @@
 
 # Modules
 import logging
+import numpy as np
 import os
 import subprocess
 import datetime
@@ -25,41 +26,63 @@ from timeit import default_timer as timer
 from .log_pipe import LogPipe
 
 # Global variables
-current_dir = os.getcwd()
-artemis_dir = os.path.abspath(
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..")
-)
-artemis_executable = os.path.join(artemis_dir, "tst", "build", "src", "artemis")
-artemis_inputs_dir = os.path.join(artemis_dir, "inputs")
-artemis_run_dir = os.path.join(artemis_dir, "tst", "build", "src", "tst")
-artemis_fig_dir = os.path.join(artemis_dir, "tst", "figs")
-artemis_log_dir = os.path.join(artemis_dir, "tst")
-custom_exe = False
+artemis_dir = os.path.abspath(os.path.join(__file__, "../../../../"))
+current_dir = "dev/null"
+artemis_exe_dir = "/dev/null"
+artemis_inputs_dir = "/dev/null"
+artemis_data_dir = "/dev/null"
+artemis_fig_dir = "/dev/null"
+artemis_log_dir = "/dev/null"
+use_mpi_oversubscribe = False
+use_supplied_exe = False
+
+
+# Optionally invoke MPI oversubscribe
+def set_mpi_oversubscribe(use_oversubscribe):
+    global use_mpi_oversubscribe
+    use_mpi_oversubscribe = use_oversubscribe
+
+
+# Invoke custom executable
+def set_supplied_exe(use_exe):
+    global use_supplied_exe
+    use_supplied_exe = use_exe
 
 
 # Optionally set custom path for executable, and update other variables related to where
 # we run the code
-def set_executable(executable_path, output_dir):
-    global artemis_executable
-    global artemis_run_dir
+def set_paths(executable_dir, output_dir):
+    global current_dir
+    global artemis_exe_dir
+    global artemis_inputs_dir
+    global artemis_data_dir
     global artemis_fig_dir
     global artemis_log_dir
-    global custom_exe
-    artemis_executable = executable_path
-    artemis_run_dir = os.path.join(output_dir, "tst")
+    current_dir = os.getcwd()
+    artemis_exe_dir = executable_dir
+    artemis_inputs_dir = os.path.join(artemis_dir, "inputs")
+    artemis_data_dir = os.path.join(output_dir, "data")
     artemis_fig_dir = os.path.join(output_dir, "figs")
-    artemis_log_dir = output_dir
-    custom_exe = True
+    artemis_log_dir = os.path.join(output_dir, "logs")
+    print("Artemis Regression Paths:")
+    print("   Artemis directory:    ", artemis_dir)
+    print("   Current directory:    ", current_dir)
+    print("   Executable directory: ", artemis_exe_dir)
+    print("   Inputs directory:     ", artemis_inputs_dir)
+    print("   Data directory:       ", artemis_data_dir)
+    print("   Figures directory:    ", artemis_fig_dir)
+    print("   Logs directory:       ", artemis_log_dir)
+    print("\n")
 
 
-# Function for returning the path to the run directory for this set of tests
-def get_run_directory():
-    return artemis_run_dir
-
-
-# Provide base directory of artemis source tree
-def get_source_directory():
-    return artemis_dir
+get_artemis_dir = lambda: artemis_dir
+get_current_dir = lambda: current_dir
+get_exe_dir = lambda: artemis_exe_dir
+get_inputs_dir = lambda: artemis_inputs_dir
+get_data_dir = lambda: artemis_data_dir
+get_fig_dir = lambda: artemis_fig_dir
+get_log_dir = lambda: artemis_log_dir
+get_supplied_exe = lambda: use_supplied_exe
 
 
 # Function for compiling Artemis
@@ -96,18 +119,20 @@ def make(cmake_args, make_nproc):
 def run(nproc, input_filename, arguments, restart=None):
     # global run_directory
     out_log = LogPipe("artemis.run", logging.INFO)
-    os.makedirs(artemis_run_dir, exist_ok=True)
 
     # Build the run command
-    run_command = ["mpiexec", "--oversubscribe", "-n", str(nproc), artemis_executable]
+    run_command = ["mpiexec"]
+    if use_mpi_oversubscribe:
+        run_command += ["--oversubscribe"]
+    run_command += ["-n", str(nproc), os.path.join(artemis_exe_dir, "artemis")]
     if restart is not None:
         run_command += ["-r", restart]
     input_filename_full = os.path.join(artemis_inputs_dir, input_filename)
     run_command += ["-i", input_filename_full]
+    run_command += ["-d", artemis_data_dir]
 
     try:
-        # os.chdir(run_directory)
-        os.chdir(artemis_run_dir)
+        os.chdir(artemis_exe_dir)
         cmd = run_command + arguments
         logging.getLogger("artemis.run").debug("Executing: " + " ".join(cmd))
         subprocess.check_call(cmd, stdout=out_log)
@@ -120,6 +145,131 @@ def run(nproc, input_filename, arguments, restart=None):
     finally:
         out_log.close()
         os.chdir(current_dir)
+
+
+# Function for reading Artemis data
+def load_level(n, base, dir="./", off=0):
+    # Loads a snapshot and combines the blocks on a single level
+    # This assumes levels are nested properly
+    import h5py
+
+    try:
+        fname = "{}/{}.{:05d}.phdf".format(dir, base, n)
+    except:
+        fname = "{}/{}.{}.phdf".format(dir, base, n)
+
+    with h5py.File(fname, "r") as f:
+        time = f["Info"].attrs["Time"]
+
+        lvl = f["Levels"][...]
+        ind = lvl == max(lvl.max() - off, 0)
+
+        offset = f["LogicalLocations"][...][ind, :]
+        x = f["Locations/x"][...][ind, :]
+        y = f["Locations/y"][...][ind, :]
+        z = f["Locations/z"][...][ind, :]
+        db = f["gas.prim.density_0"][...][ind, :]
+        pb = f["gas.prim.pressure_0"][...][ind, :]
+        ub = f["gas.prim.velocity_0"][...][ind, 0, :]
+        vb = f["gas.prim.velocity_0"][...][ind, 1, :]
+        wb = f["gas.prim.velocity_0"][...][ind, 2, :]
+        sys = f["Params"].attrs["artemis/coord_sys"]
+        time = f["Info"].attrs["Time"]
+
+    nb, bsz, bsy, bsx = db.shape
+
+    offset[:, 0] -= offset[:, 0].min()
+    offset[:, 1] -= offset[:, 1].min()
+    offset[:, 2] -= offset[:, 2].min()
+
+    nx = bsx * (offset[:, 0].max() + 1)
+    ny = bsy * (offset[:, 1].max() + 1)
+    nz = bsz * (offset[:, 2].max() + 1)
+
+    d = np.zeros((nz, ny, nx))
+    p = np.zeros((nz, ny, nx))
+    u = np.zeros((nz, ny, nx))
+    v = np.zeros((nz, ny, nx))
+    w = np.zeros((nz, ny, nx))
+    for n in range(nb):
+        ix = offset[n, 0]
+        iy = offset[n, 1]
+        iz = offset[n, 2]
+        d[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = db[n, :, :, :]
+        p[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = pb[n, :, :, :]
+        u[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = ub[n, :, :, :]
+        v[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = vb[n, :, :, :]
+        w[
+            iz * bsz : (iz + 1) * bsz,
+            iy * bsy : (iy + 1) * bsy,
+            ix * bsx : (ix + 1) * bsx,
+        ] = wb[n, :, :, :]
+
+    x = np.linspace(x.min(), x.max(), nx + 1)
+    y = np.linspace(y.min(), y.max(), ny + 1)
+    z = np.linspace(z.min(), z.max(), nz + 1)
+    return time, x, y, z, [d, u, v, w, p / d]
+
+
+# Associated functions for plotting Artemis data
+def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
+    import matplotlib
+    import matplotlib.cm
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+    labelsize = kargs.pop("labelsize", 14)
+    labelsize = kargs.pop("fontsize", 14)
+
+    if cax is None:
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes(where, size="3%", pad=0.05)
+
+    cmap = matplotlib.cm.get_cmap(cmap)
+    cb = matplotlib.colorbar.ColorbarBase(
+        ax=cax, cmap=cmap, norm=norm, orientation="horizontal", **kargs
+    )
+    cb.ax.xaxis.set_ticks_position(where)
+    cb.ax.xaxis.set_label_position(where)
+    cb.ax.tick_params(labelsize=labelsize)
+
+    return cb
+
+
+# Shared function to compute analytic Ogilvie & Lubow (2002) spiral positions
+def spiral_pos(r, r0=1.0, p0=np.pi, h=0.05):
+    # Analytic spiral position from
+    def mod_2pi(p):
+        while p > 2 * np.pi:
+            p -= 2 * np.pi
+        while p < 0.0:
+            p += 2 * np.pi
+        return p
+
+    if r > r0:
+        return mod_2pi(
+            p0 - mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
+        )
+    if r < r0:
+        return mod_2pi(
+            p0 + mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
+        )
+    return p0
 
 
 # General exception class for these functions

--- a/tst/scripts/utils/artemis.py
+++ b/tst/scripts/utils/artemis.py
@@ -18,17 +18,16 @@
 
 # Modules
 import logging
-import numpy as np
 import os
 import subprocess
-import datetime
 from timeit import default_timer as timer
 from .log_pipe import LogPipe
 
 # Global variables
 artemis_dir = os.path.abspath(os.path.join(__file__, "../../../../"))
-current_dir = "dev/null"
+current_dir = os.getcwd()
 artemis_exe_dir = "/dev/null"
+artemis_outputs_dir = "/dev/null"
 artemis_inputs_dir = "/dev/null"
 artemis_data_dir = "/dev/null"
 artemis_fig_dir = "/dev/null"
@@ -54,14 +53,14 @@ def set_supplied_exe(use_exe):
 # Optionally set custom path for executable, and update other variables related to where
 # we run the code
 def set_paths(executable_dir, output_dir):
-    global current_dir
     global artemis_exe_dir
+    global artemis_outputs_dir
     global artemis_inputs_dir
     global artemis_data_dir
     global artemis_fig_dir
     global artemis_log_dir
-    current_dir = os.getcwd()
     artemis_exe_dir = executable_dir
+    artemis_outputs_dir = output_dir
     artemis_inputs_dir = os.path.join(artemis_dir, "inputs")
     artemis_data_dir = os.path.join(output_dir, "data")
     artemis_fig_dir = os.path.join(output_dir, "figs")
@@ -70,6 +69,7 @@ def set_paths(executable_dir, output_dir):
     print("   Artemis directory:    ", artemis_dir)
     print("   Current directory:    ", current_dir)
     print("   Executable directory: ", artemis_exe_dir)
+    print("   Outputs directory:    ", artemis_outputs_dir)
     print("   Inputs directory:     ", artemis_inputs_dir)
     print("   Data directory:       ", artemis_data_dir)
     print("   Figures directory:    ", artemis_fig_dir)
@@ -80,6 +80,7 @@ def set_paths(executable_dir, output_dir):
 get_artemis_dir = lambda: artemis_dir
 get_current_dir = lambda: current_dir
 get_exe_dir = lambda: artemis_exe_dir
+get_outputs_dir = lambda: artemis_outputs_dir
 get_inputs_dir = lambda: artemis_inputs_dir
 get_data_dir = lambda: artemis_data_dir
 get_fig_dir = lambda: artemis_fig_dir
@@ -91,15 +92,14 @@ get_supplied_exe = lambda: use_supplied_exe
 def make(cmake_args, make_nproc):
     logger = logging.getLogger("artemis.make")
     out_log = LogPipe("artemis.make", logging.INFO)
-    current_dir = os.getcwd()
+    build_dir = os.path.join(artemis_dir, "tst/build")
+    build_src_dir = os.path.join(build_dir, "src")
     try:
-        subprocess.check_call(["mkdir", "build"], stdout=out_log)
-        build_dir = current_dir + "/build/"
-        os.chdir(build_dir)
-        cmake_command = ["cmake", artemis_dir] + cmake_args
-        make_command = ["make", "-j" + str(make_nproc)]
+        cmake_command = ["cmake", "-B", build_dir] + cmake_args
+        make_command = ["make", "-j" + str(make_nproc), "-C", build_src_dir]
         try:
             t0 = timer()
+            os.chdir(artemis_dir)
             logger.debug("Executing: " + " ".join(cmake_command))
             subprocess.check_call(cmake_command, stdout=out_log)
             logger.debug("Executing: " + " ".join(make_command))
@@ -133,7 +133,7 @@ def run(nproc, input_filename, arguments, restart=None):
     run_command += ["-d", artemis_data_dir]
 
     try:
-        os.chdir(artemis_exe_dir)
+        os.chdir(artemis_outputs_dir)
         cmd = run_command + arguments
         logging.getLogger("artemis.run").debug("Executing: " + " ".join(cmd))
         subprocess.check_call(cmd, stdout=out_log)
@@ -146,130 +146,6 @@ def run(nproc, input_filename, arguments, restart=None):
     finally:
         out_log.close()
         os.chdir(current_dir)
-
-
-# Function for reading Artemis data
-def load_level(n, base, dir="./", off=0):
-    # Loads a snapshot and combines the blocks on a single level
-    # This assumes levels are nested properly
-    import h5py
-
-    try:
-        fname = "{}/{}.{:05d}.phdf".format(dir, base, n)
-    except:
-        fname = "{}/{}.{}.phdf".format(dir, base, n)
-
-    with h5py.File(fname, "r") as f:
-        time = f["Info"].attrs["Time"]
-
-        lvl = f["Levels"][...]
-        ind = lvl == max(lvl.max() - off, 0)
-
-        offset = f["LogicalLocations"][...][ind, :]
-        x = f["Locations/x"][...][ind, :]
-        y = f["Locations/y"][...][ind, :]
-        z = f["Locations/z"][...][ind, :]
-        db = f["gas.prim.density_0"][...][ind, :]
-        pb = f["gas.prim.pressure_0"][...][ind, :]
-        ub = f["gas.prim.velocity_0"][...][ind, 0, :]
-        vb = f["gas.prim.velocity_0"][...][ind, 1, :]
-        wb = f["gas.prim.velocity_0"][...][ind, 2, :]
-        sys = f["Params"].attrs["artemis/coord_sys"]
-        time = f["Info"].attrs["Time"]
-
-    nb, bsz, bsy, bsx = db.shape
-
-    offset[:, 0] -= offset[:, 0].min()
-    offset[:, 1] -= offset[:, 1].min()
-    offset[:, 2] -= offset[:, 2].min()
-
-    nx = bsx * (offset[:, 0].max() + 1)
-    ny = bsy * (offset[:, 1].max() + 1)
-    nz = bsz * (offset[:, 2].max() + 1)
-
-    d = np.zeros((nz, ny, nx))
-    p = np.zeros((nz, ny, nx))
-    u = np.zeros((nz, ny, nx))
-    v = np.zeros((nz, ny, nx))
-    w = np.zeros((nz, ny, nx))
-    for n in range(nb):
-        ix = offset[n, 0]
-        iy = offset[n, 1]
-        iz = offset[n, 2]
-        d[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = db[n, :, :, :]
-        p[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = pb[n, :, :, :]
-        u[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = ub[n, :, :, :]
-        v[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = vb[n, :, :, :]
-        w[
-            iz * bsz : (iz + 1) * bsz,
-            iy * bsy : (iy + 1) * bsy,
-            ix * bsx : (ix + 1) * bsx,
-        ] = wb[n, :, :, :]
-
-    x = np.linspace(x.min(), x.max(), nx + 1)
-    y = np.linspace(y.min(), y.max(), ny + 1)
-    z = np.linspace(z.min(), z.max(), nz + 1)
-    return time, x, y, z, [d, u, v, w, p / d]
-
-
-# Associated functions for plotting Artemis data
-def create_colorbar(ax, norm, where="top", cax=None, cmap="viridis", **kargs):
-    import matplotlib
-    import matplotlib.cm
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-
-    labelsize = kargs.pop("labelsize", 14)
-    labelsize = kargs.pop("fontsize", 14)
-
-    if cax is None:
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes(where, size="3%", pad=0.05)
-
-    cmap = matplotlib.cm.get_cmap(cmap)
-    cb = matplotlib.colorbar.ColorbarBase(
-        ax=cax, cmap=cmap, norm=norm, orientation="horizontal", **kargs
-    )
-    cb.ax.xaxis.set_ticks_position(where)
-    cb.ax.xaxis.set_label_position(where)
-    cb.ax.tick_params(labelsize=labelsize)
-
-    return cb
-
-
-# Shared function to compute analytic Ogilvie & Lubow (2002) spiral positions
-def spiral_pos(r, r0=1.0, p0=np.pi, h=0.05):
-    def mod_2pi(p):
-        while p > 2 * np.pi:
-            p -= 2 * np.pi
-        while p < 0.0:
-            p += 2 * np.pi
-        return p
-
-    if r > r0:
-        return mod_2pi(
-            p0 - mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
-        )
-    if r < r0:
-        return mod_2pi(
-            p0 + mod_2pi(2.0 / (3 * h) * (r ** (1.5) - 1.5 * np.log(r) - 1.0))
-        )
-    return p0
 
 
 # General exception class for these functions

--- a/tst/scripts/utils/artemis.py
+++ b/tst/scripts/utils/artemis.py
@@ -126,9 +126,8 @@ def run(nproc, input_filename, arguments, restart=None):
         run_command += ["--oversubscribe"]
     run_command += ["-n", str(nproc), os.path.join(artemis_exe_dir, "artemis")]
     if restart is not None:
-        run_command += ["-r", restart]
-    input_filename_full = os.path.join(artemis_inputs_dir, input_filename)
-    run_command += ["-i", input_filename_full]
+        run_command += ["-r", os.path.join(artemis_data_dir, restart)]
+    run_command += ["-i", os.path.join(artemis_inputs_dir, input_filename)]
     run_command += ["-d", artemis_data_dir]
 
     try:


### PR DESCRIPTION
## Background

Moderate cleanup of CI and fixes regression execution on Macs.

## Description of Changes

- Reload "base" test module in derived tests via `importlib` (such that we will not worry about future derived tests having shared states dependent on order of execution).
- Fix Mac regression execution, requires special care of positioning of `librebound.so`.  
- Remove duplicated code in tests.
- Fix a few edge cases in CI workflows (hopefully without breaking others...)

## Checklist

- [x] New features are documented
- [x] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files
