### PR TITLE
Fix units copy constructor issue

### DIFF
--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -396,6 +396,12 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
   auto &params = gas_pkg->AllParams();
   auto eos_d = params.template Get<EOS>("eos_d");
 
+  // Test
+  auto &apkg = pm->packages.Get("artemis");
+  auto &units = apkg->AllParams().template Get<ArtemisUtils::Units>("units");
+  printf("l: %e\n", units.GetLengthCodeToPhysical());
+  exit(-1);
+
   static auto desc =
       MakePackDescriptor<gas::prim::density, gas::prim::velocity, gas::prim::sie>(
           resolved_pkgs.get());

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -396,12 +396,6 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
   auto &params = gas_pkg->AllParams();
   auto eos_d = params.template Get<EOS>("eos_d");
 
-  // Test
-  auto &apkg = pm->packages.Get("artemis");
-  auto &units = apkg->AllParams().template Get<ArtemisUtils::Units>("units");
-  printf("l: %e\n", units.GetLengthCodeToPhysical());
-  exit(-1);
-
   static auto desc =
       MakePackDescriptor<gas::prim::density, gas::prim::velocity, gas::prim::sie>(
           resolved_pkgs.get());

--- a/src/utils/units.hpp
+++ b/src/utils/units.hpp
@@ -109,7 +109,7 @@ class Constants {
   Constants(Units &units);
 
   KOKKOS_FUNCTION
-  Constants(const Constants &other) {}
+  Constants(const Constants &other) = default;
 
   KOKKOS_INLINE_FUNCTION
   Real GetGPhysical() const { return G_; }

--- a/src/utils/units.hpp
+++ b/src/utils/units.hpp
@@ -30,7 +30,7 @@ class Units {
 
   // Copy constructor must be marked with KOKKOS_FUNCTION
   KOKKOS_FUNCTION
-  Units(const Units &other) {}
+  Units(const Units &other) = default;
 
   // Return physical unit system
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
## Background

@shengtai noticed a bug when retrieving `Units` objects from `Params`

## Description of Changes

I mistakenly conflated `{}` with `= default` when decorating the `Units` and `Constants` copy constructors with `KOKKOS_FUNCTION`. This PR fixes that and I tested that `Units` has correctly initialized memory now when retrieved from `Params`.

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files
