### PR TITLE
Fix Venado submission script issue

### DIFF
--- a/env/bash
+++ b/env/bash
@@ -27,10 +27,10 @@ if [[ $HOSTNAME == ch-fe*  ||  $SLURM_CLUSTER_NAME == "chicoma" ]]; then
     else
         PARTITION="chicoma-cpu"
     fi
-elif [[ "$HOSTNAME" =~ ^ve-rfe[1-7]$ || "$HOSTNAME" =~ ^ve-fe[1-7]$ ]]; then
-    if [[ $SLURM_GPUS_ON_NODE > 0 || ("$HOSTNAME" =~ ^ve-rfe[1-3]$ || "$HOSTNAME" =~ ^ve-fe[1-3]$) ]]; then
+elif [[ "$HOST" =~ ^ve-rfe[1-7]$ || "$HOST" =~ ^ve-fe[1-7]$ ]]; then
+    if [[ $SLURM_GPUS_ON_NODE > 0 || ("$HOST" =~ ^ve-rfe[1-3]$ || "$HOST" =~ ^ve-fe[1-3]$) ]]; then
         PARTITION="venado-gh"
-    elif [[ $SLURM_GPUS_ON_NODE == 0 || ("$HOSTNAME" =~ ^ve-rfe[4-7]$ || "$HOSTNAME" =~ ^ve-fe[4-7]$) ]]; then
+    elif [[ $SLURM_GPUS_ON_NODE == 0 || ("$HOST" =~ ^ve-rfe[4-7]$ || "$HOST" =~ ^ve-fe[4-7]$) ]]; then
         PARTITION="venado-gg"
     fi
 else # Catch-all for Darwin
@@ -122,18 +122,28 @@ elif [[ $PARTITION == "darwin-volta-x86" ]]; then
     echo "...setup SUCCEEDED"
 elif [[ $PARTITION == "venado-gh" ]]; then
     module load PrgEnv-gnu
-    module load cray-mpich
+    module load cudatoolkit/24.7_12.5
+    module load craype-accel-nvidia90
+    module load cmake
     #module load cray-hdf5-parallel # Compiler wrappers fail to find hdf5.h 2024/11/8
     export HDF5_ROOT=/opt/cray/pe/hdf5-parallel/1.14.3.1/gnu/12.3
-    module load cudatoolkit
-    module load cmake
-    export MPICH_OFI_NIC_POLICY=GPU   # GPU NUMA ROUND-ROBIN
-    export MPICH_GPU_SUPPORT_ENABLED=1 # Allows GPU Aware MPI
-    export CRAY_ACCEL_TARGET=nvidia90
-    export MPICH_MALLOC_FALLBACK=1
-    export MPICH_SMP_SINGLE_COPY_MODE=NONE
-    export MPICH_MAX_THREAD_SAFETY=multiple
+    export MPICC=cc
+    export MPICXX=CC
+    export MPIFC=ftn
+    export CC=cc
+    export CXX=CC
+    export FC=ftn
+    export F90=ftn
+    export MPICH_GPU_SUPPORT_ENABLED=1
+    export CRAY_MALLOPT_OFF=1
+    export FI_CXI_DEFAULT_TX_SIZE=1024
+    export FI_CXI_RDZV_PROTO=alt_read
+    export FI_CXI_RDZV_THRESHOLD=32768
     export FI_CXI_RX_MATCH_MODE=hybrid
+    export FI_CXI_SW_RX_TX_INIT_MAX=10240
+    export MPICH_COLL_SYNC=1
+    export MPICH_MALLOC_FALLBACK=1
+    export MPICH_MAX_THREAD_SAFETY=multiple
     export PMI_MMAP_SYNC_WAIT_TIME=600
     export NVCC_WRAPPER_DEFAULT_COMPILER=g++
     export ARTEMIS_SUITE=venado-gpu

--- a/tst/launch_ci_runner.py
+++ b/tst/launch_ci_runner.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
 
         if not fnmatch.fnmatch(hostname, "darwin-fe*"):
             # if we are on a backend
-            if cluster.lower() != "darwin":
+            if cluster is None or cluster.lower() != "darwin":
                 print("ERROR script must be run from Darwin!")
                 sys.exit(1)
 


### PR DESCRIPTION
## Background

@111-1000 noticed that `env/bash` is no longer working when called from submission scripts. This is due to #13's use of `HOSTNAME` which is not the same as `HOST` on venado backend nodes; we want to switch this to `HOST`. 

## Description of Changes

- [x] Switch `HOST` to `HOSTNAME` on venado backend
- [x] Slightly more modern venado environment (still not working across multiple ranks on venado GPUs)

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
