### PR TITLE
Powerlaw diffusion coefficients

### DIFF
--- a/inputs/diffusion/conduction.in
+++ b/inputs/diffusion/conduction.in
@@ -71,7 +71,7 @@ dfloor = 1.0e-10
 siefloor = 1.0e-15
 
 <gas/conductivity>
-type = constant 
+type = conductivity 
 cond = 1.0e-1
 
 <gravity/uniform>

--- a/inputs/diffusion/gaussian_bump.in
+++ b/inputs/diffusion/gaussian_bump.in
@@ -80,7 +80,7 @@ type = constant
 nu = 5.0e-3
 
 <gas/conductivity>
-type = constant
+type = conductivity 
 cond = 5.0e-3
 
 <problem>

--- a/src/drag/drag.cpp
+++ b/src/drag/drag.cpp
@@ -110,8 +110,8 @@ TaskStatus DragSource(MeshData<Real> *md, const Real time, const Real dt) {
       auto &gas_pkg = pm->packages.Get("gas");
       const auto &dp = gas_pkg->template Param<Diffusion::DiffCoeffParams>("visc_params");
       const auto &eos_d = gas_pkg->template Param<EOS>("eos_d");
-      if (dp.type == Diffusion::DiffType::viscosity_const) {
-        return SelfDragSourceImpl<Diffusion::DiffType::viscosity_const, GEOM>(
+      if (dp.type == Diffusion::DiffType::viscosity_plaw) {
+        return SelfDragSourceImpl<Diffusion::DiffType::viscosity_plaw, GEOM>(
             md, time, dt, dp, eos_d, gas_self_par, dust_self_par);
       } else if (dp.type == Diffusion::DiffType::viscosity_alpha) {
         return SelfDragSourceImpl<Diffusion::DiffType::viscosity_alpha, GEOM>(
@@ -134,13 +134,13 @@ TaskStatus DragSource(MeshData<Real> *md, const Real time, const Real dt) {
         drag_pkg->template Param<StoppingTimeParams>("stopping_time_params");
     if (gas_self_par.damp_to_visc) {
       auto &dp = gas_pkg->template Param<Diffusion::DiffCoeffParams>("visc_params");
-      if (dp.type == Diffusion::DiffType::viscosity_const) {
+      if (dp.type == Diffusion::DiffType::viscosity_plaw) {
         if (stop_par.model == DragModel::constant) {
-          return SimpleDragSourceImpl<Diffusion::DiffType::viscosity_const,
+          return SimpleDragSourceImpl<Diffusion::DiffType::viscosity_plaw,
                                       DragModel::constant, GEOM>(
               md, time, dt, dp, eos_d, gas_self_par, dust_self_par, stop_par);
         } else if (stop_par.model == DragModel::stokes) {
-          return SimpleDragSourceImpl<Diffusion::DiffType::viscosity_const,
+          return SimpleDragSourceImpl<Diffusion::DiffType::viscosity_plaw,
                                       DragModel::stokes, GEOM>(
               md, time, dt, dp, eos_d, gas_self_par, dust_self_par, stop_par);
         }

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -436,9 +436,9 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
   const auto do_viscosity = params.template Get<bool>("do_viscosity");
   if (do_viscosity) {
     auto dp = params.template Get<Diffusion::DiffCoeffParams>("visc_params");
-    if (dp.type == Diffusion::DiffType::viscosity_const) {
+    if (dp.type == Diffusion::DiffType::viscosity_plaw) {
       visc_dt = Diffusion::EstimateTimestep<GEOM, Fluid::gas,
-                                            Diffusion::DiffType::viscosity_const>(
+                                            Diffusion::DiffType::viscosity_plaw>(
           md, dp, gas_pkg, eos_d, vmesh);
     } else if (dp.type == Diffusion::DiffType::viscosity_alpha) {
       visc_dt = Diffusion::EstimateTimestep<GEOM, Fluid::gas,
@@ -451,13 +451,13 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
   const auto do_conduction = params.template Get<bool>("do_conduction");
   if (do_conduction) {
     auto dp = params.template Get<Diffusion::DiffCoeffParams>("cond_params");
-    if (dp.type == Diffusion::DiffType::conductivity_const) {
+    if (dp.type == Diffusion::DiffType::conductivity_plaw) {
       cond_dt = Diffusion::EstimateTimestep<GEOM, Fluid::gas,
-                                            Diffusion::DiffType::conductivity_const>(
+                                            Diffusion::DiffType::conductivity_plaw>(
           md, dp, gas_pkg, eos_d, vmesh);
-    } else if (dp.type == Diffusion::DiffType::thermaldiff_const) {
+    } else if (dp.type == Diffusion::DiffType::thermaldiff_plaw) {
       cond_dt = Diffusion::EstimateTimestep<GEOM, Fluid::gas,
-                                            Diffusion::DiffType::thermaldiff_const>(
+                                            Diffusion::DiffType::thermaldiff_plaw>(
           md, dp, gas_pkg, eos_d, vmesh);
     }
   }
@@ -543,10 +543,10 @@ TaskStatus ViscousFlux(MeshData<Real> *md) {
 
   if (dp.type == Diffusion::DiffType::null) {
     return TaskStatus::complete;
-  } else if (dp.type == Diffusion::DiffType::viscosity_const) {
+  } else if (dp.type == Diffusion::DiffType::viscosity_plaw) {
     return Diffusion::MomentumFluxImpl<GEOM, Fluid::gas,
-                                       Diffusion::DiffType::viscosity_const>(md, dp, pkg,
-                                                                             vprim, vf);
+                                       Diffusion::DiffType::viscosity_plaw>(md, dp, pkg,
+                                                                            vprim, vf);
   } else if (dp.type == Diffusion::DiffType::viscosity_alpha) {
     return Diffusion::MomentumFluxImpl<GEOM, Fluid::gas,
                                        Diffusion::DiffType::viscosity_alpha>(md, dp, pkg,
@@ -581,14 +581,14 @@ TaskStatus ThermalFlux(MeshData<Real> *md) {
 
   if (dp.type == Diffusion::DiffType::null) {
     return TaskStatus::complete;
-  } else if (dp.type == Diffusion::DiffType::conductivity_const) {
+  } else if (dp.type == Diffusion::DiffType::conductivity_plaw) {
     return Diffusion::ThermalFluxImpl<GEOM, Fluid::gas,
-                                      Diffusion::DiffType::conductivity_const>(
-        md, dp, pkg, vprim, vf);
-  } else if (dp.type == Diffusion::DiffType::thermaldiff_const) {
-    return Diffusion::ThermalFluxImpl<GEOM, Fluid::gas,
-                                      Diffusion::DiffType::thermaldiff_const>(md, dp, pkg,
+                                      Diffusion::DiffType::conductivity_plaw>(md, dp, pkg,
                                                                               vprim, vf);
+  } else if (dp.type == Diffusion::DiffType::thermaldiff_plaw) {
+    return Diffusion::ThermalFluxImpl<GEOM, Fluid::gas,
+                                      Diffusion::DiffType::thermaldiff_plaw>(md, dp, pkg,
+                                                                             vprim, vf);
   } else {
     PARTHENON_FAIL("Invalid conductivity type");
   }

--- a/src/gas/params.yaml
+++ b/src/gas/params.yaml
@@ -129,14 +129,13 @@ gas:
     _description: "Viscosity models"
     type:
       _type: string
-      _default: constant
       _description: "Viscosity model"
       alpha:
         _type: opt
         _description: "Alpha viscosity"
-      constant:
+      powerlaw:
         _type: opt
-        _description: "Constant kinematic viscosity"
+        _description: "Powerlaw kinematic viscosity"
     averaging:
       _type: string
       _default: "arithmetic"
@@ -154,6 +153,9 @@ gas:
       _type: Real
       _description: "Value of the kinematic shear viscosity"
       _units: "cm^2 s^-1"
+    r_exp:
+      _type: Real
+      _description: "Value of the cylindrical powerlaw exponent"
     eta_bulk:
       _type: Real
       _default: "0.0"
@@ -164,14 +166,13 @@ gas:
     _description: "Conductivity models"
     type:
       _type: string
-      _default: constant
       _description: "Conductivity model"
-      constant:
+      conductivity:
         _type: opt
-        _description: "Constant thermal conductivity"
-      diffusivity_constant:
+        _description: "Powerlaw thermal conductivity"
+      diffusivity:
         _type: opt
-        _description: "Constant thermal diffusivity"
+        _description: "Powerlaw thermal diffusivity"
     averaging:
       _type: string
       _default: "arithmetic"
@@ -191,26 +192,21 @@ gas:
       _type: Real
       _description: "Value of heat conductivity"
       _units: "erg cm^-1 s^-1 K^-1"
-
-    averaging:
-      _type: string
-      _default: "arithmetic"
-      _description: "Averaging method for the face diffusion coefficient"
-      arithmetic:
-        _type: opt
-        _description: "Simple average (L+R)/2"
-      harmonic:
-        _type: opt
-        _description: "Harmonic average 2*(L*R)/(L+R)"
-
-    kappa:
+    temp_exp:
       _type: Real
-      _description: "Value of thermal diffusivity"
-      _units: "cm^2 s^-1"
-    cond:
+      _description: "Temperature powerlaw exponent"
+    T_ref:
       _type: Real
-      _description: "Value of heat conductivity"
-      _units: "erg cm^-1 s^-1 K^-1"
+      _description: "Reference temperature"
+      _units: "K"
+    rho_exp:
+      _type: Real
+      _description: "Density powerlaw exponent"
+    rho_ref:
+      _type: Real
+      _description: "Reference density"
+      _units: "g cm^-3"
+
 
   opacity/absorption:
     _type: node

--- a/src/pgen/conduction.hpp
+++ b/src/pgen/conduction.hpp
@@ -260,67 +260,67 @@ inline void CondBoundary(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
   const auto dcp = pkg->template Param<Diffusion::DiffCoeffParams>("cond_params");
 
   if constexpr (BDY == IndexDomain::inner_x1) {
-    if (dcp.type == Diffusion::DiffType::conductivity_const) {
+    if (dcp.type == Diffusion::DiffType::conductivity_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::inner_x1,
-                              Diffusion::DiffType::conductivity_const>(mbd, coarse);
-    } else if (dcp.type == Diffusion::DiffType::thermaldiff_const) {
+                              Diffusion::DiffType::conductivity_plaw>(mbd, coarse);
+    } else if (dcp.type == Diffusion::DiffType::thermaldiff_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::inner_x1,
-                              Diffusion::DiffType::thermaldiff_const>(mbd, coarse);
+                              Diffusion::DiffType::thermaldiff_plaw>(mbd, coarse);
     } else {
       PARTHENON_FAIL(
           "Chosen conductivity type is not compatible with conductivity boundaries");
     }
   } else if constexpr (BDY == IndexDomain::outer_x1) {
-    if (dcp.type == Diffusion::DiffType::conductivity_const) {
+    if (dcp.type == Diffusion::DiffType::conductivity_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::outer_x1,
-                              Diffusion::DiffType::conductivity_const>(mbd, coarse);
-    } else if (dcp.type == Diffusion::DiffType::thermaldiff_const) {
+                              Diffusion::DiffType::conductivity_plaw>(mbd, coarse);
+    } else if (dcp.type == Diffusion::DiffType::thermaldiff_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::outer_x1,
-                              Diffusion::DiffType::thermaldiff_const>(mbd, coarse);
+                              Diffusion::DiffType::thermaldiff_plaw>(mbd, coarse);
     } else {
       PARTHENON_FAIL(
           "Chosen conductivity type is not compatible with conductivity boundaries");
     }
   } else if constexpr (BDY == IndexDomain::inner_x2) {
-    if (dcp.type == Diffusion::DiffType::conductivity_const) {
+    if (dcp.type == Diffusion::DiffType::conductivity_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::inner_x2,
-                              Diffusion::DiffType::conductivity_const>(mbd, coarse);
-    } else if (dcp.type == Diffusion::DiffType::thermaldiff_const) {
+                              Diffusion::DiffType::conductivity_plaw>(mbd, coarse);
+    } else if (dcp.type == Diffusion::DiffType::thermaldiff_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::inner_x2,
-                              Diffusion::DiffType::thermaldiff_const>(mbd, coarse);
+                              Diffusion::DiffType::thermaldiff_plaw>(mbd, coarse);
     } else {
       PARTHENON_FAIL(
           "Chosen conductivity type is not compatible with conductivity boundaries");
     }
   } else if constexpr (BDY == IndexDomain::outer_x2) {
-    if (dcp.type == Diffusion::DiffType::conductivity_const) {
+    if (dcp.type == Diffusion::DiffType::conductivity_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::outer_x2,
-                              Diffusion::DiffType::conductivity_const>(mbd, coarse);
-    } else if (dcp.type == Diffusion::DiffType::thermaldiff_const) {
+                              Diffusion::DiffType::conductivity_plaw>(mbd, coarse);
+    } else if (dcp.type == Diffusion::DiffType::thermaldiff_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::outer_x2,
-                              Diffusion::DiffType::thermaldiff_const>(mbd, coarse);
+                              Diffusion::DiffType::thermaldiff_plaw>(mbd, coarse);
     } else {
       PARTHENON_FAIL(
           "Chosen conductivity type is not compatible with conductivity boundaries");
     }
   } else if constexpr (BDY == IndexDomain::inner_x3) {
-    if (dcp.type == Diffusion::DiffType::conductivity_const) {
+    if (dcp.type == Diffusion::DiffType::conductivity_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::inner_x3,
-                              Diffusion::DiffType::conductivity_const>(mbd, coarse);
-    } else if (dcp.type == Diffusion::DiffType::thermaldiff_const) {
+                              Diffusion::DiffType::conductivity_plaw>(mbd, coarse);
+    } else if (dcp.type == Diffusion::DiffType::thermaldiff_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::inner_x3,
-                              Diffusion::DiffType::thermaldiff_const>(mbd, coarse);
+                              Diffusion::DiffType::thermaldiff_plaw>(mbd, coarse);
     } else {
       PARTHENON_FAIL(
           "Chosen conductivity type is not compatible with conductivity boundaries");
     }
   } else if constexpr (BDY == IndexDomain::outer_x3) {
-    if (dcp.type == Diffusion::DiffType::conductivity_const) {
+    if (dcp.type == Diffusion::DiffType::conductivity_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::outer_x3,
-                              Diffusion::DiffType::conductivity_const>(mbd, coarse);
-    } else if (dcp.type == Diffusion::DiffType::thermaldiff_const) {
+                              Diffusion::DiffType::conductivity_plaw>(mbd, coarse);
+    } else if (dcp.type == Diffusion::DiffType::thermaldiff_plaw) {
       return CondBoundaryImpl<GEOM, IndexDomain::outer_x3,
-                              Diffusion::DiffType::thermaldiff_const>(mbd, coarse);
+                              Diffusion::DiffType::thermaldiff_plaw>(mbd, coarse);
     } else {
       PARTHENON_FAIL(
           "Chosen conductivity type is not compatible with conductivity boundaries");

--- a/src/pgen/disk.hpp
+++ b/src/pgen/disk.hpp
@@ -312,11 +312,11 @@ inline void InitDiskParams(MeshBlock *pmb, ParameterInput *pin) {
         disk_params.nu0 = disk_params.alpha * disk_params.gamma_gas *
                           SQR(disk_params.h0 * disk_params.r0 * disk_params.Omega0);
         disk_params.nu_indx = 1.5 + disk_params.q;
-      } else if (vtype == "constant") {
+      } else if (vtype == "powerlaw") {
         disk_params.nu0 = pin->GetReal("gas/viscosity", "nu");
-        disk_params.nu_indx = 0.0;
+        disk_params.nu_indx = pin->GetOrAddReal("gas/viscosity", "r_exp", 0.0);
       } else {
-        PARTHENON_FAIL("Disk pgen is only compatible with alpha or constant viscosity");
+        PARTHENON_FAIL("Disk pgen is only compatible with alpha or powerlaw viscosity");
       }
       if (pin->DoesParameterExist("problem", "mdot")) {
         disk_params.mdot = pin->GetReal("problem", "mdot");

--- a/src/utils/diffusion/diffusion.hpp
+++ b/src/utils/diffusion/diffusion.hpp
@@ -94,9 +94,9 @@ Real EstimateTimestep(MeshData<Real> *md, DiffCoeffParams &dp, PKG &pkg, const E
           // Get the maximum diffusion coefficient (if there's more than one)
           DiffusionCoeff<DIFF, GEOM, FLUID_TYPE> diffcoeff;
           Real mu = diffcoeff.Get(dp, coords, dens, sie, eos);
-          if constexpr (DIFF == DiffType::conductivity_const) {
+          if constexpr (DIFF == DiffType::conductivity_plaw) {
             mu /= (dens * eos.SpecificHeatFromDensityInternalEnergy(dens, sie));
-          } else if constexpr ((DIFF == DiffType::viscosity_const) ||
+          } else if constexpr ((DIFF == DiffType::viscosity_plaw) ||
                                (DIFF == DiffType::viscosity_alpha)) {
             mu *= (1.0 + (dp.eta > 1.0) * (dp.eta - 1.0)) / dens;
           }

--- a/src/utils/diffusion/diffusion_coeff.hpp
+++ b/src/utils/diffusion/diffusion_coeff.hpp
@@ -23,25 +23,25 @@ using ArtemisUtils::EOS;
 namespace Diffusion {
 
 enum class DiffType {
-  viscosity_const,
+  viscosity_plaw,
   viscosity_alpha,
-  conductivity_const,
-  thermaldiff_const,
+  conductivity_plaw,
+  thermaldiff_plaw,
   null
 };
 enum class DiffAvg { arithmetic, harmonic, null };
 
 inline DiffType ChooseDiffusion(std::string dtype, std::string type) {
   if (dtype == "viscosity") {
-    if (type == "constant")
-      return DiffType::viscosity_const;
+    if ((type == "constant") || (type == "powerlaw"))
+      return DiffType::viscosity_plaw;
     else if (type == "alpha")
       return DiffType::viscosity_alpha;
   } else if (dtype == "conductivity") {
-    if (type == "constant")
-      return DiffType::conductivity_const;
-    else if (type == "diffusivity_constant")
-      return DiffType::thermaldiff_const;
+    if (type == "conductivity")
+      return DiffType::conductivity_plaw;
+    else if (type == "diffusivity")
+      return DiffType::thermaldiff_plaw;
   }
 
   return DiffType::null;
@@ -61,10 +61,10 @@ struct DiffCoeffParams {
 
   // Viscosity
   // -----------------
-  // constant viscosity
+  // powerlaw viscosity
   // nu_s is the kinematic shear viscosity (cgs : cm^2/s)
   // eta is the ratio of the bulk to shear kinematic viscosity
-  Real nu_s, eta;
+  Real nu_s, eta, r_exp;
   // alpha viscosity
   // nu_s = alpha c_s^2 / Omega
   Real alpha, R0, Omega0;
@@ -75,9 +75,9 @@ struct DiffCoeffParams {
   // constant thermal diffusivity
   // kappa = K / (rho c_p) (cgs : cm^2/s)
   Real kappa_0;
-  // constant conductivity
+  // powerlaw conductivity
   // K  (cgs : erg/(cm s K) )
-  Real hcond_0;
+  Real hcond_0, temp_exp, rho_exp, T0, d0;
 
   // Diffusivity
   // -----------------
@@ -103,9 +103,11 @@ struct DiffCoeffParams {
       PARTHENON_FAIL(msg);
     }
     // Read the parameters
-    if (type == DiffType::viscosity_const) {
+    if (type == DiffType::viscosity_plaw) {
       nu_s = pin->GetReal(block_name, "nu");
       eta = pin->GetOrAddReal(block_name, "eta_bulk", 0.0);
+      R0 = pin->GetOrAddReal("problem", "r0", 1.0);
+      r_exp = pin->GetOrAddReal(block_name, "r_exp", 0.0);
     } else if (type == DiffType::viscosity_alpha) {
       alpha = pin->GetReal(block_name, "alpha");
       eta = pin->GetOrAddReal(block_name, "eta_bulk", 0.0);
@@ -113,10 +115,18 @@ struct DiffCoeffParams {
       R0 = pin->GetOrAddReal("problem", "r0", 1.0);
       const Real gm = packages.Get("gravity")->Param<Real>("gm");
       Omega0 = std::sqrt(gm / (R0 * R0 * R0));
-    } else if (type == DiffType::thermaldiff_const) {
+    } else if (type == DiffType::thermaldiff_plaw) {
       kappa_0 = pin->GetReal(block_name, "kappa");
-    } else if (type == DiffType::conductivity_const) {
+      temp_exp = pin->GetOrAddReal(block_name, "temp_exp", 0.0);
+      rho_exp = pin->GetOrAddReal(block_name, "rho_exp", 0.0);
+      d0 = pin->GetOrAddReal(block_name, "rho_ref", 1.0);
+      T0 = pin->GetOrAddReal(block_name, "T_ref", 1.0);
+    } else if (type == DiffType::conductivity_plaw) {
       hcond_0 = pin->GetReal(block_name, "cond");
+      temp_exp = pin->GetOrAddReal(block_name, "temp_exp", 0.0);
+      rho_exp = pin->GetOrAddReal(block_name, "rho_exp", 0.0);
+      d0 = pin->GetOrAddReal(block_name, "rho_ref", 1.0);
+      T0 = pin->GetOrAddReal(block_name, "T_ref", 1.0);
     } else {
       std::stringstream msg;
       msg << type_ << " in " << block_name << " is not supported";
@@ -181,7 +191,7 @@ class DiffusionCoeff<DiffType::null, GEOM, FLUID_TYPE> {
 
 // Viscosity
 template <Coordinates GEOM, Fluid FLUID_TYPE>
-class DiffusionCoeff<DiffType::viscosity_const, GEOM, FLUID_TYPE> {
+class DiffusionCoeff<DiffType::viscosity_plaw, GEOM, FLUID_TYPE> {
   // Constant Kinematic Viscosity
   // These routines return the dynamic viscosity, rho*nu (cgs : g/(cm s))
  public:
@@ -194,15 +204,19 @@ class DiffusionCoeff<DiffType::viscosity_const, GEOM, FLUID_TYPE> {
     using TE = parthenon::TopologicalElement;
 
     PARTHENON_DEBUG_REQUIRE(
-        dp.type == DiffType::viscosity_const,
+        dp.type == DiffType::viscosity_plaw,
         "Mismatch between evaluated viscosity type and input viscosity type");
     PARTHENON_DEBUG_REQUIRE(FLUID_TYPE == Fluid::gas,
                             "Viscosity only works with the gas fluid");
 
+    auto pco = p.GetCoordinates(b);
     parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu,
                              [&](const int i) {
+                               geometry::Coords<GEOM> coords(pco, k, j, i);
                                const Real &dens = p(b, gas::prim::density(n), k, j, i);
-                               mu(i) = dp.nu_s * dens;
+                               const auto &xv = coords.GetCellCenter();
+                               const auto &xs = coords.ConvertToCyl(xv);
+                               mu(i) = dp.nu_s * dens * std::pow(xs[0] / dp.R0, dp.r_exp);
                              });
   }
 
@@ -210,12 +224,14 @@ class DiffusionCoeff<DiffType::viscosity_const, GEOM, FLUID_TYPE> {
                                   geometry::Coords<GEOM> coords, const Real dens,
                                   const Real sie, const EOS &eos) const {
     PARTHENON_DEBUG_REQUIRE(
-        dp.type == DiffType::viscosity_const,
+        dp.type == DiffType::viscosity_plaw,
         "Mismatch between evaluated viscosity type and input viscosity type");
     PARTHENON_DEBUG_REQUIRE(FLUID_TYPE == Fluid::gas,
                             "Viscosity only works with the gas fluid");
 
-    return dp.nu_s * dens;
+    const auto &xv = coords.GetCellCenter();
+    const auto &xs = coords.ConvertToCyl(xv);
+    return dp.nu_s * dens * std::pow(xs[0] / dp.R0, dp.r_exp);
   }
 };
 
@@ -273,7 +289,7 @@ class DiffusionCoeff<DiffType::viscosity_alpha, GEOM, FLUID_TYPE> {
 
 // Conduction
 template <Coordinates GEOM, Fluid FLUID_TYPE>
-class DiffusionCoeff<DiffType::conductivity_const, GEOM, FLUID_TYPE> {
+class DiffusionCoeff<DiffType::conductivity_plaw, GEOM, FLUID_TYPE> {
   // Conductivity
   // These routines return the conductivity, K (cgs : erg/(cm s K))
  public:
@@ -286,30 +302,38 @@ class DiffusionCoeff<DiffType::conductivity_const, GEOM, FLUID_TYPE> {
     using TE = parthenon::TopologicalElement;
 
     PARTHENON_DEBUG_REQUIRE(
-        dp.type == DiffType::conductivity_const,
+        dp.type == DiffType::conductivity_plaw,
         "Mismatch between evaluated conductivity type and input conductivity  type");
     PARTHENON_DEBUG_REQUIRE(FLUID_TYPE == Fluid::gas,
-                            "Viscosity only works with the gas fluid");
+                            "Thermal conductivity only works with the gas fluid");
 
-    parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu,
-                             [&](const int i) { mu(i) = dp.hcond_0; });
+    parthenon::par_for_inner(
+        DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
+          const Real &dens = p(b, gas::prim::density(n), k, j, i);
+          const Real &sie = p(b, gas::prim::sie(n), k, j, i);
+          const Real T = eos.TemperatureFromDensityInternalEnergy(dens, sie);
+          mu(i) = dp.hcond_0 * std::pow(T / dp.T0, dp.temp_exp) *
+                  std::pow(dens / dp.d0, dp.rho_exp);
+        });
   }
   KOKKOS_INLINE_FUNCTION Real Get(const DiffCoeffParams &dp,
                                   geometry::Coords<GEOM> coords, const Real dens,
                                   const Real sie, const EOS &eos) const {
 
     PARTHENON_DEBUG_REQUIRE(
-        dp.type == DiffType::conductivity_const,
+        dp.type == DiffType::conductivity_plaw,
         "Mismatch between evaluated conductivity type and input conductivity  type");
     PARTHENON_DEBUG_REQUIRE(FLUID_TYPE == Fluid::gas,
-                            "Viscosity only works with the gas fluid");
+                            "Thermal conductivity only works with the gas fluid");
 
-    return dp.hcond_0;
+    const Real T = eos.TemperatureFromDensityInternalEnergy(dens, sie);
+    return dp.hcond_0 * std::pow(T / dp.T0, dp.temp_exp) *
+           std::pow(dens / dp.d0, dp.rho_exp);
   }
 };
 
 template <Coordinates GEOM, Fluid FLUID_TYPE>
-class DiffusionCoeff<DiffType::thermaldiff_const, GEOM, FLUID_TYPE> {
+class DiffusionCoeff<DiffType::thermaldiff_plaw, GEOM, FLUID_TYPE> {
   // Thermal Diffusivity
   // These routines return the conductivity, K (cgs : erg/(cm s K))
  public:
@@ -322,20 +346,20 @@ class DiffusionCoeff<DiffType::thermaldiff_const, GEOM, FLUID_TYPE> {
     using TE = parthenon::TopologicalElement;
 
     PARTHENON_DEBUG_REQUIRE(
-        dp.type == DiffType::conductivity_const,
+        dp.type == DiffType::conductivity_plaw,
         "Mismatch between evaluated conductivity type and input conductivity  type");
     PARTHENON_DEBUG_REQUIRE(FLUID_TYPE == Fluid::gas,
-                            "Viscosity only works with the gas fluid");
+                            "Thermal conductivity only works with the gas fluid");
 
     parthenon::par_for_inner(
         DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
           const Real &dens = p(b, gas::prim::density(n), k, j, i);
           const Real &sie = p(b, gas::prim::sie(n), k, j, i);
           const Real cv = eos.SpecificHeatFromDensityInternalEnergy(dens, sie);
-          //       const Real T =
-          //       eos.TemperatureFromDensityInternalEnergy(dens,sie);
+          const Real T = eos.TemperatureFromDensityInternalEnergy(dens, sie);
 
-          mu(i) = dp.kappa_0 * dens * cv;
+          mu(i) = dp.kappa_0 * std::pow(T / dp.T0, dp.temp_exp) *
+                  std::pow(dens / dp.d0, dp.rho_exp) * dens * cv;
         });
   }
   KOKKOS_INLINE_FUNCTION Real Get(const DiffCoeffParams &dp,
@@ -343,13 +367,15 @@ class DiffusionCoeff<DiffType::thermaldiff_const, GEOM, FLUID_TYPE> {
                                   const Real sie, const EOS &eos) const {
 
     PARTHENON_DEBUG_REQUIRE(
-        dp.type == DiffType::thermaldiff_const,
+        dp.type == DiffType::thermaldiff_plaw,
         "Mismatch between evaluated conductivity type and input conductivity  type");
     PARTHENON_DEBUG_REQUIRE(FLUID_TYPE == Fluid::gas,
-                            "Viscosity only works with the gas fluid");
+                            "Thermal conductivity only works with the gas fluid");
     const Real cv = eos.SpecificHeatFromDensityInternalEnergy(dens, sie);
+    const Real T = eos.TemperatureFromDensityInternalEnergy(dens, sie);
 
-    return dp.kappa_0 * dens * cv;
+    return dp.kappa_0 * std::pow(T / dp.T0, dp.temp_exp) *
+           std::pow(dens / dp.d0, dp.rho_exp) * dens * cv;
   }
 };
 


### PR DESCRIPTION
## Background

This converts our "constant" diffusion coeffs to power-laws with default 0 epxponents. Viscosity can now be a power-law in cylindrical radius and conductivity/thermal diffusivity are power-laws in density and temperature (e.g., Spitzer).

Closes #37 

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
