### PR TITLE
Fix rebound on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,11 @@ if(ARTEMIS_ENABLE_ASAN)
   add_link_options(-fsanitize=address -fsanitize=undefined)
 endif()
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  # silence sprintf warnings on mac
+  add_compile_options(-Wno-deprecated-declarations)
+endif()
+
 # NOTE(@jonahm): For some reason, order still matters for including
 # parthenon and singularity. Likely has to do with project
 # includes other than Kokkos. MPI and OpenMP likely culprits.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,6 +147,9 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
    # Bake in rpath to rebound on mac
    if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    set_target_properties(artemis PROPERTIES
+      BUILD_RPATH "${CMAKE_BINARY_DIR}/rebound"
+    )
     add_custom_command(TARGET artemis POST_BUILD
       COMMAND install_name_tool -add_rpath @executable_path/../rebound $<TARGET_FILE:artemis>
       COMMAND install_name_tool -change librebound.so @rpath/librebound.so $<TARGET_FILE:artemis>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,11 +147,6 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
    # Bake in rpath to rebound on mac
    if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    set_target_properties(artemis PROPERTIES
-      BUILD_RPATH "${CMAKE_BINARY_DIR}/rebound/"
-      INSTALL_RPATH "@executable_path/../rebound"
-      INSTALL_RPATH_USE_LINK_PATH TRUE
-    )
     add_custom_command(TARGET artemis POST_BUILD
       COMMAND install_name_tool -add_rpath @executable_path/../rebound $<TARGET_FILE:artemis>
       COMMAND install_name_tool -change librebound.so @rpath/librebound.so $<TARGET_FILE:artemis>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,8 +144,17 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
    message(STATUS "Standalone mode. Adding artemis executable")
    add_executable(artemis main.cpp)
    target_link_libraries(artemis PRIVATE artemislib)
-   add_custom_command(TARGET artemis POST_BUILD
-                      COMMAND ${CMAKE_COMMAND} -E copy
-                              ${CMAKE_BINARY_DIR}/rebound/librebound.so
-                              $<TARGET_FILE_DIR:artemis>)
+
+   # Bake in rpath to rebound on mac
+   if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    set_target_properties(artemis PROPERTIES
+      BUILD_RPATH "${CMAKE_BINARY_DIR}/rebound/"
+      INSTALL_RPATH "@executable_path/../rebound"
+      INSTALL_RPATH_USE_LINK_PATH TRUE
+    )
+    add_custom_command(TARGET artemis POST_BUILD
+      COMMAND install_name_tool -add_rpath @executable_path/../rebound $<TARGET_FILE:artemis>
+      COMMAND install_name_tool -change librebound.so @rpath/librebound.so $<TARGET_FILE:artemis>
+    )
+   endif()
 endif()

--- a/tst/run_tests.py
+++ b/tst/run_tests.py
@@ -157,10 +157,6 @@ def main(**kwargs):
 
         # Build working directory and copy librebound.so into working directory
         os.makedirs(artemis.get_outputs_dir(), exist_ok=True)
-        reb_path = os.path.join(artemis.get_exe_dir(), "librebound.so")
-        if not os.path.exists(reb_path):
-            raise TestError(f'librebound.so not found at "{reb_path}"!')
-        shutil.copy(reb_path, artemis.get_outputs_dir())
 
         # Run each test
         for name in test_names:
@@ -294,16 +290,12 @@ def set_globals(args):
     if exe_path is not None:
         adir = os.path.join(artemis.get_artemis_dir(), "tst")
         out_dir = os.path.join(adir, "testing") if out_dir is None else out_dir
-        reb_path = os.path.join(os.path.dirname(exe_path), "librebound.so")
 
         if use_cwd:
             raise TestError("--cwd and --exe=PATH cannot be passed together!")
 
         if not (os.path.exists(exe_path) and os.access(exe_path, os.X_OK)):
             raise TestError(f'Provided exe "{exe_path}" not found or cannot be run!')
-
-        if not os.path.exists(reb_path):
-            raise TestError(f'librebound.so not found at "{reb_path}"!')
 
         abs_out_dir = os.path.abspath(out_dir)
         abs_exe_dir = os.path.abspath(os.path.dirname(exe_path))
@@ -318,10 +310,6 @@ def set_globals(args):
             if os.path.isfile(lpath_exe) and os.access(lpath_exe, os.X_OK):
                 exe_path = lpath_exe
                 out_dir = os.path.join(cwd, "testing") if out_dir is None else out_dir
-                reb_path = os.path.join(os.path.dirname(exe_path), "librebound.so")
-
-                if not os.path.exists(reb_path):
-                    raise TestError(f'librebound.so not found at "{reb_path}"!')
 
                 abs_out_dir = os.path.abspath(out_dir)
                 abs_exe_dir = os.path.abspath(os.path.dirname(exe_path))
@@ -331,13 +319,9 @@ def set_globals(args):
                 # Check if we are one level up from the executable
                 exe_path = read_cmakecache(lpath_cache)
                 out_dir = os.path.join(cwd, "testing") if out_dir is None else out_dir
-                reb_path = os.path.join(os.path.dirname(exe_path), "librebound.so")
 
                 if not (os.path.exists(exe_path) and os.access(exe_path, os.X_OK)):
                     raise TestError(f'No exe in "{exe_path}" or cannot be run!')
-
-                if not os.path.exists(reb_path):
-                    raise TestError(f'librebound.so not found at "{reb_path}"!')
 
                 abs_out_dir = os.path.abspath(out_dir)
                 abs_exe_dir = os.path.abspath(os.path.dirname(exe_path))


### PR DESCRIPTION
## Background

This should fix the linking issues on mac. Essentially we don't try in cmake, and instead just run  `install_name_tool` after the build completes to set the `@rpath` in the binary directly.  Because of this change, we also no longer need to move `librebound.so` after building it, so I got rid of that step too.

With this, I can now successfully execute artemis from anywhere and move the binary anywhere and execute it. 

I also added the `-Wno-deprecated-declarations` to suppress the warnings from singularity. 

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
