### PR TITLE
Convert dust params from cgs

### DIFF
--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -101,7 +101,7 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   if (do_nbody) packages.Add(NBody::Initialize(pin.get(), constants));
   if (do_gravity) packages.Add(Gravity::Initialize(pin.get(), constants, packages));
   if (do_gas) packages.Add(Gas::Initialize(pin.get(), units, constants, packages));
-  if (do_dust) packages.Add(Dust::Initialize(pin.get()));
+  if (do_dust) packages.Add(Dust::Initialize(pin.get(), units));
   if (do_rotating_frame) packages.Add(RotatingFrame::Initialize(pin.get()));
   if (do_cooling) packages.Add(Gas::Cooling::Initialize(pin.get()));
   if (do_drag) packages.Add(Drag::Initialize(pin.get()));

--- a/src/dust/dust.cpp
+++ b/src/dust/dust.cpp
@@ -101,18 +101,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
 
   // Dust sizes
   const auto size_dist = pin->GetOrAddString("dust", "size_input", "direct");
-  const auto input_units = pin->GetOrAddString("dust", "input_units", "cgs");
-  Real length_conv = Null<Real>();
-  Real rho_conv = Null<Real>();
-  if (input_units == "cgs") {
-    length_conv = units.GetLengthPhysicalToCode();
-    rho_conv = units.GetMassDensityPhysicalToCode();
-  } else if (input_units == "problem") {
-    length_conv = 1.;
-    rho_conv = 1.;
-  } else {
-    PARTHENON_FAIL("dust/input_units can only be cgs or problem.");
-  }
+  const Real length_conv = units.GetLengthPhysicalToCode();
+  const Real rho_conv = units.GetMassDensityPhysicalToCode();
 
   if (size_dist == "linspace") {
     // uniform

--- a/src/dust/dust.hpp
+++ b/src/dust/dust.hpp
@@ -13,17 +13,16 @@
 #ifndef DUST_DUST_HPP_
 #define DUST_DUST_HPP_
 
-// Parthenon includes
-#include <parthenon/package.hpp>
-
 // Artemis includes
 #include "artemis.hpp"
+#include "utils/units.hpp"
 
 using namespace parthenon::package::prelude;
 
 namespace Dust {
 
-std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
+std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
+                                            ArtemisUtils::Units &units);
 
 template <Coordinates GEOM>
 Real EstimateTimestepMesh(MeshData<Real> *md);

--- a/src/dust/params.yaml
+++ b/src/dust/params.yaml
@@ -1,11 +1,6 @@
 ---
 dust:
 
-  input_units:
-    _type: string
-    _default: "cgs"
-    _description: "Unit system used when specifying dust sizes and density"
-
   cfl:
     _type: Real
     _default: "0.8"

--- a/src/dust/params.yaml
+++ b/src/dust/params.yaml
@@ -1,6 +1,11 @@
 ---
 dust:
 
+  input_units:
+    _type: string
+    _default: "cgs"
+    _description: "Unit system used when specifying dust sizes and density"
+
   cfl:
     _type: Real
     _default: "0.8"


### PR DESCRIPTION
## Background

This converts the input dust sizes and grain density from cgs to problem units. 

Closes #40 

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
