### PR TITLE
Wrap rebound simulation pointer in struct

### DIFF
--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -149,6 +149,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // Build the rebound sim
   const Real box_size = pin->GetOrAddReal("nbody", "box_size", Big<Real>());
   RebSim reb_sim;
+  printf("%s:%i\n", __FILE__, __LINE__);
   if (parthenon::Globals::my_rank == 0) {
     for (int i = 0; i < npart; i++) {
       struct reb_particle pl = {0};
@@ -213,7 +214,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     // Set the function pointers
     SetReboundPtrs(reb_sim);
   }
+  printf("%s:%i\n", __FILE__, __LINE__);
   params.Add("reb_sim", reb_sim, true);
+  printf("%s:%i\n", __FILE__, __LINE__);
 
   // Hydro integrator
   LowStorageIntegrator hydro_integ(pin);
@@ -310,6 +313,7 @@ void UserWorkBeforeRestartOutputMesh(Mesh *pmesh, ParameterInput *, SimTime &,
   // Extract Rebound simulation
   auto &nbody_pkg = pmesh->packages.Get("nbody");
   auto reb_sim = nbody_pkg->Param<RebSim>("reb_sim");
+  printf("%s:%i\n", __FILE__, __LINE__);
 
   // Write native Rebound restart
   if (Globals::my_rank == 0) {
@@ -350,6 +354,7 @@ void InitializeFromRestart(Mesh *pm) {
   // Extract Rebound parameters
   auto &nbody_pkg = pm->packages.Get("nbody");
   auto reb_sim = nbody_pkg->Param<RebSim>("reb_sim");
+  printf("%s:%i\n", __FILE__, __LINE__);
   auto particle_id = nbody_pkg->Param<std::vector<int>>("particle_id");
   auto particles = nbody_pkg->Param<ParArray1D<NBody::Particle>>("particles");
 
@@ -362,13 +367,16 @@ void InitializeFromRestart(Mesh *pm) {
     outfile.close();
 
     // Create rebound simulation from new save file
+    printf("%s:%i\n", __FILE__, __LINE__);
     RebSim new_reb_sim(NBody::rebound_filename);
     SetReboundPtrs(new_reb_sim);
+    printf("%s:%i\n", __FILE__, __LINE__);
     nbody_pkg->UpdateParam<RebSim>("reb_sim", new_reb_sim);
   }
 
   // Send restarted rebound particles to all nodes
   auto reb_sim_rst = nbody_pkg->Param<RebSim>("reb_sim");
+  printf("%s:%i\n", __FILE__, __LINE__);
   SyncWithRebound(reb_sim_rst, particle_id, particles);
 }
 

--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -161,10 +161,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       pl.vx = particles_v[i].vel[0];
       pl.vy = particles_v[i].vel[1];
       pl.vz = particles_v[i].vel[2];
-      reb_simulation_add(reb_sim.get(), pl);
+      reb_simulation_add(reb_sim, pl);
 
       // Verify that what we added still lives
-      struct reb_particle *pl2 = reb_simulation_particle_by_hash(reb_sim.get(), i + 1);
+      struct reb_particle *pl2 = reb_simulation_particle_by_hash(reb_sim, i + 1);
       PARTHENON_REQUIRE(pl2->r == particles_v[i].radius,
                         "Particle radius is inconsistent at setup!");
       PARTHENON_REQUIRE(pl2->m == particles_v[i].GM,
@@ -183,27 +183,27 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
                         "Particle vz is inconsistent at setup!");
     }
 
-    reb_simulation_configure_box(reb_sim.get(), box_size, 1, 1, 1);
-    reb_sim.get()->boundary = reb_simulation::REB_BOUNDARY_OPEN;
-    reb_sim.get()->collision = reb_simulation::REB_COLLISION_LINE;
-    reb_sim.get()->dt = dt_reb;
-    if (RebAttrs::extras) reb_sim.get()->force_is_velocity_dependent = 1;
+    reb_simulation_configure_box(reb_sim, box_size, 1, 1, 1);
+    reb_sim->boundary = reb_simulation::REB_BOUNDARY_OPEN;
+    reb_sim->collision = reb_simulation::REB_COLLISION_LINE;
+    reb_sim->dt = dt_reb;
+    if (RebAttrs::extras) reb_sim->force_is_velocity_dependent = 1;
     if (integrator == "whfast") {
-      reb_sim.get()->integrator = reb_simulation::REB_INTEGRATOR_WHFAST;
+      reb_sim->integrator = reb_simulation::REB_INTEGRATOR_WHFAST;
     } else if (integrator == "leapfrog") {
-      reb_sim.get()->integrator = reb_simulation::REB_INTEGRATOR_LEAPFROG;
+      reb_sim->integrator = reb_simulation::REB_INTEGRATOR_LEAPFROG;
     } else if (integrator == "janus") {
-      reb_sim.get()->integrator = reb_simulation::REB_INTEGRATOR_JANUS;
+      reb_sim->integrator = reb_simulation::REB_INTEGRATOR_JANUS;
     } else if (integrator == "mercurius") {
-      reb_sim.get()->integrator = reb_simulation::REB_INTEGRATOR_MERCURIUS;
+      reb_sim->integrator = reb_simulation::REB_INTEGRATOR_MERCURIUS;
     } else if (integrator == "saba") {
-      reb_sim.get()->integrator = reb_simulation::REB_INTEGRATOR_SABA;
+      reb_sim->integrator = reb_simulation::REB_INTEGRATOR_SABA;
     } else if (integrator == "bs") {
-      reb_sim.get()->integrator = reb_simulation::REB_INTEGRATOR_BS;
+      reb_sim->integrator = reb_simulation::REB_INTEGRATOR_BS;
     } else if (integrator == "ias15") {
-      reb_sim.get()->integrator = reb_simulation::REB_INTEGRATOR_IAS15;
+      reb_sim->integrator = reb_simulation::REB_INTEGRATOR_IAS15;
     } else if (integrator == "none") {
-      reb_sim.get()->integrator = reb_simulation::REB_INTEGRATOR_NONE;
+      reb_sim->integrator = reb_simulation::REB_INTEGRATOR_NONE;
     } else {
       std::stringstream msg;
       msg << integrator << " is an invalid REBOUND integrator!";
@@ -310,7 +310,6 @@ void UserWorkBeforeRestartOutputMesh(Mesh *pmesh, ParameterInput *, SimTime &,
   // Extract Rebound simulation
   auto &nbody_pkg = pmesh->packages.Get("nbody");
   auto reb_sim = nbody_pkg->Param<RebSim>("reb_sim");
-  printf("%s %i v: %i\n", __FILE__, __LINE__, reb_sim.get()->simulationarchive_version);
 
   // Write native Rebound restart
   if (Globals::my_rank == 0) {
@@ -321,9 +320,8 @@ void UserWorkBeforeRestartOutputMesh(Mesh *pmesh, ParameterInput *, SimTime &,
         PARTHENON_FAIL("Unable to delete temporary REBOUND file!");
       }
     }
-    reb_simulation_save_to_file(reb_sim.get(), NBody::rebound_filename.c_str());
+    reb_simulation_save_to_file(reb_sim, NBody::rebound_filename.c_str());
   }
-  printf("%s:%i\n", __FILE__, __LINE__);
 
 #ifdef MPI_PARALLEL
   // Ensure the file is available for all ranks
@@ -352,7 +350,6 @@ void InitializeFromRestart(Mesh *pm) {
   // Extract Rebound parameters
   auto &nbody_pkg = pm->packages.Get("nbody");
   auto reb_sim = nbody_pkg->Param<RebSim>("reb_sim");
-  printf("%i %i v: %i\n", __FILE__, __LINE__, reb_sim.get()->simulationarchive_version);
   auto particle_id = nbody_pkg->Param<std::vector<int>>("particle_id");
   auto particles = nbody_pkg->Param<ParArray1D<NBody::Particle>>("particles");
 

--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -149,7 +149,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // Build the rebound sim
   const Real box_size = pin->GetOrAddReal("nbody", "box_size", Big<Real>());
   RebSim reb_sim;
-  printf("%s:%i\n", __FILE__, __LINE__);
   if (parthenon::Globals::my_rank == 0) {
     for (int i = 0; i < npart; i++) {
       struct reb_particle pl = {0};
@@ -214,9 +213,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     // Set the function pointers
     SetReboundPtrs(reb_sim);
   }
-  printf("%s:%i\n", __FILE__, __LINE__);
   params.Add("reb_sim", reb_sim, true);
-  printf("%s:%i\n", __FILE__, __LINE__);
 
   // Hydro integrator
   LowStorageIntegrator hydro_integ(pin);
@@ -313,7 +310,6 @@ void UserWorkBeforeRestartOutputMesh(Mesh *pmesh, ParameterInput *, SimTime &,
   // Extract Rebound simulation
   auto &nbody_pkg = pmesh->packages.Get("nbody");
   auto reb_sim = nbody_pkg->Param<RebSim>("reb_sim");
-  printf("%s:%i\n", __FILE__, __LINE__);
 
   // Write native Rebound restart
   if (Globals::my_rank == 0) {
@@ -354,7 +350,6 @@ void InitializeFromRestart(Mesh *pm) {
   // Extract Rebound parameters
   auto &nbody_pkg = pm->packages.Get("nbody");
   auto reb_sim = nbody_pkg->Param<RebSim>("reb_sim");
-  printf("%s:%i\n", __FILE__, __LINE__);
   auto particle_id = nbody_pkg->Param<std::vector<int>>("particle_id");
   auto particles = nbody_pkg->Param<ParArray1D<NBody::Particle>>("particles");
 
@@ -367,16 +362,13 @@ void InitializeFromRestart(Mesh *pm) {
     outfile.close();
 
     // Create rebound simulation from new save file
-    printf("%s:%i\n", __FILE__, __LINE__);
     RebSim new_reb_sim(NBody::rebound_filename);
     SetReboundPtrs(new_reb_sim);
-    printf("%s:%i\n", __FILE__, __LINE__);
     nbody_pkg->UpdateParam<RebSim>("reb_sim", new_reb_sim);
   }
 
   // Send restarted rebound particles to all nodes
   auto reb_sim_rst = nbody_pkg->Param<RebSim>("reb_sim");
-  printf("%s:%i\n", __FILE__, __LINE__);
   SyncWithRebound(reb_sim_rst, particle_id, particles);
 }
 

--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -373,13 +373,11 @@ void InitializeFromRestart(Mesh *pm) {
     outfile.close();
 
     // Create rebound simulation from new save file
-    char *reb_filename = new char[NBody::rebound_filename.size() + 1];
-    std::strcpy(reb_filename, NBody::rebound_filename.c_str());
-    RebSim new_reb_sim;
-    new_reb_sim.set(reb_simulation_create_from_file(reb_filename, -1));
-    printf("%s:%i\n", __FILE__, __LINE__);
-    printf("v? %i\n", new_reb_sim.get()->simulationarchive_version);
-    // reb_simulation_free(reb_sim.get());
+    // char *reb_filename = new char[NBody::rebound_filename.size() + 1];
+    // std::strcpy(reb_filename, NBody::rebound_filename.c_str());
+    // RebSim new_reb_sim;
+    // new_reb_sim.set(reb_simulation_create_from_file(reb_filename, -1));
+    RebSim new_reb_sim(NBody::rebound_filename);
     SetReboundPtrs(new_reb_sim);
     nbody_pkg->UpdateParam<RebSim>("reb_sim", new_reb_sim);
   }

--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -346,6 +346,7 @@ void UserWorkBeforeRestartOutputMesh(Mesh *pmesh, ParameterInput *, SimTime &,
 
   // Store current rebound output as restartable parameter.  Every rank must store a
   // matching buffer parameter or else I/O will hang
+  printf("p[%i] buff: %s\n", Globals::my_rank, reb_sim_buffer.data());
   nbody_pkg->UpdateParam<std::vector<char>>("reb_sim_buffer", reb_sim_buffer);
 }
 

--- a/src/nbody/nbody_advance.cpp
+++ b/src/nbody/nbody_advance.cpp
@@ -178,11 +178,6 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
   // Update our copies of the particle positions and velocities
   SyncWithRebound(r_sim, particle_id, particles);
 
-  // Free the rebound copy if we are not on the last stage
-  // if ((parthenon::Globals::my_rank == 0) && (stage < nstages)) {
-  //  reb_simulation_free(r_sim.get());
-  // }
-
   // Reset pforce for next step
   for (int n = 0; n < npart; n++) {
     for (int i = 0; i < 7; i++) {

--- a/src/nbody/nbody_advance.cpp
+++ b/src/nbody/nbody_advance.cpp
@@ -92,7 +92,7 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
   auto pforce = nbody_pkg->Param<ParArray2D<Real>>("particle_force");
   auto pforce_tot = nbody_pkg->Param<ParArray2D<Real>>("particle_force_tot");
   auto pforce_step = nbody_pkg->Param<ParArray2D<Real>>("particle_force_step");
-  auto reb_sim = nbody_pkg->Param<struct reb_simulation *>("reb_sim");
+  auto reb_sim = nbody_pkg->Param<RebSim>("reb_sim");
 
   // Extract integrators/weights
   // NOTE(PDM): reb_integ is the rebound integrator pushing particles.  nbody_integ is the
@@ -130,12 +130,12 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
   }
 #endif
 
-  struct reb_simulation *r_sim = nullptr;
+  RebSim r_sim;
   if (parthenon::Globals::my_rank == 0) {
     // Advance the simulation.  If this is the final stage, advance the master simulation.
     // If not, advance a copy of the master.
     int sid = disable_stderr();
-    r_sim = (stage < nstages) ? reb_simulation_copy(reb_sim) : reb_sim;
+    r_sim.get() = (stage < nstages) ? reb_simulation_copy(reb_sim.get()) : reb_sim.get();
     SetReboundPtrs(r_sim);
     enable_stderr(sid);
 
@@ -151,7 +151,7 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
           (time >= particles_h(id).live_after) && (reb_integ != "none")) {
         // Apply the gravitational force
         // NOTE(ADM): pforce already contains factor of dt
-        struct reb_particle *pl = reb_simulation_particle_by_hash(r_sim, n + 1);
+        struct reb_particle *pl = reb_simulation_particle_by_hash(r_sim.get(), n + 1);
         if (pl != nullptr) {
           const Real mp = pl->m;
           pl->vx += mscale * pforce_step_h(n, 1) / mp;
@@ -163,14 +163,14 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
 
     // Integrate to the end of the stage. If the user set reb_integ = none, do nothing
     if (reb_integ != "none") {
-      reb_simulation_integrate(r_sim, time + dt_stage);
+      reb_simulation_integrate(r_sim.get(), time + dt_stage);
     }
 
     // If we are in a rotating frame, correct the rebound simulation
     if (omegaf != 0.0) {
       struct reb_vec3d axis = {.x = 0.0, .y = 0.0, .z = 1.0};
       struct reb_rotation r1 = reb_rotation_init_angle_axis(-omegaf * dt_stage, axis);
-      reb_simulation_irotate(r_sim, r1);
+      reb_simulation_irotate(r_sim.get(), r1);
     }
   }
 
@@ -179,7 +179,7 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
 
   // Free the rebound copy if we are not on the last stage
   if ((parthenon::Globals::my_rank == 0) && (stage < nstages)) {
-    reb_simulation_free(r_sim);
+    reb_simulation_free(r_sim.get());
   }
 
   // Reset pforce for next step

--- a/src/nbody/nbody_advance.cpp
+++ b/src/nbody/nbody_advance.cpp
@@ -93,7 +93,6 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
   auto pforce_tot = nbody_pkg->Param<ParArray2D<Real>>("particle_force_tot");
   auto pforce_step = nbody_pkg->Param<ParArray2D<Real>>("particle_force_step");
   auto reb_sim = nbody_pkg->Param<RebSim>("reb_sim");
-  printf("%s:%i v: %i\n", __FILE__, __LINE__, reb_sim.get()->simulationarchive_version);
 
   // Extract integrators/weights
   // NOTE(PDM): reb_integ is the rebound integrator pushing particles.  nbody_integ is the
@@ -152,7 +151,7 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
           (time >= particles_h(id).live_after) && (reb_integ != "none")) {
         // Apply the gravitational force
         // NOTE(ADM): pforce already contains factor of dt
-        struct reb_particle *pl = reb_simulation_particle_by_hash(r_sim.get(), n + 1);
+        struct reb_particle *pl = reb_simulation_particle_by_hash(r_sim, n + 1);
         if (pl != nullptr) {
           const Real mp = pl->m;
           pl->vx += mscale * pforce_step_h(n, 1) / mp;
@@ -164,14 +163,14 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
 
     // Integrate to the end of the stage. If the user set reb_integ = none, do nothing
     if (reb_integ != "none") {
-      reb_simulation_integrate(r_sim.get(), time + dt_stage);
+      reb_simulation_integrate(r_sim, time + dt_stage);
     }
 
     // If we are in a rotating frame, correct the rebound simulation
     if (omegaf != 0.0) {
       struct reb_vec3d axis = {.x = 0.0, .y = 0.0, .z = 1.0};
       struct reb_rotation r1 = reb_rotation_init_angle_axis(-omegaf * dt_stage, axis);
-      reb_simulation_irotate(r_sim.get(), r1);
+      reb_simulation_irotate(r_sim, r1);
     }
   }
 

--- a/src/nbody/nbody_advance.cpp
+++ b/src/nbody/nbody_advance.cpp
@@ -136,13 +136,7 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
     // Advance the simulation.  If this is the final stage, advance the master simulation.
     // If not, advance a copy of the master.
     int sid = disable_stderr();
-    // r_sim.set((stage < nstages) ? reb_simulation_copy(reb_sim.get()) : reb_sim.get());
-    if (stage < nstages) {
-      r_sim.set(reb_simulation_copy(reb_sim.get()));
-    } else {
-      r_sim = reb_sim;
-    }
-    printf("%s:%i v: %i\n", __FILE__, __LINE__, r_sim.get()->simulationarchive_version);
+    r_sim = (stage < nstages) ? RebSim(reb_sim) : reb_sim;
     SetReboundPtrs(r_sim);
     enable_stderr(sid);
 

--- a/src/nbody/nbody_advance.cpp
+++ b/src/nbody/nbody_advance.cpp
@@ -135,7 +135,12 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
     // Advance the simulation.  If this is the final stage, advance the master simulation.
     // If not, advance a copy of the master.
     int sid = disable_stderr();
-    r_sim = (stage < nstages) ? RebSim(reb_sim) : reb_sim;
+    if (stage < nstages) {
+      r_sim.copy(reb_sim);
+    } else {
+      r_sim = reb_sim;
+    }
+    // r_sim = (stage < nstages) ? RebSim(reb_sim) : reb_sim;
     SetReboundPtrs(r_sim);
     enable_stderr(sid);
 

--- a/src/nbody/nbody_advance.cpp
+++ b/src/nbody/nbody_advance.cpp
@@ -140,7 +140,6 @@ TaskStatus Advance(Mesh *pm, const Real time, const int stage,
     } else {
       r_sim = reb_sim;
     }
-    // r_sim = (stage < nstages) ? RebSim(reb_sim) : reb_sim;
     SetReboundPtrs(r_sim);
     enable_stderr(sid);
 

--- a/src/nbody/nbody_outputs.cpp
+++ b/src/nbody/nbody_outputs.cpp
@@ -44,6 +44,7 @@ void Outputs(parthenon::Mesh *pm, const Real time) {
   auto particle_id = nbody->Param<std::vector<int>>("particle_id");
   auto *output_count = nbody->MutableParam<int>("output_count");
   auto r_sim = nbody->Param<RebSim>("reb_sim");
+  printf("%s:%i v: %i\n", __FILE__, __LINE__, r_sim.get()->simulationarchive_version);
   auto base = nbody->Param<std::string>("output_base");
   auto particles = nbody->Param<ParArray1D<Particle>>("particles");
   auto pforce_tot = nbody->Param<ParArray2D<Real>>("particle_force_tot");

--- a/src/nbody/nbody_outputs.cpp
+++ b/src/nbody/nbody_outputs.cpp
@@ -23,8 +23,7 @@ extern "C" {
 // Artemis includes
 #include "artemis.hpp"
 #include "nbody.hpp"
-
-using namespace parthenon::package::prelude;
+#include "nbody_utils.hpp"
 
 namespace NBody {
 //----------------------------------------------------------------------------------------
@@ -44,7 +43,7 @@ void Outputs(parthenon::Mesh *pm, const Real time) {
   auto npart = nbody->Param<int>("npart");
   auto particle_id = nbody->Param<std::vector<int>>("particle_id");
   auto *output_count = nbody->MutableParam<int>("output_count");
-  auto r_sim = nbody->Param<struct reb_simulation *>("reb_sim");
+  auto r_sim = nbody->Param<RebSim>("reb_sim");
   auto base = nbody->Param<std::string>("output_base");
   auto particles = nbody->Param<ParArray1D<Particle>>("particles");
   auto pforce_tot = nbody->Param<ParArray2D<Real>>("particle_force_tot");
@@ -96,7 +95,7 @@ void Outputs(parthenon::Mesh *pm, const Real time) {
     // print the data
     for (int i = 0; i < npart; i++) {
       // info
-      std::fprintf(pfile, "%.8e\t", r_sim->t);
+      std::fprintf(pfile, "%.8e\t", r_sim.get()->t);
       std::fprintf(pfile, "%d\t", i + 1);
       std::fprintf(pfile, "%d\t", particles_h(i).alive);
       // data
@@ -210,13 +209,13 @@ void Outputs(parthenon::Mesh *pm, const Real time) {
               const int ip = (m1 >= m2) ? i : j;
               const int is = (m1 >= m2) ? j : i;
               struct reb_particle *primary =
-                  reb_simulation_particle_by_hash(r_sim, ip + 1);
+                  reb_simulation_particle_by_hash(r_sim.get(), ip + 1);
               struct reb_particle *secondary =
-                  reb_simulation_particle_by_hash(r_sim, is + 1);
+                  reb_simulation_particle_by_hash(r_sim.get(), is + 1);
               struct reb_orbit o =
-                  reb_orbit_from_particle(r_sim->G, *secondary, *primary);
+                  reb_orbit_from_particle(r_sim.get()->G, *secondary, *primary);
 
-              std::fprintf(pfile, "%.8e\t", r_sim->t);
+              std::fprintf(pfile, "%.8e\t", r_sim.get()->t);
               std::fprintf(pfile, "%.8e\t", mb);
               std::fprintf(pfile, "%.8e\t", mu1 * primary->x + mu2 * secondary->x);
               std::fprintf(pfile, "%.8e\t", mu1 * primary->y + mu2 * secondary->y);

--- a/src/nbody/nbody_outputs.cpp
+++ b/src/nbody/nbody_outputs.cpp
@@ -44,7 +44,6 @@ void Outputs(parthenon::Mesh *pm, const Real time) {
   auto particle_id = nbody->Param<std::vector<int>>("particle_id");
   auto *output_count = nbody->MutableParam<int>("output_count");
   auto r_sim = nbody->Param<RebSim>("reb_sim");
-  printf("%s:%i v: %i\n", __FILE__, __LINE__, r_sim.get()->simulationarchive_version);
   auto base = nbody->Param<std::string>("output_base");
   auto particles = nbody->Param<ParArray1D<Particle>>("particles");
   auto pforce_tot = nbody->Param<ParArray2D<Real>>("particle_force_tot");
@@ -96,7 +95,7 @@ void Outputs(parthenon::Mesh *pm, const Real time) {
     // print the data
     for (int i = 0; i < npart; i++) {
       // info
-      std::fprintf(pfile, "%.8e\t", r_sim.get()->t);
+      std::fprintf(pfile, "%.8e\t", r_sim->t);
       std::fprintf(pfile, "%d\t", i + 1);
       std::fprintf(pfile, "%d\t", particles_h(i).alive);
       // data
@@ -210,13 +209,13 @@ void Outputs(parthenon::Mesh *pm, const Real time) {
               const int ip = (m1 >= m2) ? i : j;
               const int is = (m1 >= m2) ? j : i;
               struct reb_particle *primary =
-                  reb_simulation_particle_by_hash(r_sim.get(), ip + 1);
+                  reb_simulation_particle_by_hash(r_sim, ip + 1);
               struct reb_particle *secondary =
-                  reb_simulation_particle_by_hash(r_sim.get(), is + 1);
+                  reb_simulation_particle_by_hash(r_sim, is + 1);
               struct reb_orbit o =
-                  reb_orbit_from_particle(r_sim.get()->G, *secondary, *primary);
+                  reb_orbit_from_particle(r_sim->G, *secondary, *primary);
 
-              std::fprintf(pfile, "%.8e\t", r_sim.get()->t);
+              std::fprintf(pfile, "%.8e\t", r_sim->t);
               std::fprintf(pfile, "%.8e\t", mb);
               std::fprintf(pfile, "%.8e\t", mu1 * primary->x + mu2 * secondary->x);
               std::fprintf(pfile, "%.8e\t", mu1 * primary->y + mu2 * secondary->y);

--- a/src/nbody/nbody_utils.hpp
+++ b/src/nbody/nbody_utils.hpp
@@ -42,8 +42,10 @@ class RebSim {
   RebSim() : reb_sim(reb_simulation_create(), reb_sim_deleter) {}
 
   // Constructor that accepts a preexisting pointer
-  RebSim(const RebSim &existing_reb_sim)
-      : reb_sim(reb_simulation_copy(existing_reb_sim), reb_sim_deleter) {}
+  // RebSim(const RebSim &existing_reb_sim)
+  //    : reb_sim(reb_simulation_copy(existing_reb_sim), reb_sim_deleter) {
+  //  printf("COPY CONSTRUCTOR!\n");
+  //}
 
   // Constructor that accepts a rebound filename
   RebSim(std::string reb_filename)
@@ -54,6 +56,10 @@ class RebSim {
   struct reb_simulation *get() const {
     PARTHENON_REQUIRE(reb_sim, "Internal pointer is null!");
     return reb_sim.get();
+  }
+
+  void copy(const RebSim &existing_reb_sim) {
+    reb_sim(reb_simulation_copy(existing_reb_sim), reb_sim_deleter);
   }
 
   // Conversion operator to return the raw pointer

--- a/src/nbody/nbody_utils.hpp
+++ b/src/nbody/nbody_utils.hpp
@@ -13,6 +13,8 @@
 #ifndef NBODY_NBODY_UTILS_HPP_
 #define NBODY_NBODY_UTILS_HPP_
 
+// This file was created in part by one of OpenAI's generative AI models
+
 // C++/C includes
 #include <cstdio>
 #include <fcntl.h>
@@ -36,20 +38,45 @@ extern int collision_resolution(struct reb_simulation *const r, struct reb_colli
 
 // Container for reb_simulation pointer that allows it to be stored in Params with
 // automatic cleanup
+// struct RebSim {
+//
+//  struct reb_simulation *&get() {
+//    return reb_sim;
+//  }
+//
+//  ~RebSim() {
+//    if (reb_sim != nullptr) {
+//      reb_simulation_free(reb_sim);
+//    }
+//  }
+//
+// private:
+//  struct reb_simulation *reb_sim = nullptr;
+//};
+
 struct RebSim {
+  // Shared pointer with a custom deleter
+  std::shared_ptr<struct reb_simulation> reb_sim;
 
-  struct reb_simulation *&get() {
-    return reb_sim;
+  // Constructor to initialize the shared_ptr with a custom deleter
+  RebSim()
+      : reb_sim(nullptr, [](struct reb_simulation *p) {
+          printf("Destructor!\n");
+          if (p != nullptr) {
+            reb_simulation_free(p);
+          }
+        }) {}
+
+  // Function to get a reference to the shared_ptr
+  struct reb_simulation *get() {
+    PARTHENON_REQUIRE(reb_sim, "Internal pointer is null!");
+    return reb_sim.get();
   }
 
-  ~RebSim() {
-    if (reb_sim != nullptr) {
-      reb_simulation_free(reb_sim);
-    }
+  void set(struct reb_simulation *ptr) {
+    PARTHENON_REQUIRE(ptr != nullptr, "Passing a null pointer!");
+    reb_sim.reset(ptr);
   }
-
- private:
-  struct reb_simulation *reb_sim = nullptr;
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/nbody/nbody_utils.hpp
+++ b/src/nbody/nbody_utils.hpp
@@ -38,8 +38,7 @@ extern int collision_resolution(struct reb_simulation *const r, struct reb_colli
 
 class RebSim {
  public:
-  // Constructor to initialize the shared_ptr with a custom deleter
-  // RebSim() : reb_sim(nullptr, reb_sim_deleter) {}
+  // Constructor to initialize the shared_ptr
   RebSim() : reb_sim(reb_simulation_create(), reb_sim_deleter) {}
 
   // Constructor that accepts a preexisting pointer
@@ -48,7 +47,8 @@ class RebSim {
 
   // Constructor that accepts a rebound filename
   RebSim(std::string reb_filename)
-      : reb_sim(reb_simulation_create_from_file(reb_filename.data(), -1)) {}
+      : reb_sim(reb_simulation_create_from_file(reb_filename.data(), -1),
+                reb_sim_deleter) {}
 
   // Function to get a reference to the shared_ptr
   struct reb_simulation *get() const {
@@ -56,10 +56,11 @@ class RebSim {
     return reb_sim.get();
   }
 
-  void set(struct reb_simulation *ptr) {
-    PARTHENON_REQUIRE(ptr != nullptr, "Passing a null pointer!");
-    reb_sim.reset(ptr);
-  }
+  // Conversion operator to return the raw pointer
+  operator struct reb_simulation *() const { return reb_sim.get(); }
+
+  // Overloaded -> operator
+  reb_simulation *operator->() const { return reb_sim.get(); }
 
  private:
   // Shared pointer which will use a custom deleter

--- a/src/nbody/nbody_utils.hpp
+++ b/src/nbody/nbody_utils.hpp
@@ -41,12 +41,6 @@ class RebSim {
   // Constructor to initialize the shared_ptr
   RebSim() : reb_sim(reb_simulation_create(), reb_sim_deleter) {}
 
-  // Constructor that accepts a preexisting pointer
-  // RebSim(const RebSim &existing_reb_sim)
-  //    : reb_sim(reb_simulation_copy(existing_reb_sim), reb_sim_deleter) {
-  //  printf("COPY CONSTRUCTOR!\n");
-  //}
-
   // Constructor that accepts a rebound filename
   RebSim(std::string reb_filename)
       : reb_sim(reb_simulation_create_from_file(reb_filename.data(), -1),
@@ -58,8 +52,9 @@ class RebSim {
     return reb_sim.get();
   }
 
+  // Copy an existing rebound simulation into the pointer owned by this struct
   void copy(const RebSim &existing_reb_sim) {
-    reb_sim(reb_simulation_copy(existing_reb_sim), reb_sim_deleter);
+    reb_sim.reset(reb_simulation_copy(existing_reb_sim), reb_sim_deleter);
   }
 
   // Conversion operator to return the raw pointer

--- a/src/nbody/nbody_utils.hpp
+++ b/src/nbody/nbody_utils.hpp
@@ -39,15 +39,8 @@ extern int collision_resolution(struct reb_simulation *const r, struct reb_colli
 class RebSim {
  public:
   // Constructor to initialize the shared_ptr with a custom deleter
-  RebSim()
-      : reb_sim(nullptr, reb_sim_deleter
-                /*[](struct reb_simulation *p) {
-                    printf("Destructor!\n");
-                    if (p != nullptr) {
-                      reb_simulation_free(p);
-                    }
-                  }*/
-        ) {}
+  // RebSim() : reb_sim(nullptr, reb_sim_deleter) {}
+  RebSim() : reb_sim(reb_simulation_create(), reb_sim_deleter) {}
 
   // Constructor that accepts a preexisting pointer
   RebSim(const RebSim &existing_reb_sim)
@@ -69,8 +62,9 @@ class RebSim {
   }
 
  private:
-  // Shared pointer with a custom deleter
+  // Shared pointer which will use a custom deleter
   std::shared_ptr<struct reb_simulation> reb_sim;
+
   // Shared custom deleter
   static void reb_sim_deleter(struct reb_simulation *p) {
     if (p != nullptr) {

--- a/src/nbody/nbody_utils.hpp
+++ b/src/nbody/nbody_utils.hpp
@@ -43,7 +43,7 @@ class RebSim {
 
   // Constructor that accepts a preexisting pointer
   RebSim(const RebSim &existing_reb_sim)
-      : reb_sim(reb_simulation_copy(existing_reb_sim.get()), reb_sim_deleter) {}
+      : reb_sim(reb_simulation_copy(existing_reb_sim), reb_sim_deleter) {}
 
   // Constructor that accepts a rebound filename
   RebSim(std::string reb_filename)
@@ -78,8 +78,8 @@ class RebSim {
 //! \fn  void NBody::SetReboundPtrs
 //! \brief
 static void SetReboundPtrs(RebSim &reb_sim) {
-  reb_sim.get()->collision_resolve = collision_resolution;
-  if (RebAttrs::extras) reb_sim.get()->additional_forces = reb_extra_forces;
+  reb_sim->collision_resolve = collision_resolution;
+  if (RebAttrs::extras) reb_sim->additional_forces = reb_extra_forces;
 }
 
 //----------------------------------------------------------------------------------------
@@ -124,7 +124,7 @@ static void SyncWithRebound(RebSim &r_sim, std::vector<int> particle_id,
   std::vector<int> alive(npart);
   if (parthenon::Globals::my_rank == 0) {
     for (int n = 0; n < npart; n++) {
-      struct reb_particle *p = reb_simulation_particle_by_hash(r_sim.get(), n + 1);
+      struct reb_particle *p = reb_simulation_particle_by_hash(r_sim, n + 1);
       if (p == nullptr) {
         alive[n] = 0;
       } else {


### PR DESCRIPTION
## Background

We have a "memory leak" currently because we aren't properly freeing the rebound simulation struct when the `Params` object holding it expires. 

This may also help with the issue of having this parameter hold a different value on different processors? Needs to be tested. 

## Description of Changes

- [x] Wrap `reb_sim` in a struct with a custom destructor
- [x] Test MPI param consistency issue.
- [x] Merge [Parthenon PR](https://github.com/parthenon-hpc-lab/parthenon/pull/1215) that fixes MPI parameter consistency issue (actually unrelated to this rebound free issue)

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files
