### PR TITLE
Add template kwds to some Param accesses (for Darwin env builds).

### DIFF
--- a/src/dust/dust.cpp
+++ b/src/dust/dust.cpp
@@ -249,11 +249,11 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
   // NOTE(@pdmullen): Without FARGO, dt must be additionally limited by the linear
   // advection of the shear background flow (vy0 = -q Omega x)
   Real qshear = 0.0, om0 = 0.0;
-  const bool do_shear = pm->packages.Get("artemis")->Param<bool>("do_shear");
+  const bool do_shear = pm->packages.Get("artemis")->template Param<bool>("do_shear");
   if (do_shear) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
-    qshear = rframe_pkg->Param<Real>("qshear");
-    om0 = rframe_pkg->Param<Real>("omega");
+    qshear = rframe_pkg->template Param<Real>("qshear");
+    om0 = rframe_pkg->template Param<Real>("omega");
   }
 
   static auto desc =

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -462,11 +462,11 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
   // NOTE(@pdmullen): Without FARGO, dt must be additionally limited by the linear
   // advection of the shear background flow (vy0 = -q Omega x)
   Real qshear = 0.0, om0 = 0.0;
-  const bool do_shear = pm->packages.Get("artemis")->Param<bool>("do_shear");
+  const bool do_shear = pm->packages.Get("artemis")->template Param<bool>("do_shear");
   if (do_shear) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
-    qshear = rframe_pkg->Param<Real>("qshear");
-    om0 = rframe_pkg->Param<Real>("omega");
+    qshear = rframe_pkg->template Param<Real>("qshear");
+    om0 = rframe_pkg->template Param<Real>("omega");
   }
 
   static auto desc =

--- a/src/radiation/moments/matter_coupling.hpp
+++ b/src/radiation/moments/matter_coupling.hpp
@@ -60,10 +60,10 @@ TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
   // Extract rotating frame quantities
   Real om0 = 0.0;
   Real qshear = 0.0;
-  if (pm->packages.Get("artemis")->Param<bool>("do_rotating_frame")) {
+  if (pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame")) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
-    qshear = rframe_pkg->Param<Real>("qshear");
-    om0 = rframe_pkg->Param<Real>("omega");
+    qshear = rframe_pkg->template Param<Real>("qshear");
+    om0 = rframe_pkg->template Param<Real>("omega");
   }
 
   // Packing and indexing
@@ -213,10 +213,10 @@ TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
   // Extract rotating frame quantities
   Real om0 = 0.0;
   Real qshear = 0.0;
-  if (pm->packages.Get("artemis")->Param<bool>("do_rotating_frame")) {
+  if (pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame")) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
-    qshear = rframe_pkg->Param<Real>("qshear");
-    om0 = rframe_pkg->Param<Real>("omega");
+    qshear = rframe_pkg->template Param<Real>("qshear");
+    om0 = rframe_pkg->template Param<Real>("omega");
   }
 
   // Packing and indexing

--- a/src/utils/diffusion/momentum_diffusion.hpp
+++ b/src/utils/diffusion/momentum_diffusion.hpp
@@ -628,11 +628,11 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
   auto eos_d = pkg->template Param<EOS>("eos_d");
 
   Real qshear = 0.0, om0 = 0.0;
-  const bool do_shear = pm->packages.Get("artemis")->Param<bool>("do_shear");
+  const bool do_shear = pm->packages.Get("artemis")->template Param<bool>("do_shear");
   if (do_shear) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
-    qshear = rframe_pkg->Param<Real>("qshear");
-    om0 = rframe_pkg->Param<Real>("omega");
+    qshear = rframe_pkg->template Param<Real>("qshear");
+    om0 = rframe_pkg->template Param<Real>("omega");
   }
 
   const int scr_level = pkg->template Param<int>("scr_level");


### PR DESCRIPTION
## Background

* skylake-gold and volta env on Darwin give compile-time errors.
* @pdmullen noted this is due to the missing template keyword issue, affecting Param calls.

## Description of Changes

* Add template kwds to some Param accesses (for Darwin env builds).

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
