### PR TITLE
Precompute gray opacity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,8 +228,8 @@ set(JAYBENNE_HOST_VARIABLE_HEADER "src/artemis.hpp")
 set(JAYBENNE_HOST_DENSITY_VARIABLE "gas::prim::density")
 set(JAYBENNE_HOST_SPECIFIC_INTERNAL_ENERGY_VARIABLE "gas::prim::sie")
 set(JAYBENNE_HOST_UPDATE_ENERGY_VARIABLE "gas::cons::internal_energy")
-set(JAYBENNE_HOST_ABSORPTION_OPACITY_VARIABLE "gas::opac::absorption")
-set(JAYBENNE_HOST_SCATTERING_OPACITY_VARIABLE "gas::opac::scattering")
+set(JAYBENNE_HOST_ABSORPTION_OPACITY_VARIABLE "rad::opac::absorption")
+set(JAYBENNE_HOST_SCATTERING_OPACITY_VARIABLE "rad::opac::scattering")
 
 # Add jaybenne
 message(STATUS "Adding jaybenne and dependencies")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(ARTEMIS_ENABLE_HIP "Enable hip for artemis and all dependencies" OFF)
 option(ARTEMIS_ENABLE_HDF5 "Enable HDF5 for artemis and all dependencies" ON)
 option(ARTEMIS_ENABLE_MPI "Enable MPI for artemis and all dependencies" ON)
 option(ARTEMIS_ENABLE_OPENMP "Enable OpenMP for artemis and parthenon" OFF)
-option(ARTEMIS_ENABLE_COMPILE_TIMING "Enable timing of compilation of artemis" ON)
+option(ARTEMIS_ENABLE_COMPILE_TIMING "Enable timing of compilation of artemis" OFF)
 option(ARTEMIS_ENABLE_ASAN "Enable AddressSanitizer to detect memory errors" OFF)
 option(ARTEMIS_PORTABLE_RESTART "Enable portable data types for REBOUND restarts" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,8 @@ set(JAYBENNE_HOST_VARIABLE_HEADER "src/artemis.hpp")
 set(JAYBENNE_HOST_DENSITY_VARIABLE "gas::prim::density")
 set(JAYBENNE_HOST_SPECIFIC_INTERNAL_ENERGY_VARIABLE "gas::prim::sie")
 set(JAYBENNE_HOST_UPDATE_ENERGY_VARIABLE "gas::cons::internal_energy")
+set(JAYBENNE_HOST_ABSORPTION_OPACITY_VARIABLE "gas::opac::absorption")
+set(JAYBENNE_HOST_SCATTERING_OPACITY_VARIABLE "gas::opac::scattering")
 
 # Add jaybenne
 message(STATUS "Adding jaybenne and dependencies")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,8 @@ set (SRC_LIST
   pgen/strat.hpp
   pgen/thermalization.hpp
 
+  radiation/radiation.hpp
+  radiation/radiation.cpp
   radiation/imc/imc_driver.cpp
   radiation/imc/imc.hpp
   radiation/moments/moments.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,8 +71,8 @@ set (SRC_LIST
   pgen/strat.hpp
   pgen/thermalization.hpp
 
-  radiation/radiation.hpp
   radiation/radiation.cpp
+  radiation/radiation.hpp
   radiation/imc/imc_driver.cpp
   radiation/imc/imc.hpp
   radiation/moments/moments.cpp

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -22,6 +22,7 @@
 #include "gravity/gravity.hpp"
 #include "nbody/nbody.hpp"
 #include "radiation/moments/moments.hpp"
+#include "radiation/radiation.hpp"
 #include "rotating_frame/rotating_frame.hpp"
 #include "utils/artemis_utils.hpp"
 #include "utils/history.hpp"
@@ -132,6 +133,7 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
       auto eos_h = packages.Get("gas")->Param<EOS>("eos_h");
       auto opacity_h = packages.Get("gas")->Param<MeanOpacity>("opacity_h");
       auto scattering_h = packages.Get("gas")->Param<MeanScattering>("scattering_h");
+      packages.Add(rad::InitializeRadDataFields(pin.get()));
       packages.Add(jaybenne::Initialize(pin.get(), opacity_h, scattering_h, eos_h,
                                         "radiation/imc"));
       PARTHENON_REQUIRE(coords == Coordinates::cartesian,

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -128,18 +128,19 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   if (do_cooling) packages.Add(Gas::Cooling::Initialize(pin.get()));
   if (do_drag) packages.Add(Drag::Initialize(pin.get()));
   if (do_radiation) {
-    // swap between native artemis radiation and jaybenne imc
+    // Top-level radiation package
+    packages.Add(Radiation::Initialize(pin.get(), constants, do_imc));
+    // Select between Jaybenne IMC or Moments
     if (do_imc) {
       auto eos_h = packages.Get("gas")->Param<EOS>("eos_h");
       auto opacity_h = packages.Get("gas")->Param<MeanOpacity>("opacity_h");
       auto scattering_h = packages.Get("gas")->Param<MeanScattering>("scattering_h");
-      packages.Add(rad::InitializeRadDataFields(pin.get()));
       packages.Add(jaybenne::Initialize(pin.get(), opacity_h, scattering_h, eos_h,
                                         "radiation/imc"));
       PARTHENON_REQUIRE(coords == Coordinates::cartesian,
                         "Jaybenne currently supports only Cartesian coordinates!");
     } else if (do_moment) {
-      packages.Add(Radiation::Initialize(pin.get(), constants));
+      packages.Add(Moments::Initialize(pin.get(), constants));
     } else {
       PARTHENON_FAIL("Unknown radiation model!");
     }

--- a/src/artemis.hpp
+++ b/src/artemis.hpp
@@ -56,10 +56,6 @@ ARTEMIS_VARIABLE(gas.diff, energy);
 namespace face {
 ARTEMIS_VARIABLE(gas.face, velocity);
 } // namespace face
-namespace opac {
-ARTEMIS_VARIABLE(gas.opac, absorption);
-ARTEMIS_VARIABLE(gas.opac, scattering);
-} // namespace opac
 } // namespace gas
 
 namespace dust {
@@ -83,6 +79,10 @@ ARTEMIS_VARIABLE(rad.prim, energy);
 ARTEMIS_VARIABLE(rad.prim, pressure);
 ARTEMIS_VARIABLE(rad.prim, flux);
 } // namespace prim
+namespace opac {
+ARTEMIS_VARIABLE(rad.opac, absorption);
+ARTEMIS_VARIABLE(rad.opac, scattering);
+} // namespace opac
 } // namespace rad
 
 #undef ARTEMIS_VARIABLE

--- a/src/artemis.hpp
+++ b/src/artemis.hpp
@@ -56,6 +56,10 @@ ARTEMIS_VARIABLE(gas.diff, energy);
 namespace face {
 ARTEMIS_VARIABLE(gas.face, velocity);
 } // namespace face
+namespace opac {
+ARTEMIS_VARIABLE(gas.opac, absorption);
+ARTEMIS_VARIABLE(gas.opac, scattering);
+} // namespace opac
 } // namespace gas
 
 namespace dust {

--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -128,7 +128,7 @@ TaskListStatus ArtemisDriver<GEOM>::Step() {
   if (status != TaskListStatus::complete) return status;
 
   // Operator split, moments subcyling (M1 or P1)
-  if (do_moment) status = Radiation::MomentsDriver<GEOM>(pmesh, tm, rad_integrator.get());
+  if (do_moment) status = Moments::MomentsDriver<GEOM>(pmesh, tm, rad_integrator.get());
   if (status != TaskListStatus::complete) return status;
 
   // Compute new dt, (de)refine, and handle sparse (if enabled)

--- a/src/derived/fill_derived.cpp
+++ b/src/derived/fill_derived.cpp
@@ -191,7 +191,7 @@ void ConsToPrim(MeshData<Real> *md) {
             const Real hfx1 = vmesh(b, rad::cons::flux(VI(n, 0)), k, j, i) / conv[0];
             const Real hfx2 = vmesh(b, rad::cons::flux(VI(n, 1)), k, j, i) / conv[1];
             const Real hfx3 = vmesh(b, rad::cons::flux(VI(n, 2)), k, j, i) / conv[2];
-            const auto fx = Radiation::NormalizeFlux(hfx1, hfx2, hfx3);
+            const auto fx = Moments::NormalizeFlux(hfx1, hfx2, hfx3);
             vmesh(b, rad::cons::flux(VI(n, 0)), k, j, i) = fx[0] * conv[0];
             vmesh(b, rad::cons::flux(VI(n, 1)), k, j, i) = fx[1] * conv[1];
             vmesh(b, rad::cons::flux(VI(n, 2)), k, j, i) = fx[2] * conv[2];
@@ -342,7 +342,7 @@ void PrimToCons(T *md) {
             const Real fx1 = vmesh(b, rad::prim::flux(VI(n, 0)), k, j, i);
             const Real fx2 = vmesh(b, rad::prim::flux(VI(n, 1)), k, j, i);
             const Real fx3 = vmesh(b, rad::prim::flux(VI(n, 2)), k, j, i);
-            const auto fx = Radiation::NormalizeFlux(fx1, fx2, fx3);
+            const auto fx = Moments::NormalizeFlux(fx1, fx2, fx3);
             vmesh(b, rad::cons::flux(VI(n, 0)), k, j, i) = fx[0] * conv[0];
             vmesh(b, rad::cons::flux(VI(n, 1)), k, j, i) = fx[1] * conv[1];
             vmesh(b, rad::cons::flux(VI(n, 2)), k, j, i) = fx[2] * conv[2];

--- a/src/derived/fill_derived.cpp
+++ b/src/derived/fill_derived.cpp
@@ -18,9 +18,12 @@
 #include "radiation/moments/moments.hpp"
 #include "utils/artemis_utils.hpp"
 #include "utils/eos/eos.hpp"
+#include "utils/opacity/opacity.hpp"
 
 using ArtemisUtils::EOS;
 using ArtemisUtils::VI;
+using ArtemisUtils::MeanOpacity;
+using ArtemisUtils::MeanScattering;
 
 namespace ArtemisDerived {
 //----------------------------------------------------------------------------------------
@@ -74,6 +77,9 @@ TaskStatus SetAuxillaryFields(MeshData<Real> *md) {
           u_u = (ufloor)*utmp + (!ufloor) * uflr;
         }
       });
+
+
+
   return TaskStatus::complete;
 }
 
@@ -220,16 +226,24 @@ void PrimToCons(T *md) {
   const bool do_gas = artemis_pkg->template Param<bool>("do_gas");
   const bool do_dust = artemis_pkg->template Param<bool>("do_dust");
   const bool do_rad = artemis_pkg->template Param<bool>("do_moment");
+  const bool do_imc = artemis_pkg->template Param<bool>("do_imc");
 
   // Extract gas parameters
   Real dflr_gas = Null<Real>();
   Real sieflr_gas = Null<Real>();
   EOS eos_d;
+  MeanOpacity mopacity_d;
+  MeanScattering mscattering_d;
   if (do_gas) {
     auto &gas_pkg = pm->packages.Get("gas");
     dflr_gas = gas_pkg->template Param<Real>("dfloor");
     sieflr_gas = gas_pkg->template Param<Real>("siefloor");
     eos_d = gas_pkg->template Param<EOS>("eos_d");
+    // opacity types
+    if (do_imc) {
+      mopacity_d = gas_pkg->template Param<MeanOpacity>("mopacity_d");
+      mscattering_d = gas_pkg->template Param<MeanScattering>("mscattering_d");
+    }
   }
 
   // Extract dust parameters
@@ -252,6 +266,7 @@ void PrimToCons(T *md) {
       MakePackDescriptor<gas::cons::density, gas::cons::momentum, gas::cons::total_energy,
                          gas::cons::internal_energy, gas::prim::density,
                          gas::prim::velocity, gas::prim::pressure, gas::prim::sie,
+                         gas::opac::absorption, gas::opac::scattering,
                          dust::cons::density, dust::cons::momentum, dust::prim::density,
                          dust::prim::velocity, rad::cons::energy, rad::cons::flux,
                          rad::prim::energy, rad::prim::flux, rad::prim::pressure>(
@@ -304,6 +319,15 @@ void PrimToCons(T *md) {
             const Real ke = 0.5 * w_d * (SQR(vel1) + SQR(vel2) + SQR(vel3));
             Real &u_e = vmesh(b, gas::cons::total_energy(n), k, j, i);
             u_e = u_u + ke;
+
+            // Sync opacity (TODO: do_rad)
+            if (do_imc) {
+              Real &aa = vmesh(b, gas::opac::absorption(), k, j, i);
+              Real &ss = vmesh(b, gas::opac::scattering(), k, j, i);
+              const Real temp = eos_d.TemperatureFromDensityInternalEnergy(w_d, w_s);
+              aa = mopacity_d.AbsorptionCoefficient(w_d, temp);
+              ss = mscattering_d.RosselandMeanTotalScatteringCoefficient(w_d, temp);
+            }
           }
         }
 

--- a/src/derived/fill_derived.cpp
+++ b/src/derived/fill_derived.cpp
@@ -18,12 +18,9 @@
 #include "radiation/moments/moments.hpp"
 #include "utils/artemis_utils.hpp"
 #include "utils/eos/eos.hpp"
-#include "utils/opacity/opacity.hpp"
 
 using ArtemisUtils::EOS;
 using ArtemisUtils::VI;
-using ArtemisUtils::MeanOpacity;
-using ArtemisUtils::MeanScattering;
 
 namespace ArtemisDerived {
 //----------------------------------------------------------------------------------------
@@ -33,7 +30,6 @@ namespace ArtemisDerived {
 template <Coordinates GEOM>
 TaskStatus SetAuxillaryFields(MeshData<Real> *md) {
   using parthenon::MakePackDescriptor;
-  using TE = parthenon::TopologicalElement;
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
 
@@ -77,9 +73,6 @@ TaskStatus SetAuxillaryFields(MeshData<Real> *md) {
           u_u = (ufloor)*utmp + (!ufloor) * uflr;
         }
       });
-
-
-
   return TaskStatus::complete;
 }
 
@@ -90,7 +83,6 @@ TaskStatus SetAuxillaryFields(MeshData<Real> *md) {
 template <Coordinates GEOM>
 void ConsToPrim(MeshData<Real> *md) {
   using parthenon::MakePackDescriptor;
-  using TE = parthenon::TopologicalElement;
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
 
@@ -217,7 +209,6 @@ void ConsToPrim(MeshData<Real> *md) {
 template <typename T, Coordinates GEOM>
 void PrimToCons(T *md) {
   using parthenon::MakePackDescriptor;
-  using TE = parthenon::TopologicalElement;
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
 
@@ -232,18 +223,11 @@ void PrimToCons(T *md) {
   Real dflr_gas = Null<Real>();
   Real sieflr_gas = Null<Real>();
   EOS eos_d;
-  MeanOpacity mopacity_d;
-  MeanScattering mscattering_d;
   if (do_gas) {
     auto &gas_pkg = pm->packages.Get("gas");
     dflr_gas = gas_pkg->template Param<Real>("dfloor");
     sieflr_gas = gas_pkg->template Param<Real>("siefloor");
     eos_d = gas_pkg->template Param<EOS>("eos_d");
-    // opacity types
-    if (do_imc) {
-      mopacity_d = gas_pkg->template Param<MeanOpacity>("mopacity_d");
-      mscattering_d = gas_pkg->template Param<MeanScattering>("mscattering_d");
-    }
   }
 
   // Extract dust parameters
@@ -266,7 +250,6 @@ void PrimToCons(T *md) {
       MakePackDescriptor<gas::cons::density, gas::cons::momentum, gas::cons::total_energy,
                          gas::cons::internal_energy, gas::prim::density,
                          gas::prim::velocity, gas::prim::pressure, gas::prim::sie,
-                         gas::opac::absorption, gas::opac::scattering,
                          dust::cons::density, dust::cons::momentum, dust::prim::density,
                          dust::prim::velocity, rad::cons::energy, rad::cons::flux,
                          rad::prim::energy, rad::prim::flux, rad::prim::pressure>(
@@ -319,15 +302,6 @@ void PrimToCons(T *md) {
             const Real ke = 0.5 * w_d * (SQR(vel1) + SQR(vel2) + SQR(vel3));
             Real &u_e = vmesh(b, gas::cons::total_energy(n), k, j, i);
             u_e = u_u + ke;
-
-            // Sync opacity (TODO: do_rad)
-            if (do_imc) {
-              Real &aa = vmesh(b, gas::opac::absorption(), k, j, i);
-              Real &ss = vmesh(b, gas::opac::scattering(), k, j, i);
-              const Real temp = eos_d.TemperatureFromDensityInternalEnergy(w_d, w_s);
-              aa = mopacity_d.AbsorptionCoefficient(w_d, temp);
-              ss = mscattering_d.RosselandMeanTotalScatteringCoefficient(w_d, temp);
-            }
           }
         }
 

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -329,13 +329,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::prim::sie>(m, control_field, fluidids);
 
-  // Absorption and scattering opacity
-  m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
-  m.SetSparseThresholds(0.0, 0.0, 0.0);
-  gas->AddSparsePool<gas::opac::absorption>(m, control_field, fluidids);
-  gas->AddSparsePool<gas::opac::scattering>(m, control_field, fluidids);
-
   // Normal face Velocity for PdV evaluation of internal energy
   m = Metadata({Metadata::Face, Metadata::Derived, Metadata::OneCopy, Metadata::Sparse});
   m.SetSparseThresholds(0.0, 0.0, 0.0);

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -329,6 +329,13 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::prim::sie>(m, control_field, fluidids);
 
+  // Absorption and scattering opacity
+  m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy});
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  m.SetSparseThresholds(0.0, 0.0, 0.0);
+  gas->AddSparsePool<gas::opac::absorption>(m, control_field, fluidids);
+  gas->AddSparsePool<gas::opac::scattering>(m, control_field, fluidids);
+
   // Normal face Velocity for PdV evaluation of internal energy
   m = Metadata({Metadata::Face, Metadata::Derived, Metadata::OneCopy, Metadata::Sparse});
   m.SetSparseThresholds(0.0, 0.0, 0.0);

--- a/src/radiation/imc/imc_driver.cpp
+++ b/src/radiation/imc/imc_driver.cpp
@@ -29,7 +29,8 @@ namespace IMC {
 //! \brief Executes thermal IMC transport (Jaybenne) and syncs updated fields
 template <Coordinates GEOM>
 TaskListStatus JaybenneIMC(Mesh *pmesh, const Real time, const Real dt) {
-  auto status = rad::UpdateRadDataFields(pmesh).Execute();
+  auto status = Radiation::UpdateRadiationFields(pmesh).Execute();
+  if (status != TaskListStatus::complete) return status;
   status = jaybenne::RadiationStep(pmesh, time, dt).Execute();
   if (status != TaskListStatus::complete) return status;
   status = ArtemisDerived::SyncFields<GEOM>(pmesh, time, dt).Execute();

--- a/src/radiation/imc/imc_driver.cpp
+++ b/src/radiation/imc/imc_driver.cpp
@@ -15,6 +15,7 @@
 #include "artemis.hpp"
 #include "derived/fill_derived.hpp"
 #include "radiation/imc/imc.hpp"
+#include "radiation/radiation.hpp"
 
 // Jaybenne includes
 #include "jaybenne.hpp"
@@ -28,7 +29,8 @@ namespace IMC {
 //! \brief Executes thermal IMC transport (Jaybenne) and syncs updated fields
 template <Coordinates GEOM>
 TaskListStatus JaybenneIMC(Mesh *pmesh, const Real time, const Real dt) {
-  auto status = jaybenne::RadiationStep(pmesh, time, dt).Execute();
+  auto status = rad::UpdateRadDataFields(pmesh).Execute();
+  status = jaybenne::RadiationStep(pmesh, time, dt).Execute();
   if (status != TaskListStatus::complete) return status;
   status = ArtemisDerived::SyncFields<GEOM>(pmesh, time, dt).Execute();
   return status;

--- a/src/radiation/moments/matter_coupling.hpp
+++ b/src/radiation/moments/matter_coupling.hpp
@@ -26,10 +26,10 @@ using ArtemisUtils::MeanOpacity;
 using ArtemisUtils::MeanScattering;
 using ArtemisUtils::VI;
 
-namespace Radiation {
+namespace Moments {
 
 //----------------------------------------------------------------------------------------
-//! \fn TaskStatus Radiation::MatterCouplingSimpleImpl
+//! \fn TaskStatus Moments::MatterCouplingSimpleImpl
 //! \brief Implementation for simple radiation-matter coupling source
 template <Coordinates GEOM, Closure CLOSURE>
 TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
@@ -47,15 +47,15 @@ TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
   auto dflr = gas_pkg->template Param<Real>("dfloor");
   auto de_switch = gas_pkg->template Param<Real>("de_switch");
 
-  // Extract radiation package and params
-  auto &rad_pkg = pm->packages.Get("moments");
-  const auto chat = rad_pkg->template Param<Real>("chat");
-  const auto c = rad_pkg->template Param<Real>("c");
-  const auto arad = rad_pkg->template Param<Real>("arad");
-  const auto outer_max = rad_pkg->template Param<int>("outer_iteration_max");
-  const auto inner_max = rad_pkg->template Param<int>("inner_iteration_max");
-  const auto outer_tol = rad_pkg->template Param<Real>("outer_iteration_tol");
-  const auto inner_tol = rad_pkg->template Param<Real>("inner_iteration_tol");
+  // Extract radiation and moments package and params
+  auto &moments_pkg = pm->packages.Get("moments");
+  const auto chat = moments_pkg->template Param<Real>("chat");
+  const auto c = moments_pkg->template Param<Real>("c");
+  const auto arad = moments_pkg->template Param<Real>("arad");
+  const auto outer_max = moments_pkg->template Param<int>("outer_iteration_max");
+  const auto inner_max = moments_pkg->template Param<int>("inner_iteration_max");
+  const auto outer_tol = moments_pkg->template Param<Real>("outer_iteration_tol");
+  const auto inner_tol = moments_pkg->template Param<Real>("inner_iteration_tol");
 
   // Extract rotating frame quantities
   Real om0 = 0.0;
@@ -80,7 +80,7 @@ TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
   // Prepare scratch pad memory
   // const int ncells1 = ib.e - ib.s + 1 + 2 * parthenon::Globals::nghost;
   // int scr_size = ScratchPad1D<Real>::shmem_size(ncells1) * 12;
-  // const int scr_level = rad_pkg->template Param<int>("scr_level");
+  // const int scr_level = moments_pkg->template Param<int>("scr_level");
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "MatterCoupling", DevExecSpace(), 0, u0->NumBlocks() - 1,
       kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
@@ -182,7 +182,7 @@ TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn TaskStatus Radiation::MatterCouplingSimpleImpl
+//! \fn TaskStatus Moments::MatterCouplingSimpleImpl
 //! \brief Implementation for "full" radiation-matter coupling source
 template <Coordinates GEOM, Closure CLOSURE>
 TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
@@ -201,14 +201,14 @@ TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
   auto de_switch = gas_pkg->template Param<Real>("de_switch");
 
   // Extract radiation package and params
-  auto &rad_pkg = pm->packages.Get("moments");
-  const auto chat = rad_pkg->template Param<Real>("chat");
-  const auto c = rad_pkg->template Param<Real>("c");
-  const auto arad = rad_pkg->template Param<Real>("arad");
-  const auto outer_max = rad_pkg->template Param<int>("outer_iteration_max");
-  const auto inner_max = rad_pkg->template Param<int>("inner_iteration_max");
-  const auto outer_tol = rad_pkg->template Param<Real>("outer_iteration_tol");
-  const auto inner_tol = rad_pkg->template Param<Real>("inner_iteration_tol");
+  auto &moments_pkg = pm->packages.Get("moments");
+  const auto chat = moments_pkg->template Param<Real>("chat");
+  const auto c = moments_pkg->template Param<Real>("c");
+  const auto arad = moments_pkg->template Param<Real>("arad");
+  const auto outer_max = moments_pkg->template Param<int>("outer_iteration_max");
+  const auto inner_max = moments_pkg->template Param<int>("inner_iteration_max");
+  const auto outer_tol = moments_pkg->template Param<Real>("outer_iteration_tol");
+  const auto inner_tol = moments_pkg->template Param<Real>("inner_iteration_tol");
 
   // Extract rotating frame quantities
   Real om0 = 0.0;
@@ -234,7 +234,7 @@ TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
   // Prepare scratch pad memory
   // const int ncells1 = ib.e - ib.s + 1 + 2 * parthenon::Globals::nghost;
   // int scr_size = ScratchPad1D<Real>::shmem_size(ncells1) * 12;
-  // const int scr_level = rad_pkg->template Param<int>("scr_level");
+  // const int scr_level = moments_pkg->template Param<int>("scr_level");
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "MatterCoupling", DevExecSpace(), 0, u0->NumBlocks() - 1,
       kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
@@ -421,6 +421,6 @@ TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
   return TaskStatus::complete;
 }
 
-} // namespace Radiation
+} // namespace Moments
 
-#endif //  RADIATION_MOMENTS_MATTER_COUPLING_HPP_
+#endif // RADIATION_MOMENTS_MATTER_COUPLING_HPP_

--- a/src/radiation/moments/moments.cpp
+++ b/src/radiation/moments/moments.cpp
@@ -31,17 +31,17 @@ using ArtemisUtils::MeanOpacity;
 using ArtemisUtils::MeanScattering;
 using ArtemisUtils::VI;
 
-namespace Radiation {
+namespace Moments {
 //----------------------------------------------------------------------------------------
-//! \fn  StateDescriptor Radiation::Initialize
-//! \brief Adds intialization function for radiation hydrodynamics package
+//! \fn  StateDescriptor Moments::Initialize
+//! \brief Adds intialization function for moments package
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                                             ArtemisUtils::Constants &constants) {
-  auto radiation = std::make_shared<StateDescriptor>("moments");
-  Params &params = radiation->AllParams();
+  auto moments = std::make_shared<StateDescriptor>("moments");
+  Params &params = moments->AllParams();
 
   // Metadata flags
-  auto MetadataMoments = radiation->GetMetadataFlag();
+  auto MetadataMoments = moments->GetMetadataFlag();
   auto MetadataOperatorSplit = Metadata::GetUserFlag("OperatorSplit");
 
   // Closure type
@@ -106,13 +106,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   params.Add("full_coupling",
              pin->GetOrAddBoolean("radiation/moment", "full_coupling", true));
 
-  // We stuff some constants into params so that can be used in post-processing
+  // Radiation constants (including chat for Moments)
+  // NOTE(@pdmullen): These are also stored in top level radiation package...
   const Real light = constants.GetCCode();
   params.Add("c", light);
-  const Real creduc = pin->GetOrAddReal("radiation/moment", "creduc", 1.0);
-  params.Add("chat", light / creduc);
   const Real arad = constants.GetARCode();
   params.Add("arad", arad);
+  const Real creduc = pin->GetOrAddReal("radiation/moment", "creduc", 1.0);
+  params.Add("chat", light / creduc);
 
   // Floors
   const Real efloor = pin->GetOrAddReal("radiation/moment", "efloor", 1.0e-20);
@@ -151,7 +152,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                          MetadataOperatorSplit});
   ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
-  radiation->AddSparsePool<rad::cons::energy>(m, control_field, fluidids);
+  moments->AddSparsePool<rad::cons::energy>(m, control_field, fluidids);
 
   // Conserved Flux
   m = Metadata({Metadata::Cell, Metadata::Vector, Metadata::Conserved,
@@ -160,7 +161,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                std::vector<int>({3}));
   ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
-  radiation->AddSparsePool<rad::cons::flux>(m, control_field, fluidids);
+  moments->AddSparsePool<rad::cons::flux>(m, control_field, fluidids);
 
   // Primitive Energy Density
   m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::Intensive, Metadata::OneCopy,
@@ -168,7 +169,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                 MetadataOperatorSplit});
   ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
-  radiation->AddSparsePool<rad::prim::energy>(m, control_field, fluidids);
+  moments->AddSparsePool<rad::prim::energy>(m, control_field, fluidids);
 
   // Primitive Pressure (and associated Riemann pressures)
   m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::Intensive, Metadata::OneCopy,
@@ -176,7 +177,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                 MetadataOperatorSplit});
   ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
-  radiation->AddSparsePool<rad::prim::pressure>(m, control_field, fluidids);
+  moments->AddSparsePool<rad::prim::pressure>(m, control_field, fluidids);
 
   // Primitive Reduced Flux
   m = Metadata({Metadata::Cell, Metadata::Vector, Metadata::Derived, Metadata::Intensive,
@@ -185,7 +186,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                std::vector<int>({3}));
   ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
-  radiation->AddSparsePool<rad::prim::flux>(m, control_field, fluidids);
+  moments->AddSparsePool<rad::prim::flux>(m, control_field, fluidids);
 
   // Radiation refinement criterion
   const std::string refine_field =
@@ -217,42 +218,42 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
       // Cartesian
       if (coords == G::cartesian) {
         if (ref_dens) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::cartesian>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::cartesian>;
         } else if (ref_pres) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::cartesian>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::cartesian>;
         }
         // Spherical
       } else if (coords == G::spherical1D) {
         if (ref_dens) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::spherical1D>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::spherical1D>;
         } else if (ref_pres) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::spherical1D>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::spherical1D>;
         }
       } else if (coords == G::spherical2D) {
         if (ref_dens) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::spherical2D>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::spherical2D>;
         } else if (ref_pres) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::spherical2D>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::spherical2D>;
         }
       } else if (coords == G::spherical3D) {
         if (ref_dens) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::spherical3D>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::spherical3D>;
         } else if (ref_pres) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::spherical3D>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::spherical3D>;
         }
         // Cylindrical
       } else if (coords == G::cylindrical) {
         if (ref_dens) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::cylindrical>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::cylindrical>;
         } else if (ref_pres) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::cylindrical>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::cylindrical>;
         }
         // Axisymmetric
       } else if (coords == G::axisymmetric) {
         if (ref_dens) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::axisymmetric>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<pdens, G::axisymmetric>;
         } else if (ref_pres) {
-          radiation->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::axisymmetric>;
+          moments->CheckRefinementBlock = ScalarFirstDerivative<ppres, G::axisymmetric>;
         }
       }
     } else if (ref_mag) {
@@ -262,19 +263,19 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
       params.Add("refine_thr", rthr);
       params.Add("deref_thr", dthr);
       if (ref_dens) {
-        radiation->CheckRefinementBlock = ScalarMagnitude<rad::prim::energy>;
+        moments->CheckRefinementBlock = ScalarMagnitude<rad::prim::energy>;
       } else if (ref_pres) {
-        radiation->CheckRefinementBlock = ScalarMagnitude<rad::prim::pressure>;
+        moments->CheckRefinementBlock = ScalarMagnitude<rad::prim::pressure>;
       }
     }
   }
 
-  return radiation;
+  return moments;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn  TaskStatus Radiation::CalculateFluxes
-//! \brief Evaluates advective fluxes for radiation evolution
+//! \fn  TaskStatus Moments::CalculateFluxes
+//! \brief Evaluates advective fluxes for moments evolution
 TaskStatus CalculateFluxes(MeshData<Real> *md) {
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
@@ -305,8 +306,8 @@ TaskStatus CalculateFluxes(MeshData<Real> *md) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn  TaskStatus Radiation::FluxSource
-//! \brief Evaluates coordinate terms from advective fluxes for radiation evolution
+//! \fn  TaskStatus Moments::FluxSource
+//! \brief Evaluates coordinate terms from advective fluxes for moments evolution
 TaskStatus FluxSource(MeshData<Real> *md, const Real dt) {
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
@@ -348,9 +349,9 @@ TaskStatus MatterCoupling(MeshData<Real> *u0, const Real dt) {
   if (!(do_gas)) return TaskStatus::complete;
 
   // Extract moments package and params
-  auto &radiation_pkg = pm->packages.Get("moments");
-  auto closure_type = radiation_pkg->template Param<Closure>("closure_type");
-  auto full_coupling = radiation_pkg->template Param<bool>("full_coupling");
+  auto &moments_pkg = pm->packages.Get("moments");
+  auto closure_type = moments_pkg->template Param<Closure>("closure_type");
+  auto full_coupling = moments_pkg->template Param<bool>("full_coupling");
 
   // Call MatterCoupling with appropriate GEOM, Fluid, and Closure type given coupling
   if (closure_type == Closure::m1) {
@@ -380,4 +381,4 @@ template TaskStatus MatterCoupling<G::spherical1D>(MD *u0, const Real dt);
 template TaskStatus MatterCoupling<G::spherical2D>(MD *u0, const Real dt);
 template TaskStatus MatterCoupling<G::spherical3D>(MD *u0, const Real dt);
 
-} // namespace Radiation
+} // namespace Moments

--- a/src/radiation/moments/moments.hpp
+++ b/src/radiation/moments/moments.hpp
@@ -18,7 +18,7 @@
 #include "utils/integrators/artemis_integrator.hpp"
 #include "utils/units.hpp"
 
-namespace Radiation {
+namespace Moments {
 
 //----------------------------------------------------------------------------------------
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
@@ -40,12 +40,12 @@ TaskCollection MomentsTasks(Mesh *pmesh, const SimTime &tm,
                             parthenon::LowStorageIntegrator *integrator);
 
 //----------------------------------------------------------------------------------------
-//! \fn Real Radiation::EstimateTimeStep
+//! \fn Real Moments::EstimateTimeStep
 //! \brief Not enrolled in parthenon's determination for global dt
 template <Coordinates GEOM>
 Real EstimateTimeStep(parthenon::Mesh *pmesh) {
-  auto &radiation_pkg = pmesh->packages.Get("moments");
-  auto &params = radiation_pkg->AllParams();
+  auto &moments_pkg = pmesh->packages.Get("moments");
+  auto &params = moments_pkg->AllParams();
 
   Real dxmin = Big<Real>();
   if constexpr (geometry::is_cartesian<GEOM>()) {
@@ -71,7 +71,7 @@ Real EstimateTimeStep(parthenon::Mesh *pmesh) {
       // Compute minimum dx
       Real min_dx = Big<Real>();
       parthenon::par_reduce(
-          parthenon::loop_pattern_mdrange_tag, "Radiation::EstimateTimestepMesh",
+          parthenon::loop_pattern_mdrange_tag, "Moments::EstimateTimestepMesh",
           DevExecSpace(), 0, md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
           KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &ldx_m) {
             // Extract coordinates
@@ -97,7 +97,7 @@ Real EstimateTimeStep(parthenon::Mesh *pmesh) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real Radiation::EddingtonFactor
+//! \fn Real Moments::EddingtonFactor
 //! \brief Computes Eddington factor given closure model
 template <Closure CTYP>
 KOKKOS_INLINE_FUNCTION Real EddingtonFactor(const Real f) {
@@ -113,7 +113,7 @@ KOKKOS_INLINE_FUNCTION Real EddingtonFactor(const Real f) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn std::array<Real, 6> Radiation::EddingtonTensor
+//! \fn std::array<Real, 6> Moments::EddingtonTensor
 //! \brief Computes entries of Eddington tensor given closure model
 template <Closure CTYP>
 KOKKOS_INLINE_FUNCTION std::array<Real, 6>
@@ -139,7 +139,7 @@ EddingtonTensor(const std::array<Real, 3> fred) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn std::tuple<Real, Real> Radiation::WaveSpeed
+//! \fn std::tuple<Real, Real> Moments::WaveSpeed
 //! \brief Computes wavespeed given closure model
 template <Closure CTYP>
 KOKKOS_INLINE_FUNCTION std::tuple<Real, Real> WaveSpeed(const Real mu, const Real f) {
@@ -160,7 +160,7 @@ KOKKOS_INLINE_FUNCTION std::tuple<Real, Real> WaveSpeed(const Real mu, const Rea
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn std::array<Real, 3> Radiation::NormalizeFlux
+//! \fn std::array<Real, 3> Moments::NormalizeFlux
 //! \brief Normalize radiation flux
 KOKKOS_INLINE_FUNCTION
 std::array<Real, 3> NormalizeFlux(const Real fx1, const Real fx2, const Real fx3) {
@@ -174,7 +174,7 @@ std::array<Real, 3> NormalizeFlux(const Real fx1, const Real fx2, const Real fx3
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real Radiation::FleckFactor
+//! \fn Real Moments::FleckFactor
 //! \brief Returns Fleck factor dB/dE
 KOKKOS_INLINE_FUNCTION
 Real FleckFactor(const Real ar, const Real T, const Real cv) {
@@ -182,7 +182,7 @@ Real FleckFactor(const Real ar, const Real T, const Real cv) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn std::array<Real, 3> Radiation::SolveRadFlux
+//! \fn std::array<Real, 3> Moments::SolveRadFlux
 //! \brief
 //!
 //!   Invert this matrix:
@@ -211,6 +211,6 @@ std::array<Real, 3> SolveRadFlux(const Real a, const Real b,
               idet};
 }
 
-} // namespace Radiation
+} // namespace Moments
 
 #endif // RADIATION_MOMENTS_MOMENTS_HPP_

--- a/src/radiation/moments/moments_driver.cpp
+++ b/src/radiation/moments/moments_driver.cpp
@@ -18,7 +18,7 @@
 #include "utils/integrators/artemis_integrator.hpp"
 #include "utils/units.hpp"
 
-namespace Radiation {
+namespace Moments {
 
 //----------------------------------------------------------------------------------------
 //! \fn TaskListStatus MomentsDriver
@@ -27,7 +27,7 @@ template <Coordinates GEOM>
 TaskListStatus MomentsDriver(Mesh *pmesh, const SimTime &tm,
                              parthenon::LowStorageIntegrator *integrator) {
   // Craft a series of **equal** substeps that sum to the unsplit step
-  const Real dtlimit = Radiation::EstimateTimeStep<GEOM>(pmesh);
+  const Real dtlimit = Moments::EstimateTimeStep<GEOM>(pmesh);
   const int nsteps = static_cast<int>(std::ceil(integrator->dt / dtlimit));
   integrator->dt = integrator->dt / nsteps;
 
@@ -95,7 +95,7 @@ TaskCollection MomentsTasks(Mesh *pmesh, const SimTime &tm,
       auto start_flx_recv = tl.AddTask(none, parthenon::StartReceiveFluxCorrections, u0m);
 
       // Compute radiation fluxes
-      auto rad_flx = tl.AddTask(none, Radiation::CalculateFluxes, u0m.get());
+      auto rad_flx = tl.AddTask(none, Moments::CalculateFluxes, u0m.get());
 
       // Communicate and set fluxes
       auto send_flx = tl.AddTask(
@@ -110,12 +110,11 @@ TaskCollection MomentsTasks(Mesh *pmesh, const SimTime &tm,
                                 u1.get(), g0, g1, 0.0);
 
       // Apply "coordinate source terms"
-      auto coord_src =
-          tl.AddTask(rupdate | cupdate, Radiation::FluxSource, u0m.get(), bdt);
+      auto coord_src = tl.AddTask(rupdate | cupdate, Moments::FluxSource, u0m.get(), bdt);
 
       // Apply matter-coupling step
       auto coupling =
-          tl.AddTask(coord_src, Radiation::MatterCoupling<GEOM>, u0c.get(), bdt);
+          tl.AddTask(coord_src, Moments::MatterCoupling<GEOM>, u0c.get(), bdt);
 
       // Set auxillary fields
       auto set_aux =
@@ -155,4 +154,4 @@ template TaskCollection MomentsTasks<G::spherical2D>(M *pm, const ST &t, LSI *ii
 template TaskCollection MomentsTasks<G::spherical3D>(M *pm, const ST &t, LSI *ii);
 template TaskCollection MomentsTasks<G::axisymmetric>(M *pm, const ST &t, LSI *ii);
 
-} // namespace Radiation
+} // namespace Moments

--- a/src/radiation/params.yaml
+++ b/src/radiation/params.yaml
@@ -149,8 +149,3 @@ radiation:
       _type: bool
       _description: "Radiation affects host fluid fields."
       _default: true
-
-
-
-
-

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -1,0 +1,106 @@
+//========================================================================================
+// (C) (or copyright) 2025. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+// Artemis includes
+#include "artemis.hpp"
+#include "geometry/geometry.hpp"
+#include "utils/artemis_utils.hpp"
+#include "utils/eos/eos.hpp"
+#include "utils/opacity/opacity.hpp"
+
+using ArtemisUtils::EOS;
+using ArtemisUtils::MeanOpacity;
+using ArtemisUtils::MeanScattering;
+
+namespace rad {
+
+std::shared_ptr<StateDescriptor> InitializeRadDataFields(ParameterInput *pin) {
+
+  // instantiate a state descriptor for the fields
+  auto rad_fs = std::make_shared<StateDescriptor>("rad_fields");
+
+  // Only one photon species
+  std::vector<int> radids = {0};
+
+  // Control field for sparse gas fields
+  const std::string control_field = "rad_fields";
+
+  // const int ndim = ProblemDimension(pin);
+  // std::string sys = pin->GetOrAddString("artemis", "coordinates", "cartesian");
+  // Coordinates coords = geometry::CoordSelect(sys, ndim);
+
+  // Absorption and scattering opacity
+  Metadata m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Sparse});
+  //ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  //m.SetSparseThresholds(0.0, 0.0, 0.0);
+  rad_fs->AddSparsePool<rad::opac::absorption>(m, control_field, radids);
+  rad_fs->AddSparsePool<rad::opac::scattering>(m, control_field, radids);
+
+  // return rad_fields state descriptor
+  return rad_fs;
+}
+
+TaskStatus UpRadDataFields(MeshData<Real> *md) {
+  using parthenon::MakePackDescriptor;
+  auto pm = md->GetParentPointer();
+  auto &resolved_pkgs = pm->resolved_packages;
+  auto &gas_pkg = pm->packages.Get("gas");
+
+  EOS eos_d = gas_pkg->template Param<EOS>("eos_d");
+  MeanOpacity opacity_d = gas_pkg->template Param<MeanOpacity>("opacity_d");
+  MeanScattering scattering_d = gas_pkg->template Param<MeanScattering>("scattering_d");
+
+  // Packing and indexing (TODO: use dust sie, density)
+  static auto desc = MakePackDescriptor<
+      gas::prim::density, gas::prim::sie,
+      rad::opac::absorption, rad::opac::scattering>(resolved_pkgs.get());
+  auto vmesh = desc.GetPack(md);
+  const int nblocks = md->NumBlocks();
+  IndexRange ib = md->GetBoundsI(IndexDomain::interior);
+  IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
+  IndexRange kb = md->GetBoundsK(IndexDomain::interior);
+
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "ConsToPrim", parthenon::DevExecSpace(), 0,
+      md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
+
+        const Real &rho = vmesh(b, gas::prim::density(), k, j, i);
+        const Real &sie = vmesh(b, gas::prim::sie(), k, j, i);
+        const Real temp = eos_d.TemperatureFromDensityInternalEnergy(rho, sie);
+        Real &aa = vmesh(b, rad::opac::absorption(), k, j, i);
+        Real &ss = vmesh(b, rad::opac::scattering(), k, j, i);
+
+        aa = opacity_d.AbsorptionCoefficient(rho, temp);
+        ss = scattering_d.RosselandMeanTotalScatteringCoefficient(rho, temp);
+      });
+
+  return TaskStatus::complete;
+}
+
+// task collection for updating data fields
+TaskCollection UpdateRadDataFields(Mesh *pmesh) {
+  TaskCollection tc;
+  TaskID none(0);
+  const int num_partitions = pmesh->DefaultNumPartitions();
+  auto &reg = tc.AddRegion(num_partitions);
+  for (int i = 0; i < num_partitions; i++) {
+    auto &tl = reg[i];
+    auto &base = pmesh->mesh_data.GetOrAdd("base", i);
+    auto upradf = tl.AddTask(none, UpRadDataFields, base.get());
+  }
+
+  return tc;
+}
+
+} // namespace rad

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -12,45 +12,69 @@
 //========================================================================================
 
 // Artemis includes
+#include "radiation.hpp"
 #include "artemis.hpp"
 #include "geometry/geometry.hpp"
 #include "utils/artemis_utils.hpp"
 #include "utils/eos/eos.hpp"
 #include "utils/opacity/opacity.hpp"
+#include "utils/units.hpp"
 
 using ArtemisUtils::EOS;
 using ArtemisUtils::MeanOpacity;
 using ArtemisUtils::MeanScattering;
 
-namespace rad {
+namespace Radiation {
+//----------------------------------------------------------------------------------------
+//! \fn  StateDescriptor Radiation::Initialize
+//! \brief Adds intialization function for radiation package
+//! NOTE(@pdmullen): ...to become a top-level package for radiation utils commmon to impl
+std::shared_ptr<StateDescriptor>
+Initialize(ParameterInput *pin, ArtemisUtils::Constants &constants, const bool do_imc) {
+  auto radiation = std::make_shared<StateDescriptor>("radiation");
+  Params &params = radiation->AllParams();
 
-std::shared_ptr<StateDescriptor> InitializeRadDataFields(ParameterInput *pin) {
+  // Metadata flags
+  auto MetadataRadiation = radiation->GetMetadataFlag();
+  auto MetadataOperatorSplit = Metadata::GetUserFlag("OperatorSplit");
 
-  // instantiate a state descriptor for the fields
-  auto rad_fs = std::make_shared<StateDescriptor>("rad_fields");
+  // Radiation constants (including chat for Moments)
+  // NOTE(@pdmullen): We require constants again in moments sector (when
+  // moments enabled) due to our anonymous flux machinery
+  const Real light = constants.GetCCode();
+  params.Add("c", light);
+  const Real arad = constants.GetARCode();
+  params.Add("arad", arad);
+  const Real creduc = pin->GetOrAddReal("radiation/moment", "creduc", 1.0);
+  params.Add("chat", light / creduc);
 
-  // Only one photon species
-  std::vector<int> radids = {0};
+  // Add derived radiation fields expected by Jaybenne
+  if (do_imc) {
+    // Number of radiation species (i.e., groups)
+    const int nspecies = pin->GetOrAddInteger("radiation/imc", "nspecies", 1);
+    params.Add("nspecies", nspecies);
+    PARTHENON_REQUIRE(nspecies == 1, "Jaybenne IMC only works with nspecies=1!");
+    std::vector<int> fluidids;
+    for (int n = 0; n < nspecies; ++n)
+      fluidids.push_back(n);
 
-  // Control field for sparse gas fields
-  const std::string control_field = "rad_fields";
+    // Control field for sparse gas fields
+    const std::string control_field = rad::opac::absorption::name();
 
-  // const int ndim = ProblemDimension(pin);
-  // std::string sys = pin->GetOrAddString("artemis", "coordinates", "cartesian");
-  // Coordinates coords = geometry::CoordSelect(sys, ndim);
+    // Absorption and scattering opacity
+    Metadata m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy,
+                           Metadata::Sparse, MetadataRadiation, MetadataOperatorSplit});
+    radiation->AddSparsePool<rad::opac::absorption>(m, control_field, fluidids);
+    radiation->AddSparsePool<rad::opac::scattering>(m, control_field, fluidids);
+  }
 
-  // Absorption and scattering opacity
-  Metadata m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Sparse});
-  //ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
-  //m.SetSparseThresholds(0.0, 0.0, 0.0);
-  rad_fs->AddSparsePool<rad::opac::absorption>(m, control_field, radids);
-  rad_fs->AddSparsePool<rad::opac::scattering>(m, control_field, radids);
-
-  // return rad_fields state descriptor
-  return rad_fs;
+  return radiation;
 }
 
-TaskStatus UpRadDataFields(MeshData<Real> *md) {
+//----------------------------------------------------------------------------------------
+//! \fn  TaskStatus Radiation::SetOpacities
+//! \brief Routine to set opacitiy fields (when required, e.g., for Jaybenne IMC)
+TaskStatus SetOpacities(MeshData<Real> *md) {
   using parthenon::MakePackDescriptor;
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
@@ -60,21 +84,21 @@ TaskStatus UpRadDataFields(MeshData<Real> *md) {
   MeanOpacity opacity_d = gas_pkg->template Param<MeanOpacity>("opacity_d");
   MeanScattering scattering_d = gas_pkg->template Param<MeanScattering>("scattering_d");
 
-  // Packing and indexing (TODO: use dust sie, density)
-  static auto desc = MakePackDescriptor<
-      gas::prim::density, gas::prim::sie,
-      rad::opac::absorption, rad::opac::scattering>(resolved_pkgs.get());
+  // Packing and indexing
+  // TODO(): Will eventually incorporate other fluids
+  static auto desc =
+      MakePackDescriptor<gas::prim::density, gas::prim::sie, rad::opac::absorption,
+                         rad::opac::scattering>(resolved_pkgs.get());
   auto vmesh = desc.GetPack(md);
-  const int nblocks = md->NumBlocks();
-  IndexRange ib = md->GetBoundsI(IndexDomain::interior);
-  IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
-  IndexRange kb = md->GetBoundsK(IndexDomain::interior);
+  IndexRange ib = md->GetBoundsI(IndexDomain::entire);
+  IndexRange jb = md->GetBoundsJ(IndexDomain::entire);
+  IndexRange kb = md->GetBoundsK(IndexDomain::entire);
 
+  // Set opacities
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "ConsToPrim", parthenon::DevExecSpace(), 0,
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
-
         const Real &rho = vmesh(b, gas::prim::density(), k, j, i);
         const Real &sie = vmesh(b, gas::prim::sie(), k, j, i);
         const Real temp = eos_d.TemperatureFromDensityInternalEnergy(rho, sie);
@@ -88,8 +112,10 @@ TaskStatus UpRadDataFields(MeshData<Real> *md) {
   return TaskStatus::complete;
 }
 
-// task collection for updating data fields
-TaskCollection UpdateRadDataFields(Mesh *pmesh) {
+//----------------------------------------------------------------------------------------
+//! \fn  TaskCollection Radiation::UpdateRadiationFields
+//! \brief TaskCollection to set radiation fields (when required, e.g., for Jaybenne IMC)
+TaskCollection UpdateRadiationFields(Mesh *pmesh) {
   TaskCollection tc;
   TaskID none(0);
   const int num_partitions = pmesh->DefaultNumPartitions();
@@ -97,10 +123,10 @@ TaskCollection UpdateRadDataFields(Mesh *pmesh) {
   for (int i = 0; i < num_partitions; i++) {
     auto &tl = reg[i];
     auto &base = pmesh->mesh_data.GetOrAdd("base", i);
-    auto upradf = tl.AddTask(none, UpRadDataFields, base.get());
+    auto set_opac = tl.AddTask(none, SetOpacities, base.get());
   }
 
   return tc;
 }
 
-} // namespace rad
+} // namespace Radiation

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -10,9 +10,20 @@
 // license in this material to reproduce, prepare derivative works, distribute copies to
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
+#ifndef RADIATION_RADIATION_HPP_
+#define RADIATION_RADIATION_HPP_
 
-namespace rad {
-std::shared_ptr<StateDescriptor> InitializeRadDataFields(ParameterInput *pin);
-TaskStatus UpRadDataFields(MeshData<Real> *md);
-TaskCollection UpdateRadDataFields(Mesh *pmesh);
-} // namespace rad
+#include "artemis.hpp"
+#include "utils/units.hpp"
+
+namespace Radiation {
+
+std::shared_ptr<StateDescriptor>
+Initialize(ParameterInput *pin, ArtemisUtils::Constants &constants, const bool do_imc);
+
+TaskStatus SetOpacities(MeshData<Real> *md);
+TaskCollection UpdateRadiationFields(Mesh *pmesh);
+
+} // namespace Radiation
+
+#endif // RADIATION_RADIATION_HPP_

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -1,0 +1,18 @@
+//========================================================================================
+// (C) (or copyright) 2025. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+namespace rad {
+std::shared_ptr<StateDescriptor> InitializeRadDataFields(ParameterInput *pin);
+TaskStatus UpRadDataFields(MeshData<Real> *md);
+TaskCollection UpdateRadDataFields(Mesh *pmesh);
+} // namespace rad

--- a/src/utils/fluxes/fluid_fluxes.hpp
+++ b/src/utils/fluxes/fluid_fluxes.hpp
@@ -377,7 +377,7 @@ TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FAC
               const Real &fy = vp_(b, IVY, k, j, i);
               const Real &fz = vp_(b, IVZ, k, j, i);
               const Real ff = std::sqrt(SQR(fx) + SQR(fy) + SQR(fz));
-              const Real chi = Radiation::EddingtonFactor<C>(ff);
+              const Real chi = Moments::EddingtonFactor<C>(ff);
               wdt *= (3.0 * chi - 1.0) * hcchat_ / (ff + Fuzz<Real>());
             }
 

--- a/src/utils/fluxes/riemann/hlle.hpp
+++ b/src/utils/fluxes/riemann/hlle.hpp
@@ -273,10 +273,10 @@ struct RiemannSolver<RSolver::hlle, FLUID_TYPE, CTYPE,
             fr = std::min(1.0, fr);
 
             // Wave speeds
-            const Real chil = Radiation::EddingtonFactor<CTYPE>(fl);
-            const Real chir = Radiation::EddingtonFactor<CTYPE>(fr);
-            const auto [sla, slb] = Radiation::WaveSpeed<CTYPE>(nlx, fl);
-            const auto [sra, srb] = Radiation::WaveSpeed<CTYPE>(nrx, fr);
+            const Real chil = Moments::EddingtonFactor<CTYPE>(fl);
+            const Real chir = Moments::EddingtonFactor<CTYPE>(fr);
+            const auto [sla, slb] = Moments::WaveSpeed<CTYPE>(nlx, fl);
+            const auto [sra, srb] = Moments::WaveSpeed<CTYPE>(nrx, fr);
             const Real sl = std::min(sla, slb);
             const Real sr = std::max(sra, srb);
 

--- a/src/utils/fluxes/riemann/llf.hpp
+++ b/src/utils/fluxes/riemann/llf.hpp
@@ -223,10 +223,10 @@ struct RiemannSolver<RSolver::llf, FLUID_TYPE, CTYPE,
             fr = std::min(1.0, fr);
 
             // Wave speeds
-            const Real chil = Radiation::EddingtonFactor<CTYPE>(fl);
-            const Real chir = Radiation::EddingtonFactor<CTYPE>(fr);
-            const auto [sla, slb] = Radiation::WaveSpeed<CTYPE>(nlx, fl);
-            const auto [sra, srb] = Radiation::WaveSpeed<CTYPE>(nrx, fr);
+            const Real chil = Moments::EddingtonFactor<CTYPE>(fl);
+            const Real chir = Moments::EddingtonFactor<CTYPE>(fr);
+            const auto [sla, slb] = Moments::WaveSpeed<CTYPE>(nlx, fl);
+            const auto [sra, srb] = Moments::WaveSpeed<CTYPE>(nrx, fr);
             const Real sl = std::min(sla, slb);
             const Real sr = std::max(sra, srb);
 

--- a/tst/scripts/radiation/rad_shock_cgs.py
+++ b/tst/scripts/radiation/rad_shock_cgs.py
@@ -73,7 +73,7 @@ def analyze():
         os.path.join(artemis.get_data_dir(), "{}.out1.final.phdf".format(_file_id)), "r"
     ) as f:
         cv = f["Params"].attrs["gas/cv"]
-        ar = f["Params"].attrs["moments/arad"]
+        ar = f["Params"].attrs["radiation/arad"]
         xm = f["Locations/x"][...].ravel()
         xc = 0.5 * (xm[:-1] + xm[1:])
         sie = f["gas.prim.sie_0"][...].ravel()


### PR DESCRIPTION
## Background

* Jaybenne will use precomputed opacity in the transport kernel, requiring scattering and absorption fields.

## Description of Changes

* Precompute gray opacity.

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
