### PR TITLE
More portable restarts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(ARTEMIS_ENABLE_MPI "Enable MPI for artemis and all dependencies" ON)
 option(ARTEMIS_ENABLE_OPENMP "Enable OpenMP for artemis and parthenon" OFF)
 option(ARTEMIS_ENABLE_COMPILE_TIMING "Enable timing of compilation of artemis" ON)
 option(ARTEMIS_ENABLE_ASAN "Enable AddressSanitizer to detect memory errors" OFF)
+option(ARTEMIS_PORTABLE_RESTART "Enable portable data types for REBOUND restarts" ON)
 
 # Force -03 optimization for RelWithDebInfo
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG" CACHE STRING "Force -O3 in RelWithDebInfo mode" FORCE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,10 @@ set (SRC_LIST
   utils/refinement/restriction.hpp
 )
 
+if (ARTEMIS_PORTABLE_RESTART)
+  add_compile_definitions(PORTABLE_RESTART)
+endif()
+
 # Generate library
 add_library(artemislib ${SRC_LIST})
 

--- a/src/artemis.hpp
+++ b/src/artemis.hpp
@@ -70,6 +70,12 @@ ARTEMIS_VARIABLE(dust.prim, velocity);
 } // namespace dust
 #undef ARTEMIS_VARIABLE
 
+#ifdef PORTABLE_RESTART
+using BYTE = uint8_t;
+#else
+using BYTE = char;
+#endif
+
 // TaskCollection function pointer for operator split tasks
 using TaskCollectionFnPtr = TaskCollection (*)(Mesh *pm, const Real time, const Real dt);
 

--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -27,12 +27,6 @@ extern "C" {
 #include "nbody/nbody_utils.hpp"
 #include "utils/units.hpp"
 
-#ifdef PORTABLE_RESTART
-using BINARY_CHAR = uint8_t;
-#else
-using BINARY_CHAR = char;
-#endif
-
 using parthenon::MetadataFlag;
 
 namespace NBody {
@@ -143,7 +137,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   params.Add("particle_force_tot", particle_force_tot);
 
   // Create vector for Rebound restart
-  std::vector<BINARY_CHAR> reb_sim_restart;
+  std::vector<BYTE> reb_sim_restart;
   params.Add("reb_sim_buffer", reb_sim_restart, Params::Mutability::Restart);
 
   // Output parameters
@@ -347,15 +341,12 @@ void UserWorkBeforeRestartOutputMesh(Mesh *pmesh, ParameterInput *, SimTime &,
 #endif
 
   // Read Rebound restart back into string
-  std::ifstream file(NBody::rebound_filename, std::ios::binary);
-  PARTHENON_REQUIRE(file.is_open(), "Error opening temporary rebound output file!");
-  std::vector<BINARY_CHAR> reb_sim_buffer((std::istreambuf_iterator<char>(file)),
-                                          std::istreambuf_iterator<char>());
-  file.close();
+
+  auto reb_sim_buffer = read_bytes_from_file(NBody::rebound_filename);
 
   // Store current rebound output as restartable parameter.  Every rank must store a
   // matching buffer parameter or else I/O will hang
-  nbody_pkg->UpdateParam<std::vector<BINARY_CHAR>>("reb_sim_buffer", reb_sim_buffer);
+  nbody_pkg->UpdateParam<std::vector<BYTE>>("reb_sim_buffer", reb_sim_buffer);
 }
 
 //----------------------------------------------------------------------------------------
@@ -374,11 +365,9 @@ void InitializeFromRestart(Mesh *pm) {
   // Initialize rebound state on rank 0
   if (Globals::my_rank == 0) {
     // Create rebound save file from stored buffer
-    auto reb_sim_buffer = nbody_pkg->Param<std::vector<BINARY_CHAR>>("reb_sim_buffer");
-    std::ofstream outfile(NBody::rebound_filename.c_str(), std::ios::binary);
-    outfile.write(reinterpret_cast<const char *>(reb_sim_buffer.data()),
-                  reb_sim_buffer.size());
-    outfile.close();
+    auto reb_sim_buffer = nbody_pkg->Param<std::vector<BYTE>>("reb_sim_buffer");
+
+    write_bytes_to_file(NBody::rebound_filename, reb_sim_buffer);
 
     // Create rebound simulation from new save file
     RebSim new_reb_sim(NBody::rebound_filename);

--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -27,6 +27,12 @@ extern "C" {
 #include "nbody/nbody_utils.hpp"
 #include "utils/units.hpp"
 
+#ifdef PORTABLE_RESTART
+using BINARY_CHAR = uint8_t;
+#else
+using BINARY_CHAR = char;
+#endif
+
 using parthenon::MetadataFlag;
 
 namespace NBody {
@@ -137,7 +143,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   params.Add("particle_force_tot", particle_force_tot);
 
   // Create vector for Rebound restart
-  std::vector<char> reb_sim_restart;
+  std::vector<BINARY_CHAR> reb_sim_restart;
   params.Add("reb_sim_buffer", reb_sim_restart, Params::Mutability::Restart);
 
   // Output parameters
@@ -343,13 +349,13 @@ void UserWorkBeforeRestartOutputMesh(Mesh *pmesh, ParameterInput *, SimTime &,
   // Read Rebound restart back into string
   std::ifstream file(NBody::rebound_filename, std::ios::binary);
   PARTHENON_REQUIRE(file.is_open(), "Error opening temporary rebound output file!");
-  std::vector<char> reb_sim_buffer((std::istreambuf_iterator<char>(file)),
-                                   std::istreambuf_iterator<char>());
+  std::vector<BINARY_CHAR> reb_sim_buffer((std::istreambuf_iterator<char>(file)),
+                                          std::istreambuf_iterator<char>());
   file.close();
 
   // Store current rebound output as restartable parameter.  Every rank must store a
   // matching buffer parameter or else I/O will hang
-  nbody_pkg->UpdateParam<std::vector<char>>("reb_sim_buffer", reb_sim_buffer);
+  nbody_pkg->UpdateParam<std::vector<BINARY_CHAR>>("reb_sim_buffer", reb_sim_buffer);
 }
 
 //----------------------------------------------------------------------------------------
@@ -368,9 +374,10 @@ void InitializeFromRestart(Mesh *pm) {
   // Initialize rebound state on rank 0
   if (Globals::my_rank == 0) {
     // Create rebound save file from stored buffer
-    auto reb_sim_buffer = nbody_pkg->Param<std::vector<char>>("reb_sim_buffer");
+    auto reb_sim_buffer = nbody_pkg->Param<std::vector<BINARY_CHAR>>("reb_sim_buffer");
     std::ofstream outfile(NBody::rebound_filename.c_str(), std::ios::binary);
-    outfile.write(reb_sim_buffer.data(), reb_sim_buffer.size());
+    outfile.write(reinterpret_cast<const char *>(reb_sim_buffer.data()),
+                  reb_sim_buffer.size());
     outfile.close();
 
     // Create rebound simulation from new save file

--- a/src/nbody/nbody_utils.hpp
+++ b/src/nbody/nbody_utils.hpp
@@ -203,6 +203,37 @@ static void enable_stderr(int stderr_save_fd) {
   }
 }
 
+inline void write_bytes_to_file(std::string filename, std::vector<BYTE> &bytes) {
+  std::ofstream outfile(filename.c_str(), std::ios::binary);
+  if (outfile.is_open()) {
+    outfile.write(reinterpret_cast<char *>(bytes.data()), bytes.size());
+    outfile.close();
+    return;
+  }
+  PARTHENON_FAIL("Unable to open binary file to write");
+}
+
+inline std::vector<BYTE> read_bytes_from_file(std::string filename) {
+  std::ifstream file(NBody::rebound_filename, std::ios::binary | std::ios::ate);
+  if (file.is_open()) {
+    auto size = file.tellg();
+    if (size == 0) {
+      PARTHENON_FAIL("Tried reading binary file, but it has zero size");
+    }
+    file.seekg(0, std::ios::beg);
+    std::vector<BYTE> buff(size);
+    if (!file.read(reinterpret_cast<char *>(buff.data()), size)) {
+      PARTHENON_FAIL("Error reading binary file");
+    }
+    file.close();
+    return buff;
+  }
+  PARTHENON_FAIL("Error opening temporary rebound output file!");
+  // unused since we've crashed out
+  std::vector<BYTE> buff;
+  return buff;
+}
+
 } // namespace NBody
 
 #endif

--- a/tst/scripts/collisions/collisions.py
+++ b/tst/scripts/collisions/collisions.py
@@ -37,11 +37,11 @@ _file_id = "collisions"
 
 # Run Artemis
 def run(**kwargs):
-    input_path = "../../" + artemis.artemis_rel_path + "inputs/"
     logger.debug("Runnning test " + __name__)
     arguments = [
         "parthenon/job/problem_id={}_{:d}".format(_file_id, _nranks),
-        "nbody/planets/input_file=" + input_path + "planet_inputs/n20_sys.txt",
+        "nbody/planets/input_file="
+        + os.path.join(artemis.get_inputs_dir(), "planet_inputs/n20_sys.txt"),
     ]
     artemis.run(
         _nranks,


### PR DESCRIPTION
## Background

This changes the rebound restart file in params from a `std::vector<char>` to a `std::vector<uint8_t>` which should be more portable. Because this would break existing restart files, I added an option to not do this. 

This updates parthenon to the latest develop

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
