### PR TITLE
Updates for GM and nbody particles

### DIFF
--- a/doc/src/physics.rst
+++ b/doc/src/physics.rst
@@ -673,10 +673,7 @@ Specifically, |code|, adds the body force,
 .. math::
    \rho \frac{D \mathbf{v}}{D t} = \rho \mathbf{g}
 
-To activate external gravity, there must be a ``<gravity>`` node and ``gravity = true`` under the ``<physics>`` node.
-The ``<gravity>`` requires setting the parameter ``gm``, typically this is set to ``gm = 1.0``.
-In addition to ``gm``, the ``tstart`` and ``tstop`` parameters control when gravity is active.
-
+To activate external gravity, there must be a subnode of ``<gravity>`` (e.g., ``<gravity/point>``) and ``gravity = true`` under the ``<physics>`` node.
 The specific model for the gravitational acceleration, :math:`\mathbf{g}`, is controlled by adding the appropriate subnode.
 Available options are:
 
@@ -687,8 +684,6 @@ Available options are:
 
   ::
 
-   <gravity>
-   gm = 1.0
    <gravity/constant>
    gx1 = 0.0
    gx2 = 0.0
@@ -703,9 +698,8 @@ Available options are:
 
   ::
 
-   <gravity>
-   gm = 1.0
    <gravity/point>
+   mass = 1.0
    x = 0.0
    y = 0.0
    z = 0.0
@@ -721,9 +715,8 @@ Available options are:
 
   ::
 
-   <gravity>
-   gm = 1.0            # Binary total GM
    <gravity/binary>
+   mass = 1.0          # Total binary mass
    x = 0.0             # Binary x center of mass
    y = 0.0             # Binary y center of mass
    z = 0.0             # Binary z center of mass
@@ -745,14 +738,11 @@ Available options are:
 * ``<gravity/nbody>``
 
   This indicates that the gravitational force will be calculated by the N-body system defined in the ``<nbody>`` input block.
-  The only parameter required is the ``gm`` parameter.
-  Note that the total mass of the system defined in the ``<nbody>`` block will be rescaled to ``gm``.
-  An example input block would thus read:
+  Unlike the other gravity nodes, ``<gravity/nbody>`` has no parameters. Instead, all parameters live under the ``<nbody>`` node.
+  To activate nbody gravity, simply add:
 
   ::
 
-   <gravity>
-   gm = 1.0
    <gravity/nbody>
 
 See `N-Body Dynamics`_ for a description of how to set up the N-body system.

--- a/inputs/diffusion/alpha_disk.in
+++ b/inputs/diffusion/alpha_disk.in
@@ -83,9 +83,8 @@ beta0 = 0.0
 tcyl = .0025
 cyl_plaw = -1.0
 
-<gravity>
-mass_tot = 1.0
 <gravity/point>
+mass = 1.0
 
 <problem>
 r0 = 1.0

--- a/inputs/disk/binary_cyl.in
+++ b/inputs/disk/binary_cyl.in
@@ -86,9 +86,8 @@ omega = 1.0
 type = alpha
 alpha = 1e-3
 
-<gravity>
-mass_tot = 1.0
 <gravity/binary>
+mass = 1.0
 q = 1.0e-5
 a = 1.0
 e = 0.0

--- a/inputs/disk/binary_nbody_cyl.in
+++ b/inputs/disk/binary_nbody_cyl.in
@@ -92,9 +92,8 @@ omega = 1.0
 type = alpha
 alpha = 1e-3
 
-<gravity>
-mass_tot = 1.0
 <gravity/nbody>
+mtot = 1.0
 
 <nbody>
 dt_reb = 0.01

--- a/inputs/disk/cb_disk.in
+++ b/inputs/disk/cb_disk.in
@@ -81,9 +81,8 @@ siefloor = 1.0e-6
 type = constant
 nu = 1e-3
 
-<gravity>
-mass_tot = 1.0
 <gravity/nbody>
+mtot = 1.0
 
 <nbody>
 integrator = ias15

--- a/inputs/disk/disk_alpha.in
+++ b/inputs/disk/disk_alpha.in
@@ -74,9 +74,8 @@ siefloor = 1.0e-10
 type = alpha
 alpha = 1e-2
 
-<gravity>
-mass_tot = 1.0
 <gravity/point>
+mass = 1.0
 
 <cooling>
 type = beta

--- a/inputs/disk/disk_axi.in
+++ b/inputs/disk/disk_axi.in
@@ -80,9 +80,8 @@ omega = 1.0
 type = alpha
 alpha = 1e-3
 
-<gravity>
-mass_tot = 1.0
 <gravity/point>
+mass = 1.0
 
 <problem>
 r0 = 1.0

--- a/inputs/disk/disk_cart.in
+++ b/inputs/disk/disk_cart.in
@@ -110,9 +110,8 @@ riemann = hlle
 dfloor = 1.0e-10
 pfloor = 1.0e-15
 
-<gravity>
-mass_tot = 1.0
 <gravity/point>
+mass = 1.0
 
 <problem>
 r0 = 1.0

--- a/inputs/disk/disk_collision.in
+++ b/inputs/disk/disk_collision.in
@@ -79,9 +79,8 @@ riemann = hllc
 dfloor = 1.0e-10
 siefloor = 1.0e-10
 
-<gravity>
-mass_tot = 1.0
 <gravity/nbody>
+mtot = 1.0
 
 <gas/damping>
 inner_x1 = 0.45

--- a/inputs/disk/disk_cyl.in
+++ b/inputs/disk/disk_cyl.in
@@ -81,9 +81,8 @@ omega = 1.0
 type = alpha
 alpha = 1e-3
 
-<gravity>
-mass_tot = 1.0
 <gravity/point>
+mass = 1.0
 
 <problem>
 r0 = 1.0

--- a/inputs/disk/disk_nbody_cyl.in
+++ b/inputs/disk/disk_nbody_cyl.in
@@ -78,8 +78,6 @@ siefloor = 1.0e-10
 type = alpha
 alpha = 1e-3
 
-<gravity>
-mass_tot = 1.0
 <gravity/nbody>
 
 <nbody>

--- a/inputs/disk/disk_sph.in
+++ b/inputs/disk/disk_sph.in
@@ -80,9 +80,8 @@ omega = 1.0
 type = alpha
 alpha = 1e-3
 
-<gravity>
-mass_tot = 1.0
 <gravity/point>
+mtot = 1.0
 
 <problem>
 r0 = 1.0

--- a/inputs/disk/disk_sph.in
+++ b/inputs/disk/disk_sph.in
@@ -81,7 +81,7 @@ type = alpha
 alpha = 1e-3
 
 <gravity/point>
-mtot = 1.0
+mass = 1.0
 
 <problem>
 r0 = 1.0

--- a/inputs/ssheet/ssheet.in
+++ b/inputs/ssheet/ssheet.in
@@ -76,9 +76,8 @@ refine_type = magnitude
 refine_thr = 3.0
 deref_thr = 0.8
 
-<gravity>
-mass_tot = 1.0e-5
 <gravity/point>
+mass = 1.0e-5
 soft = 0.03
 x = 0.0
 y = 0.0

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -100,11 +100,11 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   // Call package initializers here
   if (do_gas) packages.Add(Gas::Initialize(pin.get(), units, constants));
   if (do_dust) packages.Add(Dust::Initialize(pin.get()));
-  if (do_gravity) packages.Add(Gravity::Initialize(pin.get(), constants));
+  if (do_nbody) packages.Add(NBody::Initialize(pin.get(), constants));
+  if (do_gravity) packages.Add(Gravity::Initialize(pin.get(), constants, packages));
   if (do_rotating_frame) packages.Add(RotatingFrame::Initialize(pin.get()));
   if (do_cooling) packages.Add(Gas::Cooling::Initialize(pin.get()));
   if (do_drag) packages.Add(Drag::Initialize(pin.get()));
-  if (do_nbody) packages.Add(NBody::Initialize(pin.get(), constants));
   if (do_radiation) {
     auto eos_h = packages.Get("gas")->Param<EOS>("eos_h");
     auto opacity_h = packages.Get("gas")->Param<Opacity>("opacity_h");

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -98,10 +98,10 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   artemis->AddParam("coord_sys", sys);
 
   // Call package initializers here
-  if (do_gas) packages.Add(Gas::Initialize(pin.get(), units, constants));
-  if (do_dust) packages.Add(Dust::Initialize(pin.get()));
   if (do_nbody) packages.Add(NBody::Initialize(pin.get(), constants));
   if (do_gravity) packages.Add(Gravity::Initialize(pin.get(), constants, packages));
+  if (do_gas) packages.Add(Gas::Initialize(pin.get(), units, constants, packages));
+  if (do_dust) packages.Add(Dust::Initialize(pin.get()));
   if (do_rotating_frame) packages.Add(RotatingFrame::Initialize(pin.get()));
   if (do_cooling) packages.Add(Gas::Cooling::Initialize(pin.get()));
   if (do_drag) packages.Add(Drag::Initialize(pin.get()));

--- a/src/artemis_params.yaml
+++ b/src/artemis_params.yaml
@@ -23,13 +23,11 @@ artemis:
     _type: bool
     _default: "false"
     _description: "Add user-defined AMR criterion."
-  units:
-    _description: "Unit conversions between code and cgs."
   physical_units:
     _type: "string"
     _default: "scalefree"
     _description: "What unit system to use for physical units"
-    code:
+    scalefree:
       _type: opt
       _description: "Native code units; no conversions"
     cgs:
@@ -47,12 +45,15 @@ artemis:
       _description: "AU, Year/(2 pi), solar mass units for protoplanetary disks"
   length:
     _type: "Real"
+    _default: "1.0"
     _description: "Physical units value of length equal to 1 code unit"
   time:
     _type: "Real"
+    _default: "1.0"
     _description: "Physical units value of time equal to 1 code unit"
   mass:
     _type: "Real"
+    _default: "1.0"
     _description: "Physical units value of mass equal to 1 code unit"
 
 

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -39,7 +39,8 @@ namespace Gas {
 //! \brief Adds intialization function for gas hydrodynamics package
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                                             ArtemisUtils::Units &units,
-                                            ArtemisUtils::Constants &constants) {
+                                            ArtemisUtils::Constants &constants,
+                                            Packages_t &packages) {
   using namespace singularity::photons;
 
   auto gas = std::make_shared<StateDescriptor>("gas");
@@ -186,11 +187,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   params.Add("do_diffusion", do_diffusion);
 
   if (do_viscosity) {
-    Diffusion::DiffCoeffParams dp("gas/viscosity", "viscosity", pin, constants);
+    Diffusion::DiffCoeffParams dp("gas/viscosity", "viscosity", pin, constants, packages);
     params.Add("visc_params", dp);
   }
   if (do_conduction) {
-    Diffusion::DiffCoeffParams dp("gas/conductivity", "conductivity", pin, constants);
+    Diffusion::DiffCoeffParams dp("gas/conductivity", "conductivity", pin, constants,
+                                  packages);
     params.Add("cond_params", dp);
   }
 

--- a/src/gas/gas.hpp
+++ b/src/gas/gas.hpp
@@ -20,7 +20,8 @@ namespace Gas {
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                                             ArtemisUtils::Units &units,
-                                            ArtemisUtils::Constants &constants);
+                                            ArtemisUtils::Constants &constants,
+                                            Packages_t &packages);
 
 template <Coordinates GEOM>
 Real EstimateTimestepMesh(MeshData<Real> *md);

--- a/src/gravity/gravity.hpp
+++ b/src/gravity/gravity.hpp
@@ -94,7 +94,8 @@ struct Orbit {
 };
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
-                                            const ArtemisUtils::Constants &constants);
+                                            const ArtemisUtils::Constants &constants,
+                                            const Packages_t &packages);
 
 template <Coordinates GEOM>
 TaskStatus UniformGravity(MeshData<Real> *md, const Real time, const Real dt);

--- a/src/gravity/params.yaml
+++ b/src/gravity/params.yaml
@@ -1,11 +1,6 @@
 ---
 gravity:
   _description: "External gravitational sources"
-  mass_tot:
-    _type: Real
-    _description: "Normalization parameter setting GM."
-    _default: "NaN"
-    _units: "Msolar"
   tstart:
     _type: Real
     _description: "When to turn gravity on."
@@ -28,6 +23,10 @@ gravity:
   point:
     _type: node
     _description: "Point mass gravity."
+    mass:
+      _type: Real
+      _description: "Mass of the body"
+      _units: "g"
     soft:
       _type: Real
       _description: "Plummer softening radius of the body"
@@ -62,6 +61,10 @@ gravity:
   binary:
     _type: node
     _description: "Binary mass gravity."
+    mass:
+      _type: Real
+      _description: "Total mass of the binary"
+      _units: "g"
     soft(1,2):
       _type: Real
       _description: "Plummer softening radius of the primary/secondary"

--- a/src/nbody/nbody.hpp
+++ b/src/nbody/nbody.hpp
@@ -41,8 +41,7 @@ struct Orbit {
   Real f;
 };
 
-void NBodySetup(ParameterInput *pin, const Real GM, const Real Rf[3], const Real Vf[3],
-                std::vector<int> &particle_id, std::vector<Particle> &particles);
+std::map<int, ParticleParams> NBodySetup(ParameterInput *pin, const Real G, Real &mresc);
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                                             const ArtemisUtils::Constants &constants);

--- a/src/nbody/nbody_setup.cpp
+++ b/src/nbody/nbody_setup.cpp
@@ -647,8 +647,7 @@ int ReadPlanetarySystemBlock(ParameterInput *pin, parthenon::InputBlock *pib,
 //!
 //! You can setup a binary either with two particle blocks + a binary block
 //! or you can specify just a binary block
-void NBodySetup(ParameterInput *pin, const Real GM, const Real Rf[3], const Real Vf[3],
-                std::vector<int> &particle_id, std::vector<Particle> &particles) {
+std::map<int, ParticleParams> NBodySetup(ParameterInput *pin, const Real G, Real &mresc) {
   int npart = 0;
   parthenon::InputBlock *pib = pin->pfirst_block;
   std::map<int, ParticleParams> parts;
@@ -701,8 +700,11 @@ void NBodySetup(ParameterInput *pin, const Real GM, const Real Rf[3], const Real
     V[1] += p.m * p.vy;
     V[2] += p.m * p.vz;
   }
+  if (mresc == -Big<Real>()) {
+    mresc = mtot;
+  }
   for (auto &[id, p] : parts) {
-    parts[id].m = p.m * GM / mtot;
+    parts[id].m = p.m * mresc / mtot;
     parts[id].x = p.x - R[0];
     parts[id].y = p.y - R[1];
     parts[id].z = p.z - R[2];
@@ -710,20 +712,14 @@ void NBodySetup(ParameterInput *pin, const Real GM, const Real Rf[3], const Real
     parts[id].vy = p.vy - V[1];
     parts[id].vz = p.vz - V[2];
   }
-  if (parthenon::Globals::my_rank == 0) {
-    std::cout << npart << " Initial Particles: " << std::endl;
-    for (auto const &[id, p] : parts) {
-      PrintParticle(id, p);
-    }
-  }
+  // if (parthenon::Globals::my_rank == 0) {
+  //  std::cout << npart << " Initial Particles: " << std::endl;
+  //  for (auto const &[id, p] : parts) {
+  //    PrintParticle(id, p);
+  //  }
+  //}
 
-  // Copy into our final particle array and check that every particle was initialized
-  int count = 0;
-  for (auto const &[id, p] : parts) {
-    particle_id.push_back(count);
-    particles.push_back(Particle(p, GM, Rf, Vf));
-    count++;
-  }
+  return parts;
 }
 
 } // namespace NBody

--- a/src/nbody/params.yaml
+++ b/src/nbody/params.yaml
@@ -15,6 +15,11 @@ nbody:
     whfast:
       _type: opt
       _description: "A fast, symplectic Wisdom-Holman integrator."
+  mtot:
+    _type: Real
+    _default: "-&infin;"
+    _description: "When set, all particles are rescaled so that the total mass is this value."
+    _units: "g"
   mscale:
     _type: Real
     _default: "1.0"

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -34,6 +34,9 @@ KOKKOS_INLINE_FUNCTION std::array<Real, 3> RotationVelocity(const std::array<Rea
   // Return the rotational velocity
 
   // Empty constructor to get access to conversion routine
+  if constexpr (GEOM == Coordinates::cartesian) {
+    return {0.0, omf, 0.0}; // multiply by R0
+  }
   geometry::Coords<GEOM> coords;
 
   const auto &[xcyl, ex1, ex2, ex3] = coords.ConvertToCylWithVec(xv);

--- a/src/utils/artemis_utils.cpp
+++ b/src/utils/artemis_utils.cpp
@@ -13,6 +13,7 @@
 
 // C++ headers
 #include "artemis_utils.hpp"
+#include "nbody/nbody_utils.hpp"
 
 namespace ArtemisUtils {
 
@@ -37,7 +38,7 @@ void PrintArtemisConfiguration(Packages_t &packages) {
     if (params.Get<bool>("do_drag")) msg += hfill + "Drag\n";
     if (params.Get<bool>("do_nbody")) msg += hfill + "N-body\n";
     if (params.Get<bool>("do_radiation")) msg += hfill + "IMC radiation\n";
-    printf("\n=====================================================\n");
+    printf("\n=======================================================\n");
     printf("  ARTEMIS\n");
     printf("    name:            %s\n", params.Get<std::string>("job_name").c_str());
     printf("    problem:         %s\n", params.Get<std::string>("pgen_name").c_str());
@@ -47,7 +48,35 @@ void PrintArtemisConfiguration(Packages_t &packages) {
     printf("    dimensions:      %dx%dx%d\n", nx[0], nx[1], nx[2]);
     printf("    meshblock:       %dx%dx%d\n", nb[0], nb[1], nb[2]);
     printf("    Active physics:  %s", msg.c_str());
-    printf("=====================================================\n\n");
+
+    if (params.Get<bool>("do_nbody")) {
+
+      auto nbody_pkg = packages.Get("nbody");
+      auto particles = nbody_pkg->Param<ParArray1D<NBody::Particle>>("particles");
+      auto particles_h = particles.GetHostMirrorAndCopy();
+      auto npart = particles_h.size();
+      printf("      %d NBody particle(s)\n", npart);
+      printf("      |_\n");
+      for (int n = 0; n < npart; n++) {
+        auto &part = particles_h(n);
+        printf("        Particle      %2d:\n", part.id);
+        printf("        |            mass: %.2e\n", part.GM);
+        printf("        |         coupled: %s\n", part.couple == 1 ? "yes" : "no");
+        printf("        |            live: %s\n", part.live == 1 ? "yes" : "no");
+        printf("        |       softening: %s\n",
+               part.spline == 1 ? "spline" : "plummer");
+        printf("        |          radius: %.2e\n", part.rs);
+        printf("        | accretion rates: gamma=%.2e\n", part.gamma);
+        printf("        |                   beta=%.2e\n", part.beta);
+        printf("        |          radius: %.2e\n", part.racc);
+        printf("        |        position: (%.2e,%.2e,%.2e)\n", part.pos[0], part.pos[1],
+               part.pos[2]);
+        printf("        |        velocity: (%.2e,%.2e,%.2e)\n", part.vel[0], part.vel[1],
+               part.vel[2]);
+        printf("        -----------------------------------------------\n");
+      }
+    }
+    printf("=======================================================\n\n");
   }
 }
 

--- a/src/utils/artemis_utils.cpp
+++ b/src/utils/artemis_utils.cpp
@@ -13,8 +13,8 @@
 
 // C++ headers
 #include "artemis_utils.hpp"
-#include "units.hpp"
 #include "nbody/nbody_utils.hpp"
+#include "units.hpp"
 
 namespace ArtemisUtils {
 

--- a/src/utils/artemis_utils.cpp
+++ b/src/utils/artemis_utils.cpp
@@ -13,6 +13,7 @@
 
 // C++ headers
 #include "artemis_utils.hpp"
+#include "units.hpp"
 #include "nbody/nbody_utils.hpp"
 
 namespace ArtemisUtils {
@@ -27,6 +28,7 @@ void PrintArtemisConfiguration(Packages_t &packages) {
     const auto nx = params.Get<std::array<int, 3>>("prob_dim");
     const int nd = (nx[0] > 1) + (nx[1] > 1) + (nx[2] > 1);
     const auto nb = params.Get<std::array<int, 3>>("mb_dim");
+    const auto units = params.Get<Units>("units");
     std::string msg = "";
     if (params.Get<bool>("do_gas")) msg += "Gas\n";
     if (params.Get<bool>("do_dust")) msg += hfill + "Dust\n";
@@ -47,6 +49,10 @@ void PrintArtemisConfiguration(Packages_t &packages) {
     printf("    MPI ranks:       %d\n", parthenon::Globals::nranks);
     printf("    dimensions:      %dx%dx%d\n", nx[0], nx[1], nx[2]);
     printf("    meshblock:       %dx%dx%d\n", nb[0], nb[1], nb[2]);
+    printf("    Unit System:  %s\n", units.GetSystemName().c_str());
+    printf("                  [L] = %.2e\n", units.GetLengthCodeToPhysical());
+    printf("                  [M] = %.2e\n", units.GetMassCodeToPhysical());
+    printf("                  [T] = %.2e\n", units.GetTimeCodeToPhysical());
     printf("    Active physics:  %s", msg.c_str());
 
     if (params.Get<bool>("do_nbody")) {

--- a/src/utils/diffusion/diffusion_coeff.hpp
+++ b/src/utils/diffusion/diffusion_coeff.hpp
@@ -86,7 +86,7 @@ struct DiffCoeffParams {
   DiffCoeffParams() = default;
   DiffCoeffParams(std::string block_name, std::string dtype,
                   parthenon::ParameterInput *pin,
-                  const ArtemisUtils::Constants &constants) {
+                  const ArtemisUtils::Constants &constants, const Packages_t &packages) {
     // Read the parameter file
     std::string type_ = pin->GetString(block_name, "type");
     type = ChooseDiffusion(dtype, type_);
@@ -111,8 +111,7 @@ struct DiffCoeffParams {
       eta = pin->GetOrAddReal(block_name, "eta_bulk", 0.0);
 
       R0 = pin->GetOrAddReal("problem", "r0", 1.0);
-      const Real gm = constants.GetGCode() * pin->GetReal("gravity", "mass_tot") *
-                      constants.GetMsolarCode();
+      const Real gm = packages.Get("gravity")->Param<Real>("gm");
       Omega0 = std::sqrt(gm / (R0 * R0 * R0));
     } else if (type == DiffType::thermaldiff_const) {
       kappa_0 = pin->GetReal(block_name, "kappa");

--- a/src/utils/units.cpp
+++ b/src/utils/units.cpp
@@ -41,9 +41,9 @@ Units::Units(ParameterInput *pin, std::shared_ptr<StateDescriptor> pkg) {
     std::string unit_conversion =
         pin->GetOrAddString("artemis", "unit_conversion", "base");
     if (unit_conversion == "base") {
-      length_ = pin->GetReal("artemis", "length");
-      time_ = pin->GetReal("artemis", "time");
-      mass_ = pin->GetReal("artemis", "mass");
+      length_ = pin->GetOrAddReal("artemis", "length", 1.);
+      time_ = pin->GetOrAddReal("artemis", "time", 1.);
+      mass_ = pin->GetOrAddReal("artemis", "mass", 1.);
     } else if (unit_conversion == "ppd") {
       length_ = AU;
       mass_ = Msolar;

--- a/src/utils/units.hpp
+++ b/src/utils/units.hpp
@@ -87,9 +87,9 @@ class Units {
   KOKKOS_INLINE_FUNCTION
   Real GetSpecificHeatPhysicalToCode() const { return mass_ / energy_; }
 
- inline std::string GetSystemName() const {
-   return (physical_units_ == PhysicalUnits::scalefree) ? "Scale free" : "CGS";
- }
+  inline std::string GetSystemName() const {
+    return (physical_units_ == PhysicalUnits::scalefree) ? "Scale free" : "CGS";
+  }
 
  private:
   // Unit conversion factors from code to physical units

--- a/src/utils/units.hpp
+++ b/src/utils/units.hpp
@@ -87,6 +87,10 @@ class Units {
   KOKKOS_INLINE_FUNCTION
   Real GetSpecificHeatPhysicalToCode() const { return mass_ / energy_; }
 
+ inline std::string GetSystemName() const {
+   return (physical_units_ == PhysicalUnits::scalefree) ? "Scale free" : "CGS";
+ }
+
  private:
   // Unit conversion factors from code to physical units
   // e.g. length_ has units of cm when using CGS as physical unit system


### PR DESCRIPTION
## Background

This does a few things:

- Does away with `mass_tot` in `<gravity>` and effectively makes the base `<gravity>` node optional. 

  `<gravity/point>` and `<gravity/binary>` have `mass` parameters that set their mass now.
  `<nbody>` now has an optional parameter that will rescale the entire system to the desired mass. 

  Because `<nbody>` can set `GM` now, the gravity package is initialized after nbody and takes the `Packages_t package` in its `Initialize` function so it can pull out nbody's `GM`. 

  I've also moved the printing of initial particle properties to the big artemis splash screen. Previously it was before this and looked weird. 

- Some fixes for how the shearing box interacts with "local" nbody systems (e.g., a single point mass at the center of the box). 

- Removes the atomic adds in nbody gravity. Those were left over from when the outer loop over particles was a `par_for`. 

- Fixes an issue with CGS units where you would have to specify the length, time, and mass factors explicitly. But I should be able to just say `physicsl_units = cgs` and that should mean real cgs and the conversion factors all default to 1. 

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
