### PR TITLE
Fix formatting bash/venv environments

### DIFF
--- a/env/bash
+++ b/env/bash
@@ -34,14 +34,12 @@ elif [[ "$HOST" =~ ^ve-rfe[1-7]$ || "$HOST" =~ ^ve-fe[1-7]$ ]]; then
         PARTITION="venado-gg"
     fi
 else # Catch-all for Darwin
-    if [ -z "$SLURM_JOB_PARTITION" ]; then
-        if [[ $HOSTNAME == darwin-fe* ]]; then
-            echo "Do not compile on Darwin frontend nodes; use a specific partition!"
-            echo "Supported partitions are"
-            echo "  skylake-gold"
-            echo "  volta-x86"
-            echo "...setup FAILED"
-        fi
+    if [[ $HOSTNAME == darwin-fe* ]]; then
+        echo "Currently on darwin frontend node; formatting is supported but not compilation"
+        echo "Supported partitions are"
+        echo "  skylake-gold"
+        echo "  volta-x86"
+        PARTITION="darwin-fe"
     elif [[ $SLURM_JOB_PARTITION == "power9-rhel7" ]]; then
         PARTITION="darwin-power9-rhel7"
     elif [[ $SLURM_JOB_PARTITION == "skylake-gold" ]]; then
@@ -84,6 +82,10 @@ elif [[ $PARTITION == "chicoma-cpu" ]]; then
     module load cmake
     export ARTEMIS_SUITE=chicoma-cpu
     echo "...setup SUCCEEDED"
+elif [[ $PARTITION == "darwin-fe" ]]; then
+    module load clang/12.0.1
+    module load miniconda3/py311_23.11.0
+    source /usr/projects/jovian/dependencies/python/darwin-fe/bin/activate
 elif [[ $PARTITION == "darwin-power9-rhel7" ]]; then
     echo "darwin-power9-rhel7 partition has been decommissioned! Exiting..."
 elif [[ $PARTITION == "darwin-skylake-gold" ]]; then
@@ -209,6 +211,11 @@ function build_artemis {
                 ;;
         esac
     done
+
+    if [[ $PARTITION == "darwin-fe" ]]; then
+        echo "Building not supported on darwin frontend nodes!"
+        return 1
+    fi
 
     if [[ "$BUILD_DIR" == /* ]]; then
         # Use absolute path


### PR DESCRIPTION
## Background

`./style/format.sh` is failing on some platforms due to not finding either `clang-format` or `black`. This PR itself really just adds a darwin frontend environment to simplify formatting, basically, when working on darwin without needing to get a backend allocation, but complementary to this I've updated the environments on darwin, chicoma, and venado. 

## Description of Changes

- [x] add `darwin-fe` partition
- [x] add `black` to `skylake-gold`
- [x] add `black` to `volta-x86`
- [x] add virtual python environment to `chicoma-cpu` (also used by chicoma frontend)
- [x] install `clang-format/12` to `chicoma-cpu` environment
- [x] install `clang-format/12` and `black to `chicoma-gpu` environment
- [x] `rfe` `venado-cpu`
- [x] `rfe` `venado-gpu`
- [x] `fe` `venado-cpu`
- [x] `fe` `venado-gpu`
- [x] Updated groups/permissions for all python environments

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files
