### PR TITLE
Fix for small rad flux in curvilinear

### DIFF
--- a/src/radiation/moments/moments.hpp
+++ b/src/radiation/moments/moments.hpp
@@ -97,15 +97,15 @@ Real EstimateTimeStep(parthenon::Mesh *pmesh) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real Moments::EddingtonFactor
-//! \brief Computes Eddington factor given closure model
+//! \fn Real Moments::ThriceEddingtonFactor
+//! \brief Computes 3x the Eddington factor given closure model
 template <Closure CTYP>
-KOKKOS_INLINE_FUNCTION Real EddingtonFactor(const Real f) {
+KOKKOS_INLINE_FUNCTION Real ThriceEddingtonFactor(const Real f) {
   if constexpr (CTYP == Closure::p1) {
-    return ONE_3RD;
+    return 1.0;
   } else if (CTYP == Closure::m1) {
     const Real f2 = f * f;
-    return (3. + 4. * f2) / (5. + 2. * std::sqrt(4. - 3. * f2));
+    return 3. * (3. + 4. * f2) / (5. + 2. * std::sqrt(4. - 3. * f2));
   } else {
     PARTHENON_FAIL("Closure model not recognized!");
     return 0;
@@ -127,9 +127,9 @@ EddingtonTensor(const std::array<Real, 3> fred) {
                           fred[2] / (fmag + Fuzz<Real>())};
     fmag = std::min(1.0, fmag);
     const std::array<Real, 3> f{n[0] * fmag, n[1] * fmag, n[2] * fmag};
-    const Real chi = EddingtonFactor<CTYP>(fmag);
-    const Real ca = 0.5 * (1. - chi);
-    const Real cb = 0.5 * (3 * chi - 1.);
+    const Real chi = ThriceEddingtonFactor<CTYP>(fmag);
+    const Real ca = (3. - chi) / 6.0;
+    const Real cb = 0.5 * (chi - 1.);
     return {ca + cb * n[0] * n[0], ca + cb * n[1] * n[1], ca + cb * n[2] * n[2],
             cb * n[1] * n[2],      cb * n[0] * n[2],      cb * n[0] * n[1]};
   } else {

--- a/src/utils/fluxes/fluid_fluxes.hpp
+++ b/src/utils/fluxes/fluid_fluxes.hpp
@@ -284,7 +284,10 @@ TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FAC
         const auto dh3 = (x3dep) ? coords.GetConnX3() : NewArray<Real, 3>(0.0);
 
         // Get the rotational velocity
-        const auto rfv = RotatingFrame::RotationVelocity<G>(coords.GetCellCenter(), omf);
+        std::array<Real, 3> rfv{0.0};
+        if constexpr (F != Fluid::radiation) {
+          rfv = RotatingFrame::RotationVelocity<G>(coords.GetCellCenter(), omf);
+        }
 
         // Timestep weighted by dx
         geometry::BBox bnds = coords.bnds;
@@ -377,8 +380,8 @@ TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FAC
               const Real &fy = vp_(b, IVY, k, j, i);
               const Real &fz = vp_(b, IVZ, k, j, i);
               const Real ff = std::sqrt(SQR(fx) + SQR(fy) + SQR(fz));
-              const Real chi = Moments::EddingtonFactor<C>(ff);
-              wdt *= (3.0 * chi - 1.0) * hcchat_ / (ff + Fuzz<Real>());
+              const Real chi = Moments::ThriceEddingtonFactor<C>(ff);
+              wdt *= ((chi - 1.) / (ff + Fuzz<Real>())) * hcchat_;
             }
 
             // Update momenta

--- a/src/utils/fluxes/fluid_fluxes.hpp
+++ b/src/utils/fluxes/fluid_fluxes.hpp
@@ -285,8 +285,9 @@ TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FAC
 
         // Get the rotational velocity
         std::array<Real, 3> rfv{0.0};
+        [[maybe_unused]] Real omf_ = omf;
         if constexpr (F != Fluid::radiation) {
-          rfv = RotatingFrame::RotationVelocity<G>(coords.GetCellCenter(), omf);
+          rfv = RotatingFrame::RotationVelocity<G>(coords.GetCellCenter(), omf_);
         }
 
         // Timestep weighted by dx

--- a/src/utils/fluxes/riemann/hlle.hpp
+++ b/src/utils/fluxes/riemann/hlle.hpp
@@ -273,22 +273,22 @@ struct RiemannSolver<RSolver::hlle, FLUID_TYPE, CTYPE,
             fr = std::min(1.0, fr);
 
             // Wave speeds
-            const Real chil = Moments::EddingtonFactor<CTYPE>(fl);
-            const Real chir = Moments::EddingtonFactor<CTYPE>(fr);
+            const Real chil = Moments::ThriceEddingtonFactor<CTYPE>(fl);
+            const Real chir = Moments::ThriceEddingtonFactor<CTYPE>(fr);
             const auto [sla, slb] = Moments::WaveSpeed<CTYPE>(nlx, fl);
             const auto [sra, srb] = Moments::WaveSpeed<CTYPE>(nrx, fr);
             const Real sl = std::min(sla, slb);
             const Real sr = std::max(sra, srb);
 
             // Scales
-            const Real pscalel = chat * c * 0.5 * (1.0 - chil);
-            const Real pscaler = chat * c * 0.5 * (1.0 - chir);
+            const Real pscalel = chat * c * (3.0 - chil) / 6.0;
+            const Real pscaler = chat * c * (3.0 - chir) / 6.0;
             const Real wl_ipr = pscalel * wl_idn;
             const Real wr_ipr = pscaler * wr_idn;
             const Real norml = fl * fl;
             const Real normr = fr * fr;
-            const Real scalel = c * 0.5 * (3. * chil - 1.);
-            const Real scaler = c * 0.5 * (3. * chir - 1.);
+            const Real scalel = c * 0.5 * (chil - 1.);
+            const Real scaler = c * 0.5 * (chir - 1.);
 
             // following min/max set to TINY_NUMBER to fix bug found in converging
             // supersonic flow

--- a/src/utils/fluxes/riemann/llf.hpp
+++ b/src/utils/fluxes/riemann/llf.hpp
@@ -223,18 +223,18 @@ struct RiemannSolver<RSolver::llf, FLUID_TYPE, CTYPE,
             fr = std::min(1.0, fr);
 
             // Wave speeds
-            const Real chil = Moments::EddingtonFactor<CTYPE>(fl);
-            const Real chir = Moments::EddingtonFactor<CTYPE>(fr);
+            const Real chil = Moments::ThriceEddingtonFactor<CTYPE>(fl);
+            const Real chir = Moments::ThriceEddingtonFactor<CTYPE>(fr);
             const auto [sla, slb] = Moments::WaveSpeed<CTYPE>(nlx, fl);
             const auto [sra, srb] = Moments::WaveSpeed<CTYPE>(nrx, fr);
             const Real sl = std::min(sla, slb);
             const Real sr = std::max(sra, srb);
 
             // Scales
-            const Real pscalel = chat * c * 0.5 * (1.0 - chil);
-            const Real pscaler = chat * c * 0.5 * (1.0 - chir);
-            const Real scalel = c * 0.5 * (3. * chil - 1.) / (fl * fl + Fuzz<Real>());
-            const Real scaler = c * 0.5 * (3. * chir - 1.) / (fr * fr + Fuzz<Real>());
+            const Real pscalel = chat * c * (3.0 - chil) / 6.0;
+            const Real pscaler = chat * c * (3.0 - chir) / 6.0;
+            const Real scalel = c * 0.5 * ((chil - 1.) / (fl * fl + Fuzz<Real>()));
+            const Real scaler = c * 0.5 * ((chir - 1.) / (fr * fr + Fuzz<Real>()));
 
             // Compute sum of L/R fluxes
             const Real qa = chat * wl_idn * wl_ivx;


### PR DESCRIPTION
## Background

Radiation iterations were failing with NaNs when running the axisymmetric disk problems. This was caused by a bad division in expressions like `epsilon/( 0 + fuzz)`. I refactored how we return the Eddington factor so that now we multiply by three before returning. This prevents returning numbers like 1/3 which makes the subsequent subtractions have less floating point error. 

I can now run the axisymmetric disk setups with radiation and they cycle. But, I have to raise the convergence tolerance a lot, so some work still needs to be done. 

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
