### PR TITLE
Update singularity-eos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,8 @@ set(ARTEMIS_SINGULARITY_INCLUDE_PATHS
     ${CMAKE_CURRENT_SOURCE_DIR}/external/singularity-eos/utils/variant/include
     ${CMAKE_CURRENT_SOURCE_DIR}/external/singularity-opac/utils
     ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_SOURCE_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/generated>)
 
 # Set Jaybenne config options and paths
 # NOTE(@pdmullen): For the life of us, we are still not sure why we can't treat


### PR DESCRIPTION
## Background

So that we can use `MeanAtomicMass()` to pull out `mu` without having to pass it and `amu` to functions we are already passing the eos to. 

I also want to see if `jaybenne` will build properly...because I'm having problems on another branch when updating singularity.

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
