### PR TITLE
Add temperature to units and have units aware EOS

### DIFF
--- a/src/artemis_params.yaml
+++ b/src/artemis_params.yaml
@@ -33,13 +33,13 @@ artemis:
     cgs:
       _type: opt
       _description: "CGS unit system"
-  unit_conversion:
+  unit_specifier:
     _type: "string"
     _default: "base"
     _description: "How to provide unit conversions between code and physical units"
     base:
       _type: opt
-      _description: "Provide base unit conversions (length, time, mass)"
+      _description: "Provide base unit conversions (length, time, mass, temperature)"
     ppd:
       _type: opt
       _description: "AU, Year/(2 pi), solar mass units for protoplanetary disks"
@@ -55,6 +55,10 @@ artemis:
     _type: "Real"
     _default: "1.0"
     _description: "Physical units value of mass equal to 1 code unit"
+  temperature:
+    _type: "Real"
+    _default: "1.0"
+    _description: "Physical units value of temperature equal to 1 code unit"
 
 
 physics:

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -113,7 +113,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
       PARTHENON_REQUIRE(mu > 0, "Only positive mean molecular weight allowed!");
       cv = constants.GetKBCode() / ((gamma - 1.) * constants.GetAMUCode() * mu);
     }
-    EOS eos_host = singularity::IdealGas(gamma - 1., cv);
+    EOS eos_host = singularity::UnitSystem<singularity::IdealGas>(
+        singularity::IdealGas(gamma - 1., cv),
+        singularity::eos_units_init::LengthTimeUnitsInit(), units.GetTimeCodeToPhysical(),
+        units.GetMassCodeToPhysical(), units.GetLengthCodeToPhysical(),
+        units.GetTemperatureCodeToPhysical());
     EOS eos_device = eos_host.GetOnDevice();
     params.Add("eos_h", eos_host);
     params.Add("eos_d", eos_device);

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -133,11 +133,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   const Real length = units.GetLengthCodeToPhysical();
   const Real time = units.GetTimeCodeToPhysical();
   const Real mass = units.GetMassCodeToPhysical();
+  const Real temp = units.GetTemperatureCodeToPhysical();
   if (opacity_model_name == "none") {
-    opacity = NonCGSUnits<Gray>(Gray(0.0), time, mass, length, 1.);
+    opacity = NonCGSUnits<Gray>(Gray(0.0), time, mass, length, temp);
   } else if (opacity_model_name == "constant") {
     const Real kappa_a = pin->GetOrAddReal("gas/opacity/absorption", "kappa_a", 0.0);
-    opacity = NonCGSUnits<Gray>(Gray(kappa_a), time, mass, length, 1.);
+    opacity = NonCGSUnits<Gray>(Gray(kappa_a), time, mass, length, temp);
   } else if (opacity_model_name == "shocktube_a") {
     const Real coef_kappa_a =
         pin->GetOrAddReal("gas/opacity/absorption", "coef_kappa_a", 0.0);
@@ -159,10 +160,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   std::string scattering_model_name =
       pin->GetOrAddString("gas/opacity/scattering", "scattering_model", "none");
   if (scattering_model_name == "none") {
-    scattering = NonCGSUnitsS<GrayS>(GrayS(0.0, 1.0), time, mass, length, 1.);
+    scattering = NonCGSUnitsS<GrayS>(GrayS(0.0, 1.0), time, mass, length, temp);
   } else if (scattering_model_name == "constant") {
     const Real kappa_s = pin->GetOrAddReal("gas/opacity/scattering", "kappa_s", 0.0);
-    scattering = NonCGSUnitsS<GrayS>(GrayS(kappa_s, 1.0), time, mass, length, 1.);
+    scattering = NonCGSUnitsS<GrayS>(GrayS(kappa_s, 1.0), time, mass, length, temp);
   } else {
     PARTHENON_FAIL("Scattering model not recognized!");
   }

--- a/src/utils/artemis_utils.cpp
+++ b/src/utils/artemis_utils.cpp
@@ -53,6 +53,7 @@ void PrintArtemisConfiguration(Packages_t &packages) {
     printf("                  [L] = %.2e\n", units.GetLengthCodeToPhysical());
     printf("                  [M] = %.2e\n", units.GetMassCodeToPhysical());
     printf("                  [T] = %.2e\n", units.GetTimeCodeToPhysical());
+    printf("                  [K] = %.2e\n", units.GetTemperatureCodeToPhysical());
     printf("    Active physics:  %s", msg.c_str());
 
     if (params.Get<bool>("do_nbody")) {

--- a/src/utils/eos/eos.hpp
+++ b/src/utils/eos/eos.hpp
@@ -22,7 +22,7 @@ namespace ArtemisUtils {
 static constexpr int lambda_max_vals = 1;
 
 // Variant containing all EOSs to be used in Artemis.
-using EOS = singularity::Variant<singularity::IdealGas>;
+using EOS = singularity::Variant<singularity::UnitSystem<singularity::IdealGas>>;
 
 } // namespace ArtemisUtils
 

--- a/src/utils/units.cpp
+++ b/src/utils/units.cpp
@@ -32,29 +32,28 @@ Units::Units(ParameterInput *pin, std::shared_ptr<StateDescriptor> pkg) {
   } else {
     PARTHENON_FAIL("Physical unit system not recognized! Choices are [scalefree, cgs]");
   }
-  length_ = 1.;
-  time_ = 1.;
-  mass_ = 1.;
-  temp_ = 1.;
-  if (physical_units_ != PhysicalUnits::scalefree) {
+
+  if (physical_units_ == PhysicalUnits::scalefree) {
+    length_ = 1.;
+    time_ = 1.;
+    mass_ = 1.;
+    temp_ = 1.;
+  } else {
     std::string unit_conversion =
         pin->GetOrAddString("artemis", "unit_conversion", "base");
-    if (unit_conversion == "ppd") {
+    if (unit_conversion == "base") {
+      length_ = pin->GetOrAddReal("artemis", "length", 1.);
+      time_ = pin->GetOrAddReal("artemis", "time", 1.);
+      mass_ = pin->GetOrAddReal("artemis", "mass", 1.);
+      temp_ = pin->GetOrAddReal("artemis", "temperature", 1.);
+    } else if (unit_conversion == "ppd") {
       length_ = AU;
       mass_ = Msolar;
       time_ = Year / (2. * M_PI);
-    } else if (unit_conversion == "base") {
-      // do nothing
+      temp_ = 1.0;
     } else {
       PARTHENON_FAIL("Unit conversion not recognized! Choices are [base, ppd]");
     }
-    // not that these multiplied by whatever values were previously set.
-    // For example, if unit_conversion=ppd and mass = 10.0, then
-    // that sets mass_ to 10 MSolar.
-    length_ *= pin->GetOrAddReal("artemis", "length", 1.);
-    time_ *= pin->GetOrAddReal("artemis", "time", 1.);
-    mass_ *= pin->GetOrAddReal("artemis", "mass", 1.);
-    temp_ *= pin->GetOrAddReal("artemis", "temperature", 1.);
   }
 
   // Remaining conversion factors

--- a/src/utils/units.hpp
+++ b/src/utils/units.hpp
@@ -53,6 +53,11 @@ class Units {
   Real GetMassPhysicalToCode() const { return 1. / mass_; }
 
   KOKKOS_INLINE_FUNCTION
+  Real GetTemperatureCodeToPhysical() const { return temp_; }
+  KOKKOS_INLINE_FUNCTION
+  Real GetTemperaturePhysicalToCode() const { return 1. / temp_; }
+
+  KOKKOS_INLINE_FUNCTION
   Real GetSpeedCodeToPhysical() const { return length_ / time_; }
   KOKKOS_INLINE_FUNCTION
   Real GetSpeedPhysicalToCode() const { return time_ / mass_; }
@@ -83,9 +88,9 @@ class Units {
   Real GetOpacityPhysicalToCode() const { return mass_ / (length_ * length_); }
 
   KOKKOS_INLINE_FUNCTION
-  Real GetSpecificHeatCodeToPhysical() const { return energy_ / mass_; }
+  Real GetSpecificHeatCodeToPhysical() const { return energy_ / (mass_ * temp_); }
   KOKKOS_INLINE_FUNCTION
-  Real GetSpecificHeatPhysicalToCode() const { return mass_ / energy_; }
+  Real GetSpecificHeatPhysicalToCode() const { return mass_ * temp_ / energy_; }
 
   inline std::string GetSystemName() const {
     return (physical_units_ == PhysicalUnits::scalefree) ? "Scale free" : "CGS";
@@ -98,6 +103,7 @@ class Units {
   Real length_;
   Real time_;
   Real mass_;
+  Real temp_;
 
   Real energy_;
   Real number_density_;


### PR DESCRIPTION
## Background

This does a few things:
-  adds the missing temperature specifier for our units. That shouldn't change anything. 
-  Makes singularity-eos aware of our unit system so that it's on par with singularity-opac.

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
