### PR TITLE
Permit pgen-defined custom source terms

### DIFF
--- a/src/artemis.hpp
+++ b/src/artemis.hpp
@@ -148,6 +148,8 @@ inline int ProblemDimension(parthenon::ParameterInput *pin) {
 
 namespace artemis {
 extern std::function<AmrTag(MeshBlockData<Real> *mbd)> ProblemCheckRefinementBlock;
+extern std::function<TaskStatus(MeshData<Real> *md, const Real time, const Real dt)>
+    ProblemGeneratorSourceTerm;
 } // namespace artemis
 
 #endif // ARTEMIS_ARTEMIS_HPP_

--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -234,10 +234,15 @@ TaskCollection ArtemisDriver<GEOM>::StepTasks() {
                                 time, bdt);
       }
 
+      // Apply pgen-defined source term
+      // NOTE(@pdmullen): Intentional positioning after S(W) srcs and before S(U) srcs
+      auto pgen_src =
+          tl.AddTask(rframe_src, ArtemisUtils::ProblemSourceTerm, u0.get(), time, bdt);
+
       // Apply drag source term
-      TaskID drag_src = rframe_src;
+      TaskID drag_src = pgen_src;
       if (do_drag) {
-        drag_src = tl.AddTask(rframe_src, Drag::DragSource<GEOM>, u0.get(), time, bdt);
+        drag_src = tl.AddTask(pgen_src, Drag::DragSource<GEOM>, u0.get(), time, bdt);
       }
 
       // Apply cooling source term

--- a/src/pgen/disk.hpp
+++ b/src/pgen/disk.hpp
@@ -815,10 +815,20 @@ void DiskBoundaryExtrap(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) 
 }
 
 //----------------------------------------------------------------------------------------
+//! \fn TaskStatus ProblemGeneratorSourceTerm()
+//! \brief Custom source term for disk pgen
+template <Coordinates GEOM>
+TaskStatus ProblemGeneratorSourceTerm(MeshData<Real> *md, const Real time,
+                                      const Real dt) {
+  PARTHENON_FAIL("Disk pgen-defined source term not yet implemented!");
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn AmrTag ProblemCheckRefinementBlock()
 //! \brief Refinement criterion for disk pgen
 inline parthenon::AmrTag ProblemCheckRefinementBlock(MeshBlockData<Real> *mbd) {
-  PARTHENON_FAIL("Disk user-defined AMR criterion not yet implemented!");
+  PARTHENON_FAIL("Disk pgen-defined AMR criterion not yet implemented!");
   return AmrTag::same;
 }
 

--- a/src/pgen/problem_modifier.hpp
+++ b/src/pgen/problem_modifier.hpp
@@ -28,9 +28,9 @@
 
 // User-defined refinement criterion callback
 namespace artemis {
-
 std::function<AmrTag(MeshBlockData<Real> *mbd)> ProblemCheckRefinementBlock = nullptr;
-
+std::function<TaskStatus(MeshData<Real> *md, const Real time, const Real dt)>
+    ProblemGeneratorSourceTerm = nullptr;
 } // namespace artemis
 
 // Problem modifiers
@@ -66,6 +66,8 @@ void ProblemModifier(parthenon::ParthenonManager *pman) {
                                                cond::CondBoundary<G, ID::outer_x3>);
   } else if (artemis_problem == "disk") {
     pman->app_input->InitMeshBlockUserData = disk::InitDiskParams;
+
+    // artemis::ProblemGeneratorSourceTerm = disk::ProblemGeneratorSourceTerm<G>;
 
     artemis::ProblemCheckRefinementBlock = disk::ProblemCheckRefinementBlock;
 

--- a/src/utils/artemis_utils.hpp
+++ b/src/utils/artemis_utils.hpp
@@ -34,6 +34,16 @@ KOKKOS_FORCEINLINE_FUNCTION Real VDot(const V1 &a, const V2 &b) {
 }
 
 //----------------------------------------------------------------------------------------
+//! \fn int ArtemisUtils::ProblemSourceTerm
+//! \brief Wrapper function for user-defined source term, checking for nullptr
+static TaskStatus ProblemSourceTerm(MeshData<Real> *md, const Real time, const Real dt) {
+  if (artemis::ProblemGeneratorSourceTerm != nullptr) {
+    return artemis::ProblemGeneratorSourceTerm(md, time, dt);
+  }
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn Real ArtemisUtils::GetSpecificInternalEnergy(vmesh, const int b, const int n,
 //!              const int k, const int j, const int i, const Real de_switch,
 //!              const Real dflr, const Real sieflr, const Real hx[3])


### PR DESCRIPTION
## Background
Permits custom pgen-defined source terms.  

## Description of Changes
Adds logic to enroll a custom pgen source term.  The task is called independent of enrollment, but checks for `nullptr`.

## Checklist
- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
