### PR TITLE
[BugFix] Fix units of G and make strat pgen work in cgs

### DIFF
--- a/inputs/disk/disk_axi.in
+++ b/inputs/disk/disk_axi.in
@@ -14,6 +14,8 @@
 <artemis>
 problem = disk              # name of the pgen
 coordinates = axisymmetric  # coordinate system
+physical_units = cgs
+unit_conversion = ppd
 
 <parthenon/job>
 problem_id = disk  # problem ID: basename of output filenames

--- a/inputs/disk/disk_axi.in
+++ b/inputs/disk/disk_axi.in
@@ -1,5 +1,5 @@
 # ========================================================================================
-#  (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+#  (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 #
 #  This program was produced under U.S. Government contract 89233218CNA000001 for Los
 #  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/inputs/disk/disk_cart.in
+++ b/inputs/disk/disk_cart.in
@@ -1,5 +1,5 @@
 # ========================================================================================
-#  (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+#  (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 #
 #  This program was produced under U.S. Government contract 89233218CNA000001 for Los
 #  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -14,6 +14,8 @@
 <artemis>
 problem = disk           # name of the pgen
 coordinates = cartesian  # coordinate system
+physical_units = cgs
+unit_conversion = ppd
 
 <parthenon/job>
 problem_id = disk  # problem ID: basename of output filenames

--- a/inputs/disk/disk_cyl.in
+++ b/inputs/disk/disk_cyl.in
@@ -14,6 +14,8 @@
 <artemis>
 problem = disk             # name of the pgen
 coordinates = cylindrical  # coordinate system
+physical_units = cgs
+unit_conversion = ppd
 
 <parthenon/job>
 problem_id = disk  # problem ID: basename of output filenames

--- a/inputs/disk/disk_cyl.in
+++ b/inputs/disk/disk_cyl.in
@@ -1,5 +1,5 @@
 # ========================================================================================
-#  (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+#  (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 #
 #  This program was produced under U.S. Government contract 89233218CNA000001 for Los
 #  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/inputs/disk/disk_sph.in
+++ b/inputs/disk/disk_sph.in
@@ -14,6 +14,8 @@
 <artemis>
 problem = disk           # name of the pgen
 coordinates = spherical  # coordinate system
+physical_units = cgs
+unit_conversion = ppd
 
 <parthenon/job>
 problem_id = disk  # problem ID: basename of output filenames

--- a/inputs/disk/disk_sph.in
+++ b/inputs/disk/disk_sph.in
@@ -1,5 +1,5 @@
 # ========================================================================================
-#  (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+#  (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 #
 #  This program was produced under U.S. Government contract 89233218CNA000001 for Los
 #  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/artemis_params.yaml
+++ b/src/artemis_params.yaml
@@ -33,7 +33,7 @@ artemis:
     cgs:
       _type: opt
       _description: "CGS unit system"
-  unit_specifier:
+  unit_conversion:
     _type: "string"
     _default: "base"
     _description: "How to provide unit conversions between code and physical units"

--- a/src/pgen/strat.hpp
+++ b/src/pgen/strat.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/pgen/strat.hpp
+++ b/src/pgen/strat.hpp
@@ -49,6 +49,8 @@ struct StratParams {
   Real gm1;
   Real d2g;
   Real temp0;
+  Real r0;
+  Real kbmu;
 };
 
 //----------------------------------------------------------------------------------------
@@ -64,11 +66,21 @@ inline void InitStratParams(MeshBlock *pmb, ParameterInput *pin) {
     strat_params.Om0 = pmb->packages.Get("rotating_frame")->Param<Real>("omega");
     strat_params.h = pin->GetOrAddReal("problem", "h", 1.0);
     strat_params.rho0 = pin->GetOrAddReal("problem", "rho0", 1.0);
+    strat_params.r0 = pin->GetOrAddReal("problem", "r0", 1.0);
     strat_params.dens_min = pin->GetOrAddReal("problem", "dens_min", 1.0e-5);
     strat_params.pres_min = pin->GetOrAddReal("problem", "pres_min", 1.0e-8);
     strat_params.d2g = pin->GetOrAddReal("problem", "dust_to_gas", 0.01);
-    strat_params.temp0 = SQR(strat_params.h * strat_params.Om0);
-    strat_params.pres0 = strat_params.rho0 * strat_params.temp0;
+
+    auto &gas_pkg = pmb->packages.Get("gas");
+    auto &artemis_pkg = pmb->packages.Get("artemis");
+    const auto mu = gas_pkg->Param<Real>("mu");
+    const auto eos = gas_pkg->Param<EOS>("eos_h");
+    auto &constants = artemis_pkg->Param<ArtemisUtils::Constants>("constants");
+    strat_params.kbmu = constants.GetKBCode() / (mu * constants.GetAMUCode());
+    strat_params.temp0 =
+        SQR(strat_params.h * strat_params.r0 * strat_params.Om0) / strat_params.kbmu;
+    strat_params.pres0 = eos.PressureFromDensityTemperature(
+        strat_params.rho0, strat_params.temp0); // strat_params.rho0 * strat_params.temp0;
     params.Add("strat_params", strat_params);
   }
 }
@@ -129,7 +141,8 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         const Real vx2 = -pars.q * pars.Om0 * x;
         const Real vx3 = 0.0;
         const Real temp = pars.temp0;
-        const Real efac = (three_d) ? std::exp(-SQR(z) / (2.0 * SQR(pars.h))) : 1.0;
+        const Real efac =
+            (three_d) ? std::exp(-SQR(z) / (2.0 * SQR(pars.h * pars.r0))) : 1.0;
         const Real dens = std::max(pars.dens_min, efac * pars.rho0);
         const Real sie = eos_d.InternalEnergyFromDensityTemperature(dens, temp);
 

--- a/src/utils/units.cpp
+++ b/src/utils/units.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2024-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/utils/units.cpp
+++ b/src/utils/units.cpp
@@ -106,7 +106,7 @@ Constants::Constants(Units &units) {
   const Real energy = mass * std::pow(length / time, 2);
 
   // Convert constants to code units
-  G_code_ = G_ * std::pow(length, -3) / mass * std::pow(time, 2);
+  G_code_ = G_ * std::pow(length, -3) * mass * std::pow(time, 2);
   kb_code_ = kb_ * temp / energy;
   c_code_ = c_ * time / length;
   h_code_ = h_ / (energy * time);

--- a/src/utils/units.hpp
+++ b/src/utils/units.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2024-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/utils/units.hpp
+++ b/src/utils/units.hpp
@@ -29,7 +29,6 @@ class Units {
   Units(ParameterInput *pin, std::shared_ptr<StateDescriptor> pkg);
 
   // Copy constructor must be marked with KOKKOS_FUNCTION
-  KOKKOS_FUNCTION
   Units(const Units &other) = default;
 
   // Return physical unit system
@@ -118,7 +117,6 @@ class Constants {
   KOKKOS_FUNCTION
   Constants(Units &units);
 
-  KOKKOS_FUNCTION
   Constants(const Constants &other) = default;
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
## Background

We had the wrong units for the gravitational constant. This fixes that, puts in the modifications needed for the strat pgen to work in cgs, and does some other housekeeping.

The disk tests now are run in ppd cgs units.

## Description of Changes

## Checklist

- [x] New features are documented
- [x] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files
