### PR TITLE
Logarithmic radial coordinates

### DIFF
--- a/inputs/disk/binary_cyl.in
+++ b/inputs/disk/binary_cyl.in
@@ -14,7 +14,7 @@
 <artemis>
 problem = disk             # name of the pgen
 coordinates = cylindrical  # coordinate system
-spacing = logarithmic
+radial_spacing = logarithmic
 
 <parthenon/job>
 problem_id = disk  # problem ID: basename of output filenames

--- a/inputs/disk/binary_cyl.in
+++ b/inputs/disk/binary_cyl.in
@@ -14,6 +14,7 @@
 <artemis>
 problem = disk             # name of the pgen
 coordinates = cylindrical  # coordinate system
+spacing = logarithmic
 
 <parthenon/job>
 problem_id = disk  # problem ID: basename of output filenames
@@ -37,8 +38,8 @@ nghost = 2
 # numlevel = 4
 
 nx1    = 256                 # Number of zones in X1-direction
-x1min  = 0.3                 # minimum value of X1
-x1max  = 3.0                 # maximum value of X1
+x1min  = -1.2039728043259361 # minimum value of X1 ( = 0.3)
+x1max  = 1.0986122886681098  # maximum value of X1 ( = 3.0)
 ix1_bc = ic                  # Inner-X1 boundary condition flag
 ox1_bc = ic                  # Outer-X1 boundary condition flag
 

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -43,22 +43,6 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   auto artemis = std::make_shared<StateDescriptor>("artemis");
   Params &params = artemis->AllParams();
 
-  auto x1min = pin->GetReal("parthenon/mesh", "x1min");
-  auto x1max = pin->GetReal("parthenon/mesh", "x1max");
-  if (pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic") {
-    x1min = std::exp(x1min);
-    x1max = std::exp(x1max);
-  }
-  pin->SetReal("artemis", "x1min", x1min);
-  pin->SetReal("artemis", "x1max", x1max);
-  pin->SetReal("artemis", "x2min", pin->GetReal("parthenon/mesh", "x2min"));
-  pin->SetReal("artemis", "x2max", pin->GetReal("parthenon/mesh", "x2max"));
-  pin->SetReal("artemis", "x3min", pin->GetReal("parthenon/mesh", "x3min"));
-  pin->SetReal("artemis", "x3max", pin->GetReal("parthenon/mesh", "x3max"));
-
-  artemis->AddParam("x1min", x1min);
-  artemis->AddParam("x1max", x1max);
-
   // Store selected pgen name
   artemis->AddParam("pgen_name", pin->GetString("artemis", "problem"));
   artemis->AddParam("job_name", pin->GetString("parthenon/job", "problem_id"));

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -65,16 +65,20 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   // Correct x1 coordinate if logarithmic
   auto x1min = pin->GetReal("parthenon/mesh", "x1min");
   auto x1max = pin->GetReal("parthenon/mesh", "x1max");
+  auto x2min = pin->GetReal("parthenon/mesh", "x2min");
+  auto x2max = pin->GetReal("parthenon/mesh", "x2max");
+  auto x3min = pin->GetReal("parthenon/mesh", "x3min");
+  auto x3max = pin->GetReal("parthenon/mesh", "x3max");
   if (pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic") {
     x1min = std::exp(x1min);
     x1max = std::exp(x1max);
   }
   pin->SetReal("artemis", "x1min", x1min);
   pin->SetReal("artemis", "x1max", x1max);
-  pin->SetReal("artemis", "x2min", pin->GetReal("parthenon/mesh", "x2min"));
-  pin->SetReal("artemis", "x2max", pin->GetReal("parthenon/mesh", "x2max"));
-  pin->SetReal("artemis", "x3min", pin->GetReal("parthenon/mesh", "x3min"));
-  pin->SetReal("artemis", "x3max", pin->GetReal("parthenon/mesh", "x3max"));
+  pin->SetReal("artemis", "x2min", x2min);
+  pin->SetReal("artemis", "x2max", x2max);
+  pin->SetReal("artemis", "x3min", x3min);
+  pin->SetReal("artemis", "x3max", x3max);
 
   artemis->AddParam("x1min", x1min);
   artemis->AddParam("x1max", x1max);

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -78,6 +78,10 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
 
   artemis->AddParam("x1min", x1min);
   artemis->AddParam("x1max", x1max);
+  artemis->AddParam("x2min", x2min);
+  artemis->AddParam("x2max", x2max);
+  artemis->AddParam("x3min", x3min);
+  artemis->AddParam("x3max", x3max);
 
   // Add optionally enrollable operator split Metadata flag
   parthenon::MetadataFlag MetadataOperatorSplit =

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -73,12 +73,6 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
     x1min = std::exp(x1min);
     x1max = std::exp(x1max);
   }
-  pin->SetReal("artemis", "x1min", x1min);
-  pin->SetReal("artemis", "x1max", x1max);
-  pin->SetReal("artemis", "x2min", x2min);
-  pin->SetReal("artemis", "x2max", x2max);
-  pin->SetReal("artemis", "x3min", x3min);
-  pin->SetReal("artemis", "x3max", x3max);
 
   artemis->AddParam("x1min", x1min);
   artemis->AddParam("x1max", x1max);

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -43,6 +43,22 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   auto artemis = std::make_shared<StateDescriptor>("artemis");
   Params &params = artemis->AllParams();
 
+  auto x1min = pin->GetReal("parthenon/mesh", "x1min");
+  auto x1max = pin->GetReal("parthenon/mesh", "x1max");
+  if (pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic") {
+    x1min = std::exp(x1min);
+    x1max = std::exp(x1max);
+  }
+  pin->SetReal("artemis", "x1min", x1min);
+  pin->SetReal("artemis", "x1max", x1max);
+  pin->SetReal("artemis", "x2min", pin->GetReal("parthenon/mesh", "x2min"));
+  pin->SetReal("artemis", "x2max", pin->GetReal("parthenon/mesh", "x2max"));
+  pin->SetReal("artemis", "x3min", pin->GetReal("parthenon/mesh", "x3min"));
+  pin->SetReal("artemis", "x3max", pin->GetReal("parthenon/mesh", "x3max"));
+
+  artemis->AddParam("x1min", x1min);
+  artemis->AddParam("x1max", x1max);
+
   // Store selected pgen name
   artemis->AddParam("pgen_name", pin->GetString("artemis", "problem"));
   artemis->AddParam("job_name", pin->GetString("parthenon/job", "problem_id"));

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -62,6 +62,23 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   artemis->AddParam("units", units);
   artemis->AddParam("constants", constants);
 
+  // Correct x1 coordinate if logarithmic
+  auto x1min = pin->GetReal("parthenon/mesh", "x1min");
+  auto x1max = pin->GetReal("parthenon/mesh", "x1max");
+  if (pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic") {
+    x1min = std::exp(x1min);
+    x1max = std::exp(x1max);
+  }
+  pin->SetReal("artemis", "x1min", x1min);
+  pin->SetReal("artemis", "x1max", x1max);
+  pin->SetReal("artemis", "x2min", pin->GetReal("parthenon/mesh", "x2min"));
+  pin->SetReal("artemis", "x2max", pin->GetReal("parthenon/mesh", "x2max"));
+  pin->SetReal("artemis", "x3min", pin->GetReal("parthenon/mesh", "x3min"));
+  pin->SetReal("artemis", "x3max", pin->GetReal("parthenon/mesh", "x3max"));
+
+  artemis->AddParam("x1min", x1min);
+  artemis->AddParam("x1max", x1max);
+
   // Add optionally enrollable operator split Metadata flag
   parthenon::MetadataFlag MetadataOperatorSplit =
       parthenon::Metadata::AddUserFlag("OperatorSplit");

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -119,6 +119,9 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   artemis->AddParam("coords", coords);
   artemis->AddParam("coord_sys", sys);
 
+  geometry::CoordParams cpars(pin.get());
+  artemis->AddParam("coord_params", cpars);
+
   // Call package initializers here
   if (do_nbody) packages.Add(NBody::Initialize(pin.get(), constants));
   if (do_gravity) packages.Add(Gravity::Initialize(pin.get(), constants, packages));

--- a/src/artemis.hpp
+++ b/src/artemis.hpp
@@ -108,6 +108,8 @@ enum class Coordinates {
   axisymmetric,
   null
 };
+enum class Spacing { uniform, logarithmic };
+
 // ...Riemann solvers
 enum class RSolver { hllc, hlle, llf, null };
 // ... Upwinding (left vs right state)

--- a/src/artemis.hpp
+++ b/src/artemis.hpp
@@ -108,7 +108,6 @@ enum class Coordinates {
   axisymmetric,
   null
 };
-enum class Spacing { uniform, logarithmic };
 
 // ...Riemann solvers
 enum class RSolver { hllc, hlle, llf, null };

--- a/src/derived/fill_derived.cpp
+++ b/src/derived/fill_derived.cpp
@@ -52,13 +52,16 @@ TaskStatus SetAuxillaryFields(MeshData<Real> *md) {
   IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
   IndexRange kb = md->GetBoundsK(IndexDomain::interior);
 
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
+
   // Apply dual energy formalism to sync internal energy and total energy
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "SetAuxillaryFields", parthenon::DevExecSpace(), 0,
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract geometry
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
+
         const auto &hx = coords.GetScaleFactors();
 
         for (int n = 0; n < vmesh.GetSize(b, gas::cons::density()); ++n) {
@@ -119,6 +122,7 @@ void ConsToPrim(MeshData<Real> *md) {
     eflr_rad = rad_pkg->template Param<Real>("efloor");
     c = rad_pkg->template Param<Real>("c");
   }
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   // Packing and indexing
   static auto desc = MakePackDescriptor<
@@ -137,7 +141,7 @@ void ConsToPrim(MeshData<Real> *md) {
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &xv = coords.GetCellCenter();
         const auto &hx = coords.GetScaleFactors();
 
@@ -249,6 +253,7 @@ void PrimToCons(T *md) {
     eflr_rad = rad_pkg->template Param<Real>("efloor");
     c = rad_pkg->template Param<Real>("c");
   }
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   // Packing and indexing
   static auto desc =
@@ -269,7 +274,7 @@ void PrimToCons(T *md) {
       vmesh.GetNBlocks() - 1, kbe.s, kbe.e, jbe.s, jbe.e, ibe.s, ibe.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &xv = coords.GetCellCenter();
         const auto &hx = coords.GetScaleFactors();
 

--- a/src/drag/drag.cpp
+++ b/src/drag/drag.cpp
@@ -32,12 +32,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // We damp in the X* (* = 1,2,3) direction between
   //          x*min <= x* <= inner_x*, at the rate inner_x*_rate
   // and   outer_x* <= x* <=    x*max, at the rate outer_x*_rate
-  params.Add("x1min", pin->GetReal("artemis/mesh", "x1min"));
-  params.Add("x2min", pin->GetReal("artemis/mesh", "x2min"));
-  params.Add("x3min", pin->GetReal("artemis/mesh", "x3min"));
-  params.Add("x1max", pin->GetReal("artemis/mesh", "x1max"));
-  params.Add("x2max", pin->GetReal("artemis/mesh", "x2max"));
-  params.Add("x3max", pin->GetReal("artemis/mesh", "x3max"));
+  params.Add("x1min", pin->GetReal("parthenon/mesh", "x1min"));
+  params.Add("x2min", pin->GetReal("parthenon/mesh", "x2min"));
+  params.Add("x3min", pin->GetReal("parthenon/mesh", "x3min"));
+  params.Add("x1max", pin->GetReal("parthenon/mesh", "x1max"));
+  params.Add("x2max", pin->GetReal("parthenon/mesh", "x2max"));
+  params.Add("x3max", pin->GetReal("parthenon/mesh", "x3max"));
 
   // Coupling type for drag
   const bool do_gas = pin->GetOrAddBoolean("physics", "gas", true);

--- a/src/drag/drag.cpp
+++ b/src/drag/drag.cpp
@@ -32,12 +32,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // We damp in the X* (* = 1,2,3) direction between
   //          x*min <= x* <= inner_x*, at the rate inner_x*_rate
   // and   outer_x* <= x* <=    x*max, at the rate outer_x*_rate
-  params.Add("x1min", pin->GetReal("parthenon/mesh", "x1min"));
-  params.Add("x2min", pin->GetReal("parthenon/mesh", "x2min"));
-  params.Add("x3min", pin->GetReal("parthenon/mesh", "x3min"));
-  params.Add("x1max", pin->GetReal("parthenon/mesh", "x1max"));
-  params.Add("x2max", pin->GetReal("parthenon/mesh", "x2max"));
-  params.Add("x3max", pin->GetReal("parthenon/mesh", "x3max"));
+  params.Add("x1min", pin->GetReal("artemis/mesh", "x1min"));
+  params.Add("x2min", pin->GetReal("artemis/mesh", "x2min"));
+  params.Add("x3min", pin->GetReal("artemis/mesh", "x3min"));
+  params.Add("x1max", pin->GetReal("artemis/mesh", "x1max"));
+  params.Add("x2max", pin->GetReal("artemis/mesh", "x2max"));
+  params.Add("x3max", pin->GetReal("artemis/mesh", "x3max"));
 
   // Coupling type for drag
   const bool do_gas = pin->GetOrAddBoolean("physics", "gas", true);

--- a/src/drag/drag.cpp
+++ b/src/drag/drag.cpp
@@ -32,12 +32,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // We damp in the X* (* = 1,2,3) direction between
   //          x*min <= x* <= inner_x*, at the rate inner_x*_rate
   // and   outer_x* <= x* <=    x*max, at the rate outer_x*_rate
-  params.Add("x1min", pin->GetReal("parthenon/mesh", "x1min"));
-  params.Add("x2min", pin->GetReal("parthenon/mesh", "x2min"));
-  params.Add("x3min", pin->GetReal("parthenon/mesh", "x3min"));
-  params.Add("x1max", pin->GetReal("parthenon/mesh", "x1max"));
-  params.Add("x2max", pin->GetReal("parthenon/mesh", "x2max"));
-  params.Add("x3max", pin->GetReal("parthenon/mesh", "x3max"));
 
   // Coupling type for drag
   const bool do_gas = pin->GetOrAddBoolean("physics", "gas", true);

--- a/src/drag/drag.hpp
+++ b/src/drag/drag.hpp
@@ -192,6 +192,8 @@ TaskStatus SelfDragSourceImpl(MeshData<Real> *md, const Real time, const Real dt
     auto &dust_pkg = pm->packages.Get("dust");
     dflr_dust = dust_pkg->template Param<Real>("dfloor");
   }
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   // Extract drag parameters
   auto &drag_pkg = pm->packages.Get("drag");
@@ -217,7 +219,7 @@ TaskStatus SelfDragSourceImpl(MeshData<Real> *md, const Real time, const Real dt
       kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &xv = coords.GetCellCenter();
         const auto &hx = coords.GetScaleFactors();
         const auto &[xcyl, ex1, ex2, ex3] = coords.ConvertToCylWithVec(xv);
@@ -369,6 +371,9 @@ TaskStatus SimpleDragSourceImpl(MeshData<Real> *md, const Real time, const Real 
   const auto grain_density = dust_pkg->template Param<Real>("grain_density");
   const Real dflr_dust = dust_pkg->template Param<Real>("dfloor");
 
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+
   // Packing and indexing
   static auto desc =
       MakePackDescriptor<gas::cons::total_energy, gas::cons::momentum, gas::cons::density,
@@ -384,7 +389,7 @@ TaskStatus SimpleDragSourceImpl(MeshData<Real> *md, const Real time, const Real 
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &xv = coords.GetCellCenter();
         const auto &hx = coords.GetScaleFactors();
         const auto &[xcyl, ex1, ex2, ex3] = coords.ConvertToCylWithVec(xv);

--- a/src/drag/drag.hpp
+++ b/src/drag/drag.hpp
@@ -192,17 +192,14 @@ TaskStatus SelfDragSourceImpl(MeshData<Real> *md, const Real time, const Real dt
     auto &dust_pkg = pm->packages.Get("dust");
     dflr_dust = dust_pkg->template Param<Real>("dfloor");
   }
-  const auto &cpars =
-      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
-  // Extract drag parameters
-  auto &drag_pkg = pm->packages.Get("drag");
-  const Real x1min = drag_pkg->template Param<Real>("x1min");
-  const Real x1max = drag_pkg->template Param<Real>("x1max");
-  const Real x2min = drag_pkg->template Param<Real>("x2min");
-  const Real x2max = drag_pkg->template Param<Real>("x2max");
-  const Real x3min = drag_pkg->template Param<Real>("x3min");
-  const Real x3max = drag_pkg->template Param<Real>("x3max");
+  const Real x1min = artemis_pkg->template Param<Real>("x1min");
+  const Real x1max = artemis_pkg->template Param<Real>("x1max");
+  const Real x2min = artemis_pkg->template Param<Real>("x2min");
+  const Real x2max = artemis_pkg->template Param<Real>("x2max");
+  const Real x3min = artemis_pkg->template Param<Real>("x3min");
+  const Real x3max = artemis_pkg->template Param<Real>("x3max");
 
   // Packing and indexing
   static auto desc =
@@ -349,6 +346,7 @@ TaskStatus SimpleDragSourceImpl(MeshData<Real> *md, const Real time, const Real 
   const int ndim = pm->ndim;
   const int multi_d = (ndim >= 2);
   const int three_d = (ndim == 3);
+  auto &artemis_pkg = pm->packages.Get("artemis");
 
   // Extract gas package and params
   auto &gas_pkg = pm->packages.Get("gas");
@@ -356,14 +354,12 @@ TaskStatus SimpleDragSourceImpl(MeshData<Real> *md, const Real time, const Real 
   const Real dflr_gas = gas_pkg->template Param<Real>("dfloor");
   const Real sieflr_gas = gas_pkg->template Param<Real>("siefloor");
 
-  // Extract drag package and params
-  auto &drag_pkg = pm->packages.Get("drag");
-  const Real x1min = drag_pkg->template Param<Real>("x1min");
-  const Real x1max = drag_pkg->template Param<Real>("x1max");
-  const Real x2min = drag_pkg->template Param<Real>("x2min");
-  const Real x2max = drag_pkg->template Param<Real>("x2max");
-  const Real x3min = drag_pkg->template Param<Real>("x3min");
-  const Real x3max = drag_pkg->template Param<Real>("x3max");
+  const Real x1min = artemis_pkg->template Param<Real>("x1min");
+  const Real x1max = artemis_pkg->template Param<Real>("x1max");
+  const Real x2min = artemis_pkg->template Param<Real>("x2min");
+  const Real x2max = artemis_pkg->template Param<Real>("x2max");
+  const Real x3min = artemis_pkg->template Param<Real>("x3min");
+  const Real x3max = artemis_pkg->template Param<Real>("x3max");
 
   // Extract dust package and params
   auto &dust_pkg = pm->packages.Get("dust");
@@ -371,8 +367,7 @@ TaskStatus SimpleDragSourceImpl(MeshData<Real> *md, const Real time, const Real 
   const auto grain_density = dust_pkg->template Param<Real>("grain_density");
   const Real dflr_dust = dust_pkg->template Param<Real>("dfloor");
 
-  const auto &cpars =
-      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   // Packing and indexing
   static auto desc =

--- a/src/dust/dust.cpp
+++ b/src/dust/dust.cpp
@@ -162,7 +162,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   const int scr_level = pin->GetOrAddInteger("dust", "scr_level", 0);
   params.Add("scr_level", scr_level);
 
-  const bool log = pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic";
+  const bool log =
+      pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic";
 
   // Control field for sparse dust fields
   std::string control_field = dust::cons::density::name();

--- a/src/dust/dust.cpp
+++ b/src/dust/dust.cpp
@@ -162,13 +162,15 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   const int scr_level = pin->GetOrAddInteger("dust", "scr_level", 0);
   params.Add("scr_level", scr_level);
 
+  const bool log = pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic";
+
   // Control field for sparse dust fields
   std::string control_field = dust::cons::density::name();
 
   // Conserved Dust Density
   Metadata m = Metadata({Metadata::Cell, Metadata::Conserved, Metadata::Independent,
                          Metadata::WithFluxes, Metadata::Sparse});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   dust->AddSparsePool<dust::cons::density>(m, control_field, dustids);
 
@@ -176,14 +178,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   m = Metadata({Metadata::Cell, Metadata::Vector, Metadata::Conserved,
                 Metadata::Independent, Metadata::WithFluxes, Metadata::Sparse},
                std::vector<int>({3}));
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   dust->AddSparsePool<dust::cons::momentum>(m, control_field, dustids);
 
   // Primitive Density
   m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::Intensive, Metadata::OneCopy,
                 Metadata::FillGhost, Metadata::Sparse});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   dust->AddSparsePool<dust::prim::density>(m, control_field, dustids);
 
@@ -191,7 +193,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   m = Metadata({Metadata::Cell, Metadata::Vector, Metadata::Derived, Metadata::Intensive,
                 Metadata::OneCopy, Metadata::FillGhost, Metadata::Sparse},
                std::vector<int>({3}));
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   dust->AddSparsePool<dust::prim::velocity>(m, control_field, dustids);
 
@@ -236,13 +238,15 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
   IndexRange kb = md->GetBoundsK(IndexDomain::interior);
   const int ndim = pm->ndim;
 
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
   Real min_dt = std::numeric_limits<Real>::max();
   parthenon::par_reduce(
       parthenon::loop_pattern_mdrange_tag, "Dust::EstimateTimestepMesh", DevExecSpace(),
       0, md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &ldt) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &dx = coords.GetCellWidths();
 
         for (int n = 0; n < vmesh.GetSize(b, dust::prim::density()); ++n) {

--- a/src/gas/cooling/beta_cooling.cpp
+++ b/src/gas/cooling/beta_cooling.cpp
@@ -80,13 +80,15 @@ TaskStatus BetaCooling(MeshData<Real> *md, const Real time, const Real dt) {
     particles = nbody_pkg->template Param<ParArray1D<NBody::Particle>>("particles");
     npart = static_cast<int>(particles.size());
   }
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "BetaCooling", parthenon::DevExecSpace(), 0,
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &xv = coords.GetCellCenter();
         const auto &hx = coords.GetScaleFactors();
         const auto &xcyl = coords.ConvertToCyl(xv);

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -249,13 +249,15 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   const int scr_level = pin->GetOrAddInteger("gas", "scr_level", 0);
   params.Add("scr_level", scr_level);
 
+  const bool log = pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic";
+
   // Control field for sparse gas fields
   std::string control_field = gas::cons::density::name();
 
   // Conserved Gas Density
   Metadata m = Metadata({Metadata::Cell, Metadata::Conserved, Metadata::Independent,
                          Metadata::WithFluxes, Metadata::Sparse});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::cons::density>(m, control_field, fluidids);
 
@@ -263,14 +265,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   m = Metadata({Metadata::Cell, Metadata::Vector, Metadata::Conserved,
                 Metadata::Independent, Metadata::WithFluxes, Metadata::Sparse},
                std::vector<int>({3}));
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::cons::momentum>(m, control_field, fluidids);
 
   // Conserved Gas Total Energy
   m = Metadata({Metadata::Cell, Metadata::Conserved, Metadata::WithFluxes,
                 Metadata::Sparse, Metadata::Restart});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::cons::total_energy>(m, control_field, fluidids);
 
@@ -278,21 +280,21 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   // not actually "conserved"
   m = Metadata({Metadata::Cell, Metadata::Conserved, Metadata::Independent,
                 Metadata::Sparse, Metadata::WithFluxes});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::cons::internal_energy>(m, control_field, fluidids);
 
   // Primitive Density
   m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::Intensive, Metadata::OneCopy,
                 Metadata::FillGhost, Metadata::Sparse});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::prim::density>(m, control_field, fluidids);
 
   // Primitive Pressure (and associated Riemann pressures)
   m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::Intensive, Metadata::OneCopy,
                 Metadata::WithFluxes, Metadata::Sparse});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::prim::pressure>(m, control_field, fluidids);
 
@@ -300,14 +302,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   m = Metadata({Metadata::Cell, Metadata::Vector, Metadata::Derived, Metadata::Intensive,
                 Metadata::OneCopy, Metadata::FillGhost, Metadata::Sparse},
                std::vector<int>({3}));
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::prim::velocity>(m, control_field, fluidids);
 
   // Gas specific internal energy
   m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::Intensive, Metadata::OneCopy,
                 Metadata::FillGhost, Metadata::Sparse});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   gas->AddSparsePool<gas::prim::sie>(m, control_field, fluidids);
 
@@ -319,10 +321,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   if (do_diffusion) {
     m = Metadata({Metadata::Face, Metadata::Flux, Metadata::Sparse},
                  std::vector<int>({3}));
-    ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+    ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
     gas->AddSparsePool<gas::diff::momentum>(m, control_field, fluidids);
     m = Metadata({Metadata::Face, Metadata::Flux, Metadata::Sparse});
-    ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+    ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
     gas->AddSparsePool<gas::diff::energy>(m, control_field, fluidids);
   }
 
@@ -449,6 +451,8 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
   IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
   IndexRange kb = md->GetBoundsK(IndexDomain::interior);
   const int ndim = pm->ndim;
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   Real min_dt = Big<Real>();
   parthenon::par_reduce(
@@ -456,7 +460,7 @@ Real EstimateTimestepMesh(MeshData<Real> *md) {
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &ldt) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &dx = coords.GetCellWidths();
 
         for (int n = 0; n < vmesh.GetSize(b, gas::prim::density()); ++n) {

--- a/src/gas/gas.cpp
+++ b/src/gas/gas.cpp
@@ -249,7 +249,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   const int scr_level = pin->GetOrAddInteger("gas", "scr_level", 0);
   params.Add("scr_level", scr_level);
 
-  const bool log = pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic";
+  const bool log =
+      pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic";
 
   // Control field for sparse gas fields
   std::string control_field = gas::cons::density::name();

--- a/src/geometry/axisymmetric.hpp
+++ b/src/geometry/axisymmetric.hpp
@@ -37,27 +37,32 @@ class Coords<Coordinates::axisymmetric>
     : public CoordsBase<Coords<Coordinates::axisymmetric>> {
  public:
   KOKKOS_INLINE_FUNCTION
-  Coords(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : CoordsBase<Coords<Coordinates::axisymmetric>>(pco, k, j, i) {}
+  Coords(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,
+         const int j, const int i)
+      : CoordsBase<Coords<Coordinates::axisymmetric>>(cpars, pco, k, j, i) {}
+  KOKKOS_INLINE_FUNCTION
+  Coords(const bool log, const parthenon::Coordinates_t &pco, const int k, const int j,
+         const int i)
+      : CoordsBase<Coords<Coordinates::axisymmetric>>(log, pco, k, j, i) {}
   KOKKOS_INLINE_FUNCTION
   Coords() : CoordsBase<Coords<Coordinates::axisymmetric>>() {}
 
   KOKKOS_INLINE_FUNCTION
-  bool x1dep() { return true; }
+  bool x1dep() const { return true; }
 
-  KOKKOS_INLINE_FUNCTION Real x1v() {
+  KOKKOS_INLINE_FUNCTION Real x1v() const {
     return 2.0 / 3.0 *
            (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] + bnds.x1[1] * bnds.x1[1]) /
            (bnds.x1[0] + bnds.x1[1]);
   }
 
-  KOKKOS_INLINE_FUNCTION Real hx3(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx3(const Real x1, const Real x2, const Real x3) const {
     return x1;
   }
 
-  KOKKOS_INLINE_FUNCTION Real hx3v() { return x1v(); }
+  KOKKOS_INLINE_FUNCTION Real hx3v() const { return x1v(); }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) const {
     // <r> = d(r^3/3) / d(r^2/2)
     return {2.0 / 3.0 *
                 (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] +
@@ -66,29 +71,31 @@ class Coords<Coordinates::axisymmetric>
             bnds.x2[static_cast<int>(f)], 0.5 * (bnds.x3[0] + bnds.x3[1])};
   }
 
-  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) const {
     // \int r*dz*dp = r*dz*dp
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return x1f * dx2 * dx3;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) const {
     // \int r*dp*dr = d(r^2/2)*dp
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return (bnds.x1[0] + bnds.x1[1]) * 0.5 * dx1 * dx3;
   }
 
-  KOKKOS_INLINE_FUNCTION Real Volume() {
+  KOKKOS_INLINE_FUNCTION Real Volume() const {
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return (bnds.x1[0] + bnds.x1[1]) * 0.5 * dx1 * dx2 * dx3;
   }
 
-  KOKKOS_INLINE_FUNCTION Real dh3dx1() { return 1.0 / (0.5 * (bnds.x1[0] + bnds.x1[1])); }
+  KOKKOS_INLINE_FUNCTION Real dh3dx1() const {
+    return 1.0 / (0.5 * (bnds.x1[0] + bnds.x1[1]));
+  }
 
-  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() {
+  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() const {
     // Set the flux averaging weights in the rotating frame for the angular momentum
     // \pm ( <R^2>_j^\pm - <R^2> )
     const Real ans = 0.5 * (bnds.x1[0] + bnds.x1[1]) * (bnds.x1[1] - bnds.x1[0]);
@@ -96,12 +103,12 @@ class Coords<Coordinates::axisymmetric>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCart(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCart(const std::array<Real, 3> &xi) const {
     const Real cp = std::cos(xi[2]);
     const Real sp = std::sin(xi[2]);
     return {xi[0] * cp, xi[0] * sp, xi[1]};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) const {
     const Real cp = std::cos(xi[2]);
     const Real sp = std::sin(xi[2]);
     // clang-format off
@@ -113,13 +120,13 @@ class Coords<Coordinates::axisymmetric>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToSph(const std::array<Real, 3> &xi) {
+  ConvertCoordsToSph(const std::array<Real, 3> &xi) const {
     const Real R = std::sqrt(xi[0] * xi[0] + xi[1] * xi[1]);
     const Real ct = xi[1] / (R + Fuzz<Real>());
     const Real st = xi[0] / (R + Fuzz<Real>());
     return {R, std::acos(ct), xi[2]};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) const {
     const Real rsph = std::sqrt(xi[0] * xi[0] + xi[1] * xi[1]);
     const Real ct = xi[1] / (rsph + Fuzz<Real>());
     const Real st = xi[0] / (rsph + Fuzz<Real>());
@@ -132,10 +139,10 @@ class Coords<Coordinates::axisymmetric>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCyl(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCyl(const std::array<Real, 3> &xi) const {
     return {xi[0], xi[2], xi[1]};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) const {
     // clang-format off
     std::array<Real,3> ex1{ 1.0, 0.0, 0.0};
     std::array<Real,3> ex2{ 0.0, 0.0, 1.0};
@@ -145,10 +152,10 @@ class Coords<Coordinates::axisymmetric>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToAxi(const std::array<Real, 3> &xi) {
+  ConvertCoordsToAxi(const std::array<Real, 3> &xi) const {
     return xi;
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) const {
     std::array<Real, 3> ex1{1.0, 0.0, 0.0};
     std::array<Real, 3> ex2{0.0, 1.0, 0.0};
     std::array<Real, 3> ex3{0.0, 0.0, 1.0};

--- a/src/geometry/cylindrical.hpp
+++ b/src/geometry/cylindrical.hpp
@@ -34,27 +34,32 @@ class Coords<Coordinates::cylindrical>
     : public CoordsBase<Coords<Coordinates::cylindrical>> {
  public:
   KOKKOS_INLINE_FUNCTION
-  Coords(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : CoordsBase<Coords<Coordinates::cylindrical>>(pco, k, j, i) {}
+  Coords(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,
+         const int j, const int i)
+      : CoordsBase<Coords<Coordinates::cylindrical>>(cpars, pco, k, j, i) {}
+  KOKKOS_INLINE_FUNCTION
+  Coords(const bool log, const parthenon::Coordinates_t &pco, const int k, const int j,
+         const int i)
+      : CoordsBase<Coords<Coordinates::cylindrical>>(log, pco, k, j, i) {}
   KOKKOS_INLINE_FUNCTION
   Coords() : CoordsBase<Coords<Coordinates::cylindrical>>() {}
 
   KOKKOS_INLINE_FUNCTION
-  bool x1dep() { return true; }
+  bool x1dep() const { return true; }
 
-  KOKKOS_INLINE_FUNCTION Real x1v() {
+  KOKKOS_INLINE_FUNCTION Real x1v() const {
     return 2.0 / 3.0 *
            (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] + bnds.x1[1] * bnds.x1[1]) /
            (bnds.x1[0] + bnds.x1[1]);
   }
 
-  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) const {
     return x1;
   }
 
-  KOKKOS_INLINE_FUNCTION Real hx2v() { return x1v(); }
+  KOKKOS_INLINE_FUNCTION Real hx2v() const { return x1v(); }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) const {
     //  <r> = d(r^3/3) / d(r^2/2)
     return {2.0 / 3.0 *
                 (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] +
@@ -63,29 +68,31 @@ class Coords<Coordinates::cylindrical>
             0.5 * (bnds.x2[0] + bnds.x2[1]), bnds.x3[static_cast<int>(f)]};
   }
 
-  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) const {
     // \int r*dz*dp   =  r*dz*dp
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return x1f * dx2 * dx3;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX3(const Real x3f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX3(const Real x3f) const {
     // \int r*dp*dr = d(r^2/2)*dp
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     return 0.5 * (bnds.x1[0] + bnds.x1[1]) * dx1 * dx2;
   }
 
-  KOKKOS_INLINE_FUNCTION Real Volume() {
+  KOKKOS_INLINE_FUNCTION Real Volume() const {
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return (bnds.x1[0] + bnds.x1[1]) * 0.5 * dx1 * dx2 * dx3;
   }
 
-  KOKKOS_INLINE_FUNCTION Real dh2dx1() { return 1.0 / (0.5 * (bnds.x1[0] + bnds.x1[1])); }
+  KOKKOS_INLINE_FUNCTION Real dh2dx1() const {
+    return 1.0 / (0.5 * (bnds.x1[0] + bnds.x1[1]));
+  }
 
-  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() {
+  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() const {
     // Set the flux averaging weights in the rotating frame for the angular momentum
     // \pm ( <R^2>_j^\pm - <R^2> )
     const Real ans = 0.5 * (bnds.x1[0] + bnds.x1[1]) * (bnds.x1[1] - bnds.x1[0]);
@@ -93,12 +100,12 @@ class Coords<Coordinates::cylindrical>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCart(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCart(const std::array<Real, 3> &xi) const {
     const Real cp = std::cos(xi[1]);
     const Real sp = std::sin(xi[1]);
     return {xi[0] * cp, xi[0] * sp, xi[2]};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) const {
     const Real cp = std::cos(xi[1]);
     const Real sp = std::sin(xi[1]);
     std::array<Real, 3> ex1{cp, sp, 0.0};
@@ -108,13 +115,13 @@ class Coords<Coordinates::cylindrical>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToSph(const std::array<Real, 3> &xi) {
+  ConvertCoordsToSph(const std::array<Real, 3> &xi) const {
     const Real R = std::sqrt(xi[0] * xi[0] + xi[2] * xi[2]);
     const Real ct = xi[2] / (R + Fuzz<Real>());
     const Real st = xi[0] / (R + Fuzz<Real>());
     return {R, std::acos(ct), xi[1]};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) const {
     const Real rsph = std::sqrt(xi[0] * xi[0] + xi[2] * xi[2]);
     const Real ct = xi[2] / (rsph + Fuzz<Real>());
     const Real st = xi[0] / (rsph + Fuzz<Real>());
@@ -125,10 +132,10 @@ class Coords<Coordinates::cylindrical>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCyl(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCyl(const std::array<Real, 3> &xi) const {
     return xi;
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) const {
     std::array<Real, 3> ex1{1.0, 0.0, 0.0};
     std::array<Real, 3> ex2{0.0, 1.0, 0.0};
     std::array<Real, 3> ex3{0.0, 0.0, 1.0};
@@ -136,10 +143,10 @@ class Coords<Coordinates::cylindrical>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToAxi(const std::array<Real, 3> &xi) {
+  ConvertCoordsToAxi(const std::array<Real, 3> &xi) const {
     return {xi[0], xi[2], xi[1]};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) const {
     std::array<Real, 3> ex1{1.0, 0.0, 0.0};
     std::array<Real, 3> ex2{0.0, 0.0, 1.0};
     std::array<Real, 3> ex3{0.0, 1.0, 0.0};

--- a/src/geometry/geometry.hpp
+++ b/src/geometry/geometry.hpp
@@ -34,7 +34,7 @@ enum class CellFace { lower = 0, upper = 1 };
 
 struct CoordParams {
   CoordParams(ParameterInput *pin) {
-    log = (pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic");
+    log = (pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic");
   }
   KOKKOS_INLINE_FUNCTION
   CoordParams() = default;
@@ -158,7 +158,7 @@ class CoordsBase {
   BBox bnds;
   KOKKOS_INLINE_FUNCTION
   CoordsBase(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : bnds(pco, k, j, i){};
+      : bnds(pco, k, j, i) {};
 
   KOKKOS_INLINE_FUNCTION
   CoordsBase(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,

--- a/src/geometry/geometry.hpp
+++ b/src/geometry/geometry.hpp
@@ -32,6 +32,16 @@ namespace geometry {
 // Face indexing
 enum class CellFace { lower = 0, upper = 1 };
 
+struct CoordParams {
+  CoordParams(ParameterInput *pin) {
+    log = (pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic");
+  }
+  KOKKOS_INLINE_FUNCTION
+  CoordParams() = default;
+
+  bool log = false;
+};
+
 //----------------------------------------------------------------------------------------
 //! \fn  Coordinates geometry::CoordSelect
 //! \brief
@@ -146,78 +156,96 @@ template <class T>
 class CoordsBase {
  public:
   BBox bnds;
-
   KOKKOS_INLINE_FUNCTION
   CoordsBase(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : bnds(pco, k, j, i) {}
+      : bnds(pco, k, j, i) {};
+
+  KOKKOS_INLINE_FUNCTION
+  CoordsBase(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,
+             const int j, const int i)
+      : bnds(pco, k, j, i) {
+    if (cpars.log) {
+      bnds.x1[0] = std::exp(bnds.x1[0]);
+      bnds.x1[1] = std::exp(bnds.x1[1]);
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
+  CoordsBase(const bool log, const parthenon::Coordinates_t &pco, const int k,
+             const int j, const int i)
+      : bnds(pco, k, j, i) {
+    if (log) {
+      bnds.x1[0] = std::exp(bnds.x1[0]);
+      bnds.x1[1] = std::exp(bnds.x1[1]);
+    }
+  }
 
   // This constructor allows us to easily access the coordinate conversion routines
   KOKKOS_INLINE_FUNCTION
   CoordsBase() : bnds() {}
 
   // Is the metric x1, x2, and/or x3 dependent?
-  KOKKOS_INLINE_FUNCTION bool x1dep() { return false; }
-  KOKKOS_INLINE_FUNCTION bool x2dep() { return false; }
-  KOKKOS_INLINE_FUNCTION bool x3dep() { return false; }
+  KOKKOS_INLINE_FUNCTION bool x1dep() const { return false; }
+  KOKKOS_INLINE_FUNCTION bool x2dep() const { return false; }
+  KOKKOS_INLINE_FUNCTION bool x3dep() const { return false; }
 
   // Volume averaged coordinates
   // xiv = \int x_i dV/ \int dV
-  KOKKOS_INLINE_FUNCTION Real x1v() { return 0.5 * (bnds.x1[0] + bnds.x1[1]); }
-  KOKKOS_INLINE_FUNCTION Real x2v() { return 0.5 * (bnds.x2[0] + bnds.x2[1]); }
-  KOKKOS_INLINE_FUNCTION Real x3v() { return 0.5 * (bnds.x3[0] + bnds.x3[1]); }
+  KOKKOS_INLINE_FUNCTION Real x1v() const { return 0.5 * (bnds.x1[0] + bnds.x1[1]); }
+  KOKKOS_INLINE_FUNCTION Real x2v() const { return 0.5 * (bnds.x2[0] + bnds.x2[1]); }
+  KOKKOS_INLINE_FUNCTION Real x3v() const { return 0.5 * (bnds.x3[0] + bnds.x3[1]); }
 
   // Scale factor functions and volume averaged scale factors
   // hxiv = \iht h_i dV/dV
-  KOKKOS_INLINE_FUNCTION Real hx1(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx1(const Real x1, const Real x2, const Real x3) const {
     return 1.0;
   }
-  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) const {
     return 1.0;
   }
-  KOKKOS_INLINE_FUNCTION Real hx3(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx3(const Real x1, const Real x2, const Real x3) const {
     return 1.0;
   }
 
-  KOKKOS_INLINE_FUNCTION Real hx1v() { return 1.0; }
-  KOKKOS_INLINE_FUNCTION Real hx2v() { return 1.0; }
-  KOKKOS_INLINE_FUNCTION Real hx3v() { return 1.0; }
+  KOKKOS_INLINE_FUNCTION Real hx1v() const { return 1.0; }
+  KOKKOS_INLINE_FUNCTION Real hx2v() const { return 1.0; }
+  KOKKOS_INLINE_FUNCTION Real hx3v() const { return 1.0; }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX1(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX1(const CellFace f) const {
     // The centroid value of the X1 face
-    return {bnds.x1[static_cast<int>(f)], static_cast<T *>(this)->x2v(),
-            static_cast<T *>(this)->x3v()};
+    return {bnds.x1[static_cast<int>(f)], static_cast<const T *>(this)->x2v(),
+            static_cast<const T *>(this)->x3v()};
   }
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) const {
     // The centroid value of the X2 face
-    return {static_cast<T *>(this)->x1v(), bnds.x2[static_cast<int>(f)],
-            static_cast<T *>(this)->x3v()};
+    return {static_cast<const T *>(this)->x1v(), bnds.x2[static_cast<int>(f)],
+            static_cast<const T *>(this)->x3v()};
   }
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) const {
     // The centroid value of the X3 face
-    return {static_cast<T *>(this)->x1v(), static_cast<T *>(this)->x2v(),
+    return {static_cast<const T *>(this)->x1v(), static_cast<const T *>(this)->x2v(),
             bnds.x3[static_cast<int>(f)]};
   }
 
-  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) const {
     // The X1 face area
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return dx2 * dx3;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) const {
     // The X2 face area
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return dx1 * dx3;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX3(Real x3f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX3(Real x3f) const {
     // The X3 face area
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     return dx1 * dx2;
   }
 
-  KOKKOS_INLINE_FUNCTION Real Volume() {
+  KOKKOS_INLINE_FUNCTION Real Volume() const {
     // The zone volume
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
@@ -225,7 +253,7 @@ class CoordsBase {
     return dx1 * dx2 * dx3;
   }
 
-  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() {
+  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() const {
     // Set the flux averaging weights in the rotating frame for the angular momentum
     // \pm ( <R^2>_j^\pm - <R^2> )
     return {NewArray<Real, 2>(0.0), NewArray<Real, 2>(0.0), NewArray<Real, 2>(0.0)};
@@ -233,24 +261,24 @@ class CoordsBase {
 
   // The relevant components of the connection for
   // orthogonal coordinates
-  KOKKOS_INLINE_FUNCTION Real dh1dx1() { return 0.0; }
-  KOKKOS_INLINE_FUNCTION Real dh1dx2() { return 0.0; }
-  KOKKOS_INLINE_FUNCTION Real dh1dx3() { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh1dx1() const { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh1dx2() const { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh1dx3() const { return 0.0; }
 
-  KOKKOS_INLINE_FUNCTION Real dh2dx1() { return 0.0; }
-  KOKKOS_INLINE_FUNCTION Real dh2dx2() { return 0.0; }
-  KOKKOS_INLINE_FUNCTION Real dh2dx3() { return 0.0; }
-  KOKKOS_INLINE_FUNCTION Real dh3dx1() { return 0.0; }
-  KOKKOS_INLINE_FUNCTION Real dh3dx2() { return 0.0; }
-  KOKKOS_INLINE_FUNCTION Real dh3dx3() { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh2dx1() const { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh2dx2() const { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh2dx3() const { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh3dx1() const { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh3dx2() const { return 0.0; }
+  KOKKOS_INLINE_FUNCTION Real dh3dx3() const { return 0.0; }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCart(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCart(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to Cartesian
     return xi;
   }
 
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to Cartesian
     std::array<Real, 3> ex1{1.0, 0.0, 0.0};
     std::array<Real, 3> ex2{0.0, 1.0, 0.0};
@@ -259,7 +287,7 @@ class CoordsBase {
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToSph(const std::array<Real, 3> &xi) {
+  ConvertCoordsToSph(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to spherical
     const Real R = std::sqrt(xi[0] * xi[0] + xi[1] * xi[1]);
     const Real r = std::sqrt(R * R + xi[2] * xi[2]);
@@ -268,7 +296,7 @@ class CoordsBase {
     const Real sp = xi[1] / (R + Fuzz<Real>());
     return {r, std::acos(ct), std::atan2(sp, cp)};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to spherical
     const Real R = std::sqrt(xi[0] * xi[0] + xi[1] * xi[1]);
     const Real r = std::sqrt(R * R + xi[2] * xi[2]);
@@ -283,14 +311,14 @@ class CoordsBase {
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCyl(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCyl(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to cylindrical
     Real R = std::sqrt(xi[0] * xi[0] + xi[1] * xi[1]);
     const Real cp = xi[0] / (R + Fuzz<Real>());
     const Real sp = xi[1] / (R + Fuzz<Real>());
     return {R, std::atan2(sp, cp), xi[2]};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to cylindrical
     Real R = std::sqrt(xi[0] * xi[0] + xi[1] * xi[1]);
     const Real cp = xi[0] / (R + Fuzz<Real>());
@@ -302,14 +330,14 @@ class CoordsBase {
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToAxi(const std::array<Real, 3> &xi) {
+  ConvertCoordsToAxi(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to axisymmetric
     Real R = std::sqrt(xi[0] * xi[0] + xi[1] * xi[1]);
     const Real cp = xi[0] / (R + Fuzz<Real>());
     const Real sp = xi[1] / (R + Fuzz<Real>());
     return {R, xi[2], std::atan2(sp, cp)};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to axisymmetric
     Real R = std::sqrt(xi[0] * xi[0] + xi[1] * xi[1]);
     const Real cp = xi[0] / (R + Fuzz<Real>());
@@ -325,159 +353,180 @@ class CoordsBase {
   // We use static_cast<T*>(this)-> to access the methods in order to call
   // the correct derived variants. This is the key to static polymorphism and CRTP.
 
-  KOKKOS_INLINE_FUNCTION Real GetCellWidthX1() {
+  KOKKOS_INLINE_FUNCTION BBox &GetBounds() const {
+    return static_cast<const T *>(this)->bnds;
+  }
+  KOKKOS_INLINE_FUNCTION Real GetCellWidthX1() const {
     // The cell width in the X1 direction
-    const Real xv[3] = {static_cast<T *>(this)->x1v(), static_cast<T *>(this)->x2v(),
-                        static_cast<T *>(this)->x3v()};
-    return static_cast<T *>(this)->hx1(xv[0], xv[1], xv[2]) * (bnds.x1[1] - bnds.x1[0]);
+    const Real xv[3] = {static_cast<const T *>(this)->x1v(),
+                        static_cast<const T *>(this)->x2v(),
+                        static_cast<const T *>(this)->x3v()};
+    return static_cast<const T *>(this)->hx1(xv[0], xv[1], xv[2]) *
+           (bnds.x1[1] - bnds.x1[0]);
   }
-  KOKKOS_INLINE_FUNCTION Real GetCellWidthX2() {
+  KOKKOS_INLINE_FUNCTION Real GetCellWidthX2() const {
     // The cell width in the X2 direction
-    const Real xv[3] = {static_cast<T *>(this)->x1v(), static_cast<T *>(this)->x2v(),
-                        static_cast<T *>(this)->x3v()};
-    return static_cast<T *>(this)->hx2(xv[0], xv[1], xv[2]) * (bnds.x2[1] - bnds.x2[0]);
+    const Real xv[3] = {static_cast<const T *>(this)->x1v(),
+                        static_cast<const T *>(this)->x2v(),
+                        static_cast<const T *>(this)->x3v()};
+    return static_cast<const T *>(this)->hx2(xv[0], xv[1], xv[2]) *
+           (bnds.x2[1] - bnds.x2[0]);
   }
-  KOKKOS_INLINE_FUNCTION Real GetCellWidthX3() {
+  KOKKOS_INLINE_FUNCTION Real GetCellWidthX3() const {
     // The cell width in the X3 direction
-    const Real xv[3] = {static_cast<T *>(this)->x1v(), static_cast<T *>(this)->x2v(),
-                        static_cast<T *>(this)->x3v()};
-    return static_cast<T *>(this)->hx3(xv[0], xv[1], xv[2]) * (bnds.x3[1] - bnds.x3[0]);
+    const Real xv[3] = {static_cast<const T *>(this)->x1v(),
+                        static_cast<const T *>(this)->x2v(),
+                        static_cast<const T *>(this)->x3v()};
+    return static_cast<const T *>(this)->hx3(xv[0], xv[1], xv[2]) *
+           (bnds.x3[1] - bnds.x3[0]);
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetCellWidths() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetCellWidths() const {
     // Return all cell widths
-    const Real xv[3] = {static_cast<T *>(this)->x1v(), static_cast<T *>(this)->x2v(),
-                        static_cast<T *>(this)->x3v()};
-    return {static_cast<T *>(this)->hx1(xv[0], xv[1], xv[2]) * (bnds.x1[1] - bnds.x1[0]),
-            static_cast<T *>(this)->hx2(xv[0], xv[1], xv[2]) * (bnds.x2[1] - bnds.x2[0]),
-            static_cast<T *>(this)->hx3(xv[0], xv[1], xv[2]) * (bnds.x3[1] - bnds.x3[0])};
+    const Real xv[3] = {static_cast<const T *>(this)->x1v(),
+                        static_cast<const T *>(this)->x2v(),
+                        static_cast<const T *>(this)->x3v()};
+    return {static_cast<const T *>(this)->hx1(xv[0], xv[1], xv[2]) *
+                (bnds.x1[1] - bnds.x1[0]),
+            static_cast<const T *>(this)->hx2(xv[0], xv[1], xv[2]) *
+                (bnds.x2[1] - bnds.x2[0]),
+            static_cast<const T *>(this)->hx3(xv[0], xv[1], xv[2]) *
+                (bnds.x3[1] - bnds.x3[0])};
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetCellCenter() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetCellCenter() const {
     // Get the cell centroid
-    return {static_cast<T *>(this)->x1v(), static_cast<T *>(this)->x2v(),
-            static_cast<T *>(this)->x3v()};
+    return {static_cast<const T *>(this)->x1v(), static_cast<const T *>(this)->x2v(),
+            static_cast<const T *>(this)->x3v()};
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetScaleFactors() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetScaleFactors() const {
     // Get the volume averaged scale factors
-    return {static_cast<T *>(this)->hx1v(), static_cast<T *>(this)->hx2v(),
-            static_cast<T *>(this)->hx3v()};
+    return {static_cast<const T *>(this)->hx1v(), static_cast<const T *>(this)->hx2v(),
+            static_cast<const T *>(this)->hx3v()};
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 2> GetFaceAreaX1() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 2> GetFaceAreaX1() const {
     // Get the lower and upper face areas in the X1 direction
-    return {static_cast<T *>(this)->AreaX1(bnds.x1[0]),
-            static_cast<T *>(this)->AreaX1(bnds.x1[1])};
+    return {static_cast<const T *>(this)->AreaX1(bnds.x1[0]),
+            static_cast<const T *>(this)->AreaX1(bnds.x1[1])};
   }
-  KOKKOS_INLINE_FUNCTION std::array<Real, 2> GetFaceAreaX2() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 2> GetFaceAreaX2() const {
     // Get the lower and upper face areas in the X2 direction
-    return {static_cast<T *>(this)->AreaX2(bnds.x2[0]),
-            static_cast<T *>(this)->AreaX2(bnds.x2[1])};
+    return {static_cast<const T *>(this)->AreaX2(bnds.x2[0]),
+            static_cast<const T *>(this)->AreaX2(bnds.x2[1])};
   }
-  KOKKOS_INLINE_FUNCTION std::array<Real, 2> GetFaceAreaX3() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 2> GetFaceAreaX3() const {
     // Get the lower and upper face areas in the X3 direction
-    return {static_cast<T *>(this)->AreaX3(bnds.x3[0]),
-            static_cast<T *>(this)->AreaX3(bnds.x3[1])};
+    return {static_cast<const T *>(this)->AreaX3(bnds.x3[0]),
+            static_cast<const T *>(this)->AreaX3(bnds.x3[1])};
   }
 
   template <parthenon::CoordinateDirection XDIR>
-  KOKKOS_INLINE_FUNCTION Real GetFaceArea() {
+  KOKKOS_INLINE_FUNCTION Real GetFaceArea() const {
     // Get the face area in the direction asked for
     if constexpr (XDIR == parthenon::CoordinateDirection::X1DIR) {
-      return static_cast<T *>(this)->AreaX1(bnds.x1[0]);
+      return static_cast<const T *>(this)->AreaX1(bnds.x1[0]);
     } else if constexpr (XDIR == parthenon::CoordinateDirection::X2DIR) {
-      return static_cast<T *>(this)->AreaX2(bnds.x2[0]);
+      return static_cast<const T *>(this)->AreaX2(bnds.x2[0]);
     } else if constexpr (XDIR == parthenon::CoordinateDirection::X3DIR) {
-      return static_cast<T *>(this)->AreaX3(bnds.x3[0]);
+      return static_cast<const T *>(this)->AreaX3(bnds.x3[0]);
     }
     PARTHENON_FAIL("Bad GetFaceArea XDIR");
     return 0.0;
   }
 
   KOKKOS_INLINE_FUNCTION Real Distance(const std::array<Real, 3> &x1,
-                                       const std::array<Real, 3> &x2) {
+                                       const std::array<Real, 3> &x2) const {
     // { dh1/dx1, dh2/dx1, dh3/dx1 }
-    const auto &xc1 = static_cast<T *>(this)->ConvertToCart(x1);
-    const auto &xc2 = static_cast<T *>(this)->ConvertToCart(x2);
+    const auto &xc1 = static_cast<const T *>(this)->ConvertToCart(x1);
+    const auto &xc2 = static_cast<const T *>(this)->ConvertToCart(x2);
     return std::sqrt(SQR(xc1[0] - xc2[0]) + SQR(xc1[1] - xc2[1]) + SQR(xc1[2] - xc2[2]));
   }
 
-  KOKKOS_INLINE_FUNCTION Mat3x2 GetRFWeights() {
-    return static_cast<T *>(this)->RFWeights();
+  KOKKOS_INLINE_FUNCTION Mat3x2 GetRFWeights() const {
+    return static_cast<const T *>(this)->RFWeights();
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetConnX1() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetConnX1() const {
     // { dh1/dx1, dh2/dx1, dh3/dx1 }
-    return {static_cast<T *>(this)->dh1dx1(), static_cast<T *>(this)->dh2dx1(),
-            static_cast<T *>(this)->dh3dx1()};
+    return {static_cast<const T *>(this)->dh1dx1(),
+            static_cast<const T *>(this)->dh2dx1(),
+            static_cast<const T *>(this)->dh3dx1()};
   }
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetConnX2() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetConnX2() const {
     // { dh1/dx2, dh2/dx2, dh3/dx2 }
-    return {static_cast<T *>(this)->dh1dx2(), static_cast<T *>(this)->dh2dx2(),
-            static_cast<T *>(this)->dh3dx2()};
+    return {static_cast<const T *>(this)->dh1dx2(),
+            static_cast<const T *>(this)->dh2dx2(),
+            static_cast<const T *>(this)->dh3dx2()};
   }
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetConnX3() {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> GetConnX3() const {
     // { dh1/dx3, dh2/dx3, dh3/dx3 }
-    return {static_cast<T *>(this)->dh1dx3(), static_cast<T *>(this)->dh2dx3(),
-            static_cast<T *>(this)->dh3dx3()};
+    return {static_cast<const T *>(this)->dh1dx3(),
+            static_cast<const T *>(this)->dh2dx3(),
+            static_cast<const T *>(this)->dh3dx3()};
   }
 
-  KOKKOS_INLINE_FUNCTION Mat3x3 GetConns() {
+  KOKKOS_INLINE_FUNCTION Mat3x3 GetConns() const {
     // Return all of the connections
-    return {static_cast<T *>(this)->GetConnX1(), static_cast<T *>(this)->GetConnX2(),
-            static_cast<T *>(this)->GetConnX3()};
+    return {static_cast<const T *>(this)->GetConnX1(),
+            static_cast<const T *>(this)->GetConnX2(),
+            static_cast<const T *>(this)->GetConnX3()};
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertToCart(const std::array<Real, 3> &xi) {
+  ConvertToCart(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to Cartesian
-    return static_cast<T *>(this)->ConvertCoordsToCart(xi);
+    return static_cast<const T *>(this)->ConvertCoordsToCart(xi);
   }
 
-  KOKKOS_INLINE_FUNCTION Mat4x3 ConvertToCartWithVec(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat4x3
+  ConvertToCartWithVec(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to Cartesian
 
-    const auto &[ex1, ex2, ex3] = static_cast<T *>(this)->ConvertVecToCart(xi);
-    const auto &xo = static_cast<T *>(this)->ConvertCoordsToCart(xi);
+    const auto &[ex1, ex2, ex3] = static_cast<const T *>(this)->ConvertVecToCart(xi);
+    const auto &xo = static_cast<const T *>(this)->ConvertCoordsToCart(xi);
     return {xo, ex1, ex2, ex3};
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> ConvertToAxi(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3>
+  ConvertToAxi(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to Axisymmetric
-    return static_cast<T *>(this)->ConvertCoordsToAxi(xi);
+    return static_cast<const T *>(this)->ConvertCoordsToAxi(xi);
   }
 
-  KOKKOS_INLINE_FUNCTION Mat4x3 ConvertToAxiWithVec(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat4x3 ConvertToAxiWithVec(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to Axisymmetric
 
-    const auto &[ex1, ex2, ex3] = static_cast<T *>(this)->ConvertVecToAxi(xi);
-    const auto &xo = static_cast<T *>(this)->ConvertCoordsToAxi(xi);
+    const auto &[ex1, ex2, ex3] = static_cast<const T *>(this)->ConvertVecToAxi(xi);
+    const auto &xo = static_cast<const T *>(this)->ConvertCoordsToAxi(xi);
     return {xo, ex1, ex2, ex3};
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> ConvertToSph(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3>
+  ConvertToSph(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to spherical
-    return static_cast<T *>(this)->ConvertCoordsToSph(xi);
+    return static_cast<const T *>(this)->ConvertCoordsToSph(xi);
   }
 
-  KOKKOS_INLINE_FUNCTION Mat4x3 ConvertToSphWithVec(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat4x3 ConvertToSphWithVec(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to spherical
 
-    const auto &[ex1, ex2, ex3] = static_cast<T *>(this)->ConvertVecToSph(xi);
-    const auto &xo = static_cast<T *>(this)->ConvertCoordsToSph(xi);
+    const auto &[ex1, ex2, ex3] = static_cast<const T *>(this)->ConvertVecToSph(xi);
+    const auto &xo = static_cast<const T *>(this)->ConvertCoordsToSph(xi);
     return {xo, ex1, ex2, ex3};
   }
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> ConvertToCyl(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3>
+  ConvertToCyl(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to cylindrical
-    return static_cast<T *>(this)->ConvertCoordsToCyl(xi);
+    return static_cast<const T *>(this)->ConvertCoordsToCyl(xi);
   }
 
-  KOKKOS_INLINE_FUNCTION Mat4x3 ConvertToCylWithVec(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat4x3 ConvertToCylWithVec(const std::array<Real, 3> &xi) const {
     // Convert the input vector from the problem coordinate system to cylindrical
 
-    const auto &[ex1, ex2, ex3] = static_cast<T *>(this)->ConvertVecToCyl(xi);
-    const auto &xo = static_cast<T *>(this)->ConvertCoordsToCyl(xi);
+    const auto &[ex1, ex2, ex3] = static_cast<const T *>(this)->ConvertVecToCyl(xi);
+    const auto &xo = static_cast<const T *>(this)->ConvertCoordsToCyl(xi);
     return {xo, ex1, ex2, ex3};
   }
 };
@@ -493,8 +542,13 @@ template <>
 class Coords<Coordinates::cartesian> : public CoordsBase<Coords<Coordinates::cartesian>> {
  public:
   KOKKOS_INLINE_FUNCTION
-  Coords(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : CoordsBase<Coords<Coordinates::cartesian>>(pco, k, j, i) {}
+  Coords(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,
+         const int j, const int i)
+      : CoordsBase<Coords<Coordinates::cartesian>>(cpars, pco, k, j, i) {}
+  KOKKOS_INLINE_FUNCTION
+  Coords(const bool log, const parthenon::Coordinates_t &pco, const int k, const int j,
+         const int i)
+      : CoordsBase<Coords<Coordinates::cartesian>>(log, pco, k, j, i) {}
   KOKKOS_INLINE_FUNCTION
   Coords() : CoordsBase<Coords<Coordinates::cartesian>>() {}
 };

--- a/src/geometry/geometry.hpp
+++ b/src/geometry/geometry.hpp
@@ -158,7 +158,7 @@ class CoordsBase {
   BBox bnds;
   KOKKOS_INLINE_FUNCTION
   CoordsBase(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : bnds(pco, k, j, i) {};
+      : bnds(pco, k, j, i){};
 
   KOKKOS_INLINE_FUNCTION
   CoordsBase(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,

--- a/src/geometry/spherical.hpp
+++ b/src/geometry/spherical.hpp
@@ -39,26 +39,31 @@ class Coords<Coordinates::spherical3D>
 
  public:
   KOKKOS_INLINE_FUNCTION
-  Coords(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : CoordsBase<Coords<Coordinates::spherical3D>>(pco, k, j, i) {}
+  Coords(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,
+         const int j, const int i)
+      : CoordsBase<Coords<Coordinates::spherical3D>>(cpars, pco, k, j, i) {}
+  KOKKOS_INLINE_FUNCTION
+  Coords(const bool log, const parthenon::Coordinates_t &pco, const int k, const int j,
+         const int i)
+      : CoordsBase<Coords<Coordinates::spherical3D>>(log, pco, k, j, i) {}
   KOKKOS_INLINE_FUNCTION
   Coords() : CoordsBase<Coords<Coordinates::spherical3D>>() {}
 
-  KOKKOS_INLINE_FUNCTION bool x1dep() { return true; }
-  KOKKOS_INLINE_FUNCTION bool x2dep() { return true; }
+  KOKKOS_INLINE_FUNCTION bool x1dep() const { return true; }
+  KOKKOS_INLINE_FUNCTION bool x2dep() const { return true; }
 
-  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) const {
     return x1;
   }
-  KOKKOS_INLINE_FUNCTION Real hx3(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx3(const Real x1, const Real x2, const Real x3) const {
     return x1 * std::sin(x2);
   }
 
-  KOKKOS_INLINE_FUNCTION Real x1v() {
+  KOKKOS_INLINE_FUNCTION Real x1v() const {
     const Real dr2 = bnds.x1[0] * bnds.x1[0] + bnds.x1[1] * bnds.x1[1];
     return 0.75 * (bnds.x1[0] + bnds.x1[1]) * dr2 / (dr2 + bnds.x1[0] * bnds.x1[1]);
   }
-  KOKKOS_INLINE_FUNCTION Real x2v() {
+  KOKKOS_INLINE_FUNCTION Real x2v() const {
     // \int t * sin(t) *dt/ \int sin(t) * dt = d( sin(t) -
     // t*cos(t))/d(-cos(t))
     const Real ctm = std::cos(bnds.x2[0]);
@@ -67,8 +72,8 @@ class Coords<Coordinates::spherical3D>
     return (dst - bnds.x2[1] * ctp + bnds.x2[0] * ctm) / std::abs(ctm - ctp);
   }
 
-  KOKKOS_INLINE_FUNCTION Real hx2v() { return x1v(); }
-  KOKKOS_INLINE_FUNCTION Real hx3v() {
+  KOKKOS_INLINE_FUNCTION Real hx2v() const { return x1v(); }
+  KOKKOS_INLINE_FUNCTION Real hx3v() const {
     // \int r sin(t)  (r^2 sin(t) dr dt dp)
     // \int r^3 dr/ int r^2 dr  * \int sin^2 dt / \int sin dt
     // <r> <sin(t)>
@@ -85,7 +90,7 @@ class Coords<Coordinates::spherical3D>
     return x1v() * 0.5 * (dx2 - dsc) / std::abs(ctm - ctp);
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) const {
     // <r> = d(r^3/3) / d(r^2/2)
     return {2.0 / 3.0 *
                 (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] +
@@ -94,7 +99,7 @@ class Coords<Coordinates::spherical3D>
             bnds.x2[static_cast<int>(f)], 0.5 * (bnds.x3[0] + bnds.x3[1])};
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) const {
     // <r> = d(r^3/3) / d(r^2/2)
     return {2.0 / 3.0 *
                 (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] +
@@ -103,25 +108,25 @@ class Coords<Coordinates::spherical3D>
             0.5 * (bnds.x2[0] + bnds.x2[1]), bnds.x3[static_cast<int>(f)]};
   }
 
-  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) const {
     // \int r^2 sin(t) dp*dt = d(-cos(t)) * r^2 *dp
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return x1f * x1f * std::abs(std::cos(bnds.x2[0]) - std::cos(bnds.x2[1])) * dx3;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) const {
     // \int r*sin(t)*dp*dr = d(r^2/2)*sin(t)*dp
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
     return 0.5 * (bnds.x1[1] + bnds.x1[0]) * std::sin(x2f) * dx1 * dx3;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX3(const Real x3f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX3(const Real x3f) const {
     // \int r*dt*dr = d(r^2/2)*dt
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     return 0.5 * (bnds.x1[0] + bnds.x1[1]) * dx1 * dx2;
   }
 
-  KOKKOS_INLINE_FUNCTION Real Volume() {
+  KOKKOS_INLINE_FUNCTION Real Volume() const {
     // \int r^2 sin(t) dr dt dp = d(r^3/3) d(-cos(t)) dp
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx3 = bnds.x3[1] - bnds.x3[0];
@@ -132,20 +137,20 @@ class Coords<Coordinates::spherical3D>
     return rfac * dx1 * dx2 * dx3;
   }
 
-  KOKKOS_INLINE_FUNCTION Real dh2dx1() {
+  KOKKOS_INLINE_FUNCTION Real dh2dx1() const {
     return 3.0 / 2.0 * (bnds.x1[0] + bnds.x1[1]) /
            (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] + bnds.x1[1] * bnds.x1[1]);
   }
-  KOKKOS_INLINE_FUNCTION Real dh3dx1() {
+  KOKKOS_INLINE_FUNCTION Real dh3dx1() const {
     return 3.0 / 2.0 * (bnds.x1[0] + bnds.x1[1]) /
            (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] + bnds.x1[1] * bnds.x1[1]);
   }
-  KOKKOS_INLINE_FUNCTION Real dh3dx2() {
+  KOKKOS_INLINE_FUNCTION Real dh3dx2() const {
     return (std::sin(bnds.x2[1]) - std::sin(bnds.x2[0])) /
            std::abs(std::cos(bnds.x2[0]) - std::cos(bnds.x2[1]));
   }
 
-  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() {
+  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() const {
     // Set the flux averaging weights in the rotating frame for the angular momentum
     // \pm ( <R^2>_j^\pm - <R^2> ) where R is the cylindrical radius
 
@@ -169,14 +174,14 @@ class Coords<Coordinates::spherical3D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCart(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCart(const std::array<Real, 3> &xi) const {
     const Real cp = std::cos(xi[2]);
     const Real sp = std::sin(xi[2]);
     const Real ct = std::cos(xi[1]);
     const Real st = std::sin(xi[1]);
     return {xi[0] * st * cp, xi[0] * st * sp, xi[0] * ct};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) const {
     const Real cp = std::cos(xi[2]);
     const Real sp = std::sin(xi[2]);
     const Real ct = std::cos(xi[1]);
@@ -188,10 +193,10 @@ class Coords<Coordinates::spherical3D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToSph(const std::array<Real, 3> &xi) {
+  ConvertCoordsToSph(const std::array<Real, 3> &xi) const {
     return xi;
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) const {
     std::array<Real, 3> ex1{1.0, 0.0, 0.0};
     std::array<Real, 3> ex2{0.0, 1.0, 0.0};
     std::array<Real, 3> ex3{0.0, 0.0, 1.0};
@@ -199,7 +204,7 @@ class Coords<Coordinates::spherical3D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCyl(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCyl(const std::array<Real, 3> &xi) const {
     // rhat = st * Rhat + ct * Zhat = (st, 0, ct)
     // that = ct * Rhat - st * Zhat = (ct, 0, -st)
     // phat = phat                  = (0, 1,0)
@@ -208,7 +213,7 @@ class Coords<Coordinates::spherical3D>
 
     return {xi[0] * st, xi[2], xi[0] * ct};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) const {
     // rhat = st * Rhat + ct * Zhat = (st, 0, ct)
     // that = ct * Rhat - st * Zhat = (ct, 0, -st)
     // phat = phat                  = (0, 1,0)
@@ -221,12 +226,12 @@ class Coords<Coordinates::spherical3D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToAxi(const std::array<Real, 3> &xi) {
+  ConvertCoordsToAxi(const std::array<Real, 3> &xi) const {
     const Real ct = std::cos(xi[1]);
     const Real st = std::sin(xi[1]);
     return {xi[0] * st, xi[0] * ct, xi[2]};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) const {
     const Real ct = std::cos(xi[1]);
     const Real st = std::sin(xi[1]);
     std::array<Real, 3> ex1{st, ct, 0.0};
@@ -243,26 +248,31 @@ class Coords<Coordinates::spherical2D>
 
  public:
   KOKKOS_INLINE_FUNCTION
-  Coords(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : CoordsBase<Coords<Coordinates::spherical2D>>(pco, k, j, i) {}
+  Coords(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,
+         const int j, const int i)
+      : CoordsBase<Coords<Coordinates::spherical2D>>(cpars, pco, k, j, i) {}
+  KOKKOS_INLINE_FUNCTION
+  Coords(const bool log, const parthenon::Coordinates_t &pco, const int k, const int j,
+         const int i)
+      : CoordsBase<Coords<Coordinates::spherical2D>>(log, pco, k, j, i) {}
   KOKKOS_INLINE_FUNCTION
   Coords() : CoordsBase<Coords<Coordinates::spherical2D>>() {}
 
-  KOKKOS_INLINE_FUNCTION bool x1dep() { return true; }
-  KOKKOS_INLINE_FUNCTION bool x2dep() { return true; }
+  KOKKOS_INLINE_FUNCTION bool x1dep() const { return true; }
+  KOKKOS_INLINE_FUNCTION bool x2dep() const { return true; }
 
-  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) const {
     return x1;
   }
-  KOKKOS_INLINE_FUNCTION Real hx3(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx3(const Real x1, const Real x2, const Real x3) const {
     return x1 * std::sin(x2);
   }
 
-  KOKKOS_INLINE_FUNCTION Real x1v() {
+  KOKKOS_INLINE_FUNCTION Real x1v() const {
     const Real dr2 = bnds.x1[0] * bnds.x1[0] + bnds.x1[1] * bnds.x1[1];
     return 0.75 * (bnds.x1[0] + bnds.x1[1]) * dr2 / (dr2 + bnds.x1[0] * bnds.x1[1]);
   }
-  KOKKOS_INLINE_FUNCTION Real x2v() {
+  KOKKOS_INLINE_FUNCTION Real x2v() const {
     // \int t * sin(t) *dt/ \int sin(t) * dt = d( sin(t) -
     // t*cos(t))/d(-cos(t))
     const Real ctm = std::cos(bnds.x2[0]);
@@ -271,8 +281,8 @@ class Coords<Coordinates::spherical2D>
     return (dst - bnds.x2[1] * ctp + bnds.x2[0] * ctm) / std::abs(ctm - ctp);
   }
 
-  KOKKOS_INLINE_FUNCTION Real hx2v() { return x1v(); }
-  KOKKOS_INLINE_FUNCTION Real hx3v() {
+  KOKKOS_INLINE_FUNCTION Real hx2v() const { return x1v(); }
+  KOKKOS_INLINE_FUNCTION Real hx3v() const {
     // \int r sin(t)  (r^2 sin(t) dr dt dp)
     // \int r^3 dr/ int r^2 dr  * \int sin^2 dt / \int sin dt
     // <r> <sin(t)>
@@ -289,7 +299,7 @@ class Coords<Coordinates::spherical2D>
     return x1v() * 0.5 * (dx2 - dsc) / std::abs(ctm - ctp);
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) const {
     // <r> = d(r^3/3) / d(r^2/2)
     return {2.0 / 3.0 *
                 (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] +
@@ -298,7 +308,7 @@ class Coords<Coordinates::spherical2D>
             bnds.x2[static_cast<int>(f)], 0.0};
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) const {
     // <r> = d(r^3/3) / d(r^2/2)
     return {2.0 / 3.0 *
                 (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] +
@@ -307,23 +317,23 @@ class Coords<Coordinates::spherical2D>
             0.5 * (bnds.x2[0] + bnds.x2[1]), 0.0};
   }
 
-  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) const {
     // \int r^2 sin(t) dp*dt = d(-cos(t)) * r^2 *dp
     return x1f * x1f * std::abs(std::cos(bnds.x2[0]) - std::cos(bnds.x2[1]));
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) const {
     // \int r*sin(t)*dp*dr = d(r^2/2)*sin(t)*dp
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     return 0.5 * (bnds.x1[1] + bnds.x1[0]) * std::sin(x2f) * dx1;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX3(const Real x3f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX3(const Real x3f) const {
     // \int r*dt*dr = d(r^2/2)*dt
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real dx2 = bnds.x2[1] - bnds.x2[0];
     return 0.5 * (bnds.x1[0] + bnds.x1[1]) * dx1 * dx2;
   }
 
-  KOKKOS_INLINE_FUNCTION Real Volume() {
+  KOKKOS_INLINE_FUNCTION Real Volume() const {
     // \int r^2 sin(t) dr dt dp = d(r^3/3) d(-cos(t)) dp
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real rfac =
@@ -333,20 +343,20 @@ class Coords<Coordinates::spherical2D>
     return rfac * dx1 * dx2;
   }
 
-  KOKKOS_INLINE_FUNCTION Real dh2dx1() {
+  KOKKOS_INLINE_FUNCTION Real dh2dx1() const {
     return 3.0 / 2.0 * (bnds.x1[0] + bnds.x1[1]) /
            (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] + bnds.x1[1] * bnds.x1[1]);
   }
-  KOKKOS_INLINE_FUNCTION Real dh3dx1() {
+  KOKKOS_INLINE_FUNCTION Real dh3dx1() const {
     return 3.0 / 2.0 * (bnds.x1[0] + bnds.x1[1]) /
            (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] + bnds.x1[1] * bnds.x1[1]);
   }
-  KOKKOS_INLINE_FUNCTION Real dh3dx2() {
+  KOKKOS_INLINE_FUNCTION Real dh3dx2() const {
     return (std::sin(bnds.x2[1]) - std::sin(bnds.x2[0])) /
            std::abs(std::cos(bnds.x2[0]) - std::cos(bnds.x2[1]));
   }
 
-  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() {
+  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() const {
     // Set the flux averaging weights in the rotating frame for the angular momentum
     // \pm ( <R^2>_j^\pm - <R^2> ) where R is the cylindrical radius
 
@@ -370,14 +380,14 @@ class Coords<Coordinates::spherical2D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCart(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCart(const std::array<Real, 3> &xi) const {
     const Real cp = 1.0;
     const Real sp = 0.0;
     const Real ct = std::cos(xi[1]);
     const Real st = std::sin(xi[1]);
     return {xi[0] * st * cp, xi[0] * st * sp, xi[0] * ct};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) const {
     const Real cp = 1.0;
     const Real sp = 0.0;
     const Real ct = std::cos(xi[1]);
@@ -389,10 +399,10 @@ class Coords<Coordinates::spherical2D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToSph(const std::array<Real, 3> &xi) {
+  ConvertCoordsToSph(const std::array<Real, 3> &xi) const {
     return xi;
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) const {
     std::array<Real, 3> ex1{1.0, 0.0, 0.0};
     std::array<Real, 3> ex2{0.0, 1.0, 0.0};
     std::array<Real, 3> ex3{0.0, 0.0, 1.0};
@@ -400,7 +410,7 @@ class Coords<Coordinates::spherical2D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCyl(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCyl(const std::array<Real, 3> &xi) const {
     // rhat = st * Rhat + ct * Zhat = (st, 0, ct)
     // that = ct * Rhat - st * Zhat = (ct, 0, -st)
     // phat = phat                  = (0, 1,0)
@@ -409,7 +419,7 @@ class Coords<Coordinates::spherical2D>
 
     return {xi[0] * st, 0.0, xi[0] * ct};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) const {
     // rhat = st * Rhat + ct * Zhat = (st, 0, ct)
     // that = ct * Rhat - st * Zhat = (ct, 0, -st)
     // phat = phat                  = (0, 1,0)
@@ -422,12 +432,12 @@ class Coords<Coordinates::spherical2D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToAxi(const std::array<Real, 3> &xi) {
+  ConvertCoordsToAxi(const std::array<Real, 3> &xi) const {
     const Real ct = std::cos(xi[1]);
     const Real st = std::sin(xi[1]);
     return {xi[0] * st, xi[0] * ct, 0.0};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) const {
     const Real ct = std::cos(xi[1]);
     const Real st = std::sin(xi[1]);
     std::array<Real, 3> ex1{st, ct, 0.0};
@@ -444,23 +454,28 @@ class Coords<Coordinates::spherical1D>
 
  public:
   KOKKOS_INLINE_FUNCTION
-  Coords(const parthenon::Coordinates_t &pco, const int k, const int j, const int i)
-      : CoordsBase<Coords<Coordinates::spherical1D>>(pco, k, j, i) {}
+  Coords(const CoordParams &cpars, const parthenon::Coordinates_t &pco, const int k,
+         const int j, const int i)
+      : CoordsBase<Coords<Coordinates::spherical1D>>(cpars, pco, k, j, i) {}
+  KOKKOS_INLINE_FUNCTION
+  Coords(const bool log, const parthenon::Coordinates_t &pco, const int k, const int j,
+         const int i)
+      : CoordsBase<Coords<Coordinates::spherical1D>>(log, pco, k, j, i) {}
   KOKKOS_INLINE_FUNCTION
   Coords() : CoordsBase<Coords<Coordinates::spherical1D>>() {}
 
-  KOKKOS_INLINE_FUNCTION bool x1dep() { return true; }
+  KOKKOS_INLINE_FUNCTION bool x1dep() const { return true; }
 
-  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) {
+  KOKKOS_INLINE_FUNCTION Real hx2(const Real x1, const Real x2, const Real x3) const {
     return x1;
   }
 
-  KOKKOS_INLINE_FUNCTION Real x1v() {
+  KOKKOS_INLINE_FUNCTION Real x1v() const {
     const Real dr2 = bnds.x1[0] * bnds.x1[0] + bnds.x1[1] * bnds.x1[1];
     return 0.75 * (bnds.x1[0] + bnds.x1[1]) * dr2 / (dr2 + bnds.x1[0] * bnds.x1[1]);
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX2(const CellFace f) const {
     // <r> = d(r^3/3) / d(r^2/2)
     return {2.0 / 3.0 *
                 (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] +
@@ -469,7 +484,7 @@ class Coords<Coordinates::spherical1D>
             M_PI * 0.5, 0.0};
   }
 
-  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) {
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> FaceCenX3(const CellFace f) const {
     // <r> = d(r^3/3) / d(r^2/2)
     return {2.0 / 3.0 *
                 (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] +
@@ -478,22 +493,22 @@ class Coords<Coordinates::spherical1D>
             M_PI * 0.5, 0.0};
   }
 
-  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX1(const Real x1f) const {
     // \int r^2 sin(t) dp*dt = d(-cos(t)) * r^2 *dp
     return x1f * x1f;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX2(const Real x2f) const {
     // \int r*sin(t)*dp*dr = d(r^2/2)*sin(t)*dp
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     return 0.5 * (bnds.x1[1] + bnds.x1[0]) * dx1;
   }
-  KOKKOS_INLINE_FUNCTION Real AreaX3(const Real x3f) {
+  KOKKOS_INLINE_FUNCTION Real AreaX3(const Real x3f) const {
     // \int r*dt*dr = d(r^2/2)*dt
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     return 0.5 * (bnds.x1[0] + bnds.x1[1]) * dx1;
   }
 
-  KOKKOS_INLINE_FUNCTION Real Volume() {
+  KOKKOS_INLINE_FUNCTION Real Volume() const {
     // \int r^2 sin(t) dr dt dp = d(r^3/3) d(-cos(t)) dp
     const Real dx1 = bnds.x1[1] - bnds.x1[0];
     const Real rfac =
@@ -502,16 +517,16 @@ class Coords<Coordinates::spherical1D>
     return rfac * dx1;
   }
 
-  KOKKOS_INLINE_FUNCTION Real dh2dx1() {
+  KOKKOS_INLINE_FUNCTION Real dh2dx1() const {
     return 3.0 / 2.0 * (bnds.x1[0] + bnds.x1[1]) /
            (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] + bnds.x1[1] * bnds.x1[1]);
   }
-  KOKKOS_INLINE_FUNCTION Real dh3dx1() {
+  KOKKOS_INLINE_FUNCTION Real dh3dx1() const {
     return 3.0 / 2.0 * (bnds.x1[0] + bnds.x1[1]) /
            (bnds.x1[0] * bnds.x1[0] + bnds.x1[0] * bnds.x1[1] + bnds.x1[1] * bnds.x1[1]);
   }
 
-  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() {
+  KOKKOS_INLINE_FUNCTION Mat3x2 RFWeights() const {
     // Set the flux averaging weights in the rotating frame for the angular momentum
     // \pm ( <R^2>_j^\pm - <R^2> ) where R is the cylindrical radius
 
@@ -526,14 +541,14 @@ class Coords<Coordinates::spherical1D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCart(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCart(const std::array<Real, 3> &xi) const {
     const Real cp = 1.0;
     const Real sp = 0.0;
     const Real ct = 0.0;
     const Real st = 1.0;
     return {xi[0] * st * cp, xi[0] * st * sp, xi[0] * ct};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCart(const std::array<Real, 3> &xi) const {
     const Real cp = 1.0;
     const Real sp = 0.0;
     const Real ct = 0.0;
@@ -545,10 +560,10 @@ class Coords<Coordinates::spherical1D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToSph(const std::array<Real, 3> &xi) {
+  ConvertCoordsToSph(const std::array<Real, 3> &xi) const {
     return xi;
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToSph(const std::array<Real, 3> &xi) const {
     std::array<Real, 3> ex1{1.0, 0.0, 0.0};
     std::array<Real, 3> ex2{0.0, 1.0, 0.0};
     std::array<Real, 3> ex3{0.0, 0.0, 1.0};
@@ -556,7 +571,7 @@ class Coords<Coordinates::spherical1D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToCyl(const std::array<Real, 3> &xi) {
+  ConvertCoordsToCyl(const std::array<Real, 3> &xi) const {
     // rhat = st * Rhat + ct * Zhat = (st, 0, ct)
     // that = ct * Rhat - st * Zhat = (ct, 0, -st)
     // phat = phat                  = (0, 1,0)
@@ -565,7 +580,7 @@ class Coords<Coordinates::spherical1D>
 
     return {xi[0] * st, 0.0, xi[0] * ct};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToCyl(const std::array<Real, 3> &xi) const {
     // rhat = st * Rhat + ct * Zhat = (st, 0, ct)
     // that = ct * Rhat - st * Zhat = (ct, 0, -st)
     // phat = phat                  = (0, 1,0)
@@ -578,12 +593,12 @@ class Coords<Coordinates::spherical1D>
   }
 
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  ConvertCoordsToAxi(const std::array<Real, 3> &xi) {
+  ConvertCoordsToAxi(const std::array<Real, 3> &xi) const {
     const Real ct = 0.0;
     const Real st = 1.0;
     return {xi[0] * st, xi[0] * ct, 0.0};
   }
-  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) {
+  KOKKOS_INLINE_FUNCTION Mat3x3 ConvertVecToAxi(const std::array<Real, 3> &xi) const {
     const Real ct = 0.0;
     const Real st = 1.0;
     std::array<Real, 3> ex1{st, ct, 0.0};

--- a/src/gravity/binary_mass.cpp
+++ b/src/gravity/binary_mass.cpp
@@ -71,6 +71,7 @@ TaskStatus BinaryMassGravity(MeshData<Real> *md, const Real time, const Real dt)
     pos1[n] = com[n] - mu2 * rb[n];
     pos2[n] = com[n] + mu1 * rb[n];
   }
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   // Packing and indexing
   static auto desc =
@@ -91,7 +92,7 @@ TaskStatus BinaryMassGravity(MeshData<Real> *md, const Real time, const Real dt)
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinate information
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &dx = coords.GetCellCenter();
         const auto &[dxc1_, ex1, ex2, ex3] = coords.ConvertToCartWithVec(dx);
         auto dxc1 = dxc1_;

--- a/src/gravity/nbody_gravity.hpp
+++ b/src/gravity/nbody_gravity.hpp
@@ -25,13 +25,12 @@ namespace Gravity {
 //! \brief Process fluids, applying effects of gravitational accelerations and accretion
 template <Coordinates GEOM, typename V1>
 KOKKOS_INLINE_FUNCTION void
-NBodyGravityImpl(V1 vmesh, const NBody::Particle &pl,
-                 ArtemisUtils::array_type<Real, 7> &lforce, const int b, const int k,
-                 const int j, const int i, const bool do_gas, const bool do_dust,
-                 const Real qshear, const Real omb, const Real omf, const Real time,
-                 const Real dt) {
+NBodyGravityImpl(V1 vmesh, const geometry::Coords<GEOM> &coords,
+                 const NBody::Particle &pl, ArtemisUtils::array_type<Real, 7> &lforce,
+                 const int b, const int k, const int j, const int i, const bool do_gas,
+                 const bool do_dust, const Real qshear, const Real omb, const Real omf,
+                 const Real time, const Real dt) {
   // Extract coordinates
-  geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
   const auto &x = coords.GetCellCenter();
   const auto &[xcart, ex1, ex2, ex3] = coords.ConvertToCartWithVec(x);
   const auto &hx = coords.GetScaleFactors();
@@ -190,6 +189,7 @@ TaskStatus NBodyGravity(MeshData<Real> *md, const Real time, const Real dt) {
       qshear = rf_pkg->template Param<Real>("qshear");
     }
   }
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   // Grab all the relevent nbody data
   auto particles = nbody_pkg->template Param<ParArray1D<NBody::Particle>>("particles");
@@ -216,8 +216,9 @@ TaskStatus NBodyGravity(MeshData<Real> *md, const Real time, const Real dt) {
         KOKKOS_LAMBDA(const int b, const int k, const int j, const int i,
                       ArtemisUtils::array_type<Real, 7> &lsum) {
           if (particles(n).couple) {
-            NBodyGravityImpl<GEOM>(vmesh, particles(n), lsum, b, k, j, i, do_gas, do_dust,
-                                   qshear, omb, omf, time, dt);
+            const geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
+            NBodyGravityImpl<GEOM>(vmesh, coords, particles(n), lsum, b, k, j, i, do_gas,
+                                   do_dust, qshear, omb, omf, time, dt);
           }
         },
         ArtemisUtils::SumMyArray<Real, Kokkos::HostSpace, 7>(lforce));

--- a/src/gravity/point_mass.cpp
+++ b/src/gravity/point_mass.cpp
@@ -34,6 +34,8 @@ TaskStatus PointMassGravity(MeshData<Real> *md, const Real time, const Real dt) 
   const bool do_gas = artemis_pkg->template Param<bool>("do_gas");
   const bool do_dust = artemis_pkg->template Param<bool>("do_dust");
 
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
+
   auto &gravity_pkg = pm->packages.Get("gravity");
   const Real gm_ = gravity_pkg->template Param<Real>("gm");
   const Real sink_rate = dt * (gravity_pkg->template Param<Real>("sink_rate"));
@@ -64,7 +66,7 @@ TaskStatus PointMassGravity(MeshData<Real> *md, const Real time, const Real dt) 
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &dx = coords.GetCellCenter();
         const auto &hx = coords.GetScaleFactors();
 

--- a/src/gravity/uniform.cpp
+++ b/src/gravity/uniform.cpp
@@ -40,6 +40,8 @@ TaskStatus UniformGravity(MeshData<Real> *md, const Real time, const Real dt) {
   const Real gx2 = gravity_pkg->template Param<Real>("gx2");
   const Real gx3 = gravity_pkg->template Param<Real>("gx3");
 
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
+
   static auto desc =
       MakePackDescriptor<gas::cons::momentum, gas::cons::total_energy,
                          dust::cons::momentum, gas::prim::density, gas::prim::velocity,
@@ -54,7 +56,7 @@ TaskStatus UniformGravity(MeshData<Real> *md, const Real time, const Real dt) {
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
         const auto &hx = coords.GetScaleFactors();
 
         if (do_gas) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ parthenon::DriverStatus LaunchWorkFlow(parthenon::ParthenonManager &pman,
   // (2) Call ParthenonInit to set up the mesh and packages
   // (3) Execute driver
   std::string sys = pin->GetOrAddString("artemis", "coordinates", "cartesian");
-  std::string spacing = pin->GetOrAddString("artemis", "spacing", "uniform");
+  std::string spacing = pin->GetOrAddString("artemis", "radial_spacing", "uniform");
   if (spacing == "logarithmic") {
     PARTHENON_REQUIRE(sys != "cartesian",
                       "Cannot have logarithmic spacing with Cartesian coordinates");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,11 @@ parthenon::DriverStatus LaunchWorkFlow(parthenon::ParthenonManager &pman,
   // (2) Call ParthenonInit to set up the mesh and packages
   // (3) Execute driver
   std::string sys = pin->GetOrAddString("artemis", "coordinates", "cartesian");
+  std::string spacing = pin->GetOrAddString("artemis", "spacing", "uniform");
+  if (spacing == "logarithmic") {
+    PARTHENON_REQUIRE(sys != "cartesian",
+                      "Cannot have logarithmic spacing with Cartesian coordinates");
+  }
   const int nx[3] = {pin->GetInteger("parthenon/mesh", "nx1"),
                      pin->GetInteger("parthenon/mesh", "nx2"),
                      pin->GetInteger("parthenon/mesh", "nx3")};

--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -282,6 +282,8 @@ AmrTag DistanceRefinement(MeshBlockData<Real> *md) {
   auto particles = nbody_pkg->Param<ParArray1D<NBody::Particle>>("particles");
   const auto npart = static_cast<int>(particles.size());
   const auto derefine_factor = nbody_pkg->Param<Real>("derefine_factor");
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   IndexRange ib = md->GetBoundsI(IndexDomain::interior);
   IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
@@ -293,7 +295,7 @@ AmrTag DistanceRefinement(MeshBlockData<Real> *md) {
       kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i, Real &ldist) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const auto &x = coords.GetCellCenter();
 
         const auto &xcart = coords.ConvertToCart(x);

--- a/src/pgen/advection.hpp
+++ b/src/pgen/advection.hpp
@@ -182,13 +182,14 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
   auto &pco = pmb->coords;
   auto adv = av;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for(
       "pgen_linwave1", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
         // cell-centered coordinates
 
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const auto &xv = coords.GetCellCenter();
 
         const Real x1v = xv[0];
@@ -260,6 +261,7 @@ inline void UserWorkAfterLoop(Mesh *pmesh, ParameterInput *pin, parthenon::SimTi
   auto artemis_pkg = pmb->packages.Get("artemis");
   const bool do_gas = artemis_pkg->Param<bool>("do_gas");
   const bool do_dust = artemis_pkg->Param<bool>("do_dust");
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   ArtemisUtils::array_type<Real, nvars> l1_err;
   parthenon::par_reduce(
@@ -268,7 +270,7 @@ inline void UserWorkAfterLoop(Mesh *pmesh, ParameterInput *pin, parthenon::SimTi
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i,
                     ArtemisUtils::array_type<Real, nvars> &lsum) {
         // Capture coordinates this Meshblock
-        geometry::Coords<GEOM> coords(v.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, v.GetCoordinates(b), k, j, i);
         const auto &xv = coords.GetCellCenter();
         Real x1v = xv[0];
         Real x2v = xv[1];

--- a/src/pgen/beam.hpp
+++ b/src/pgen/beam.hpp
@@ -86,11 +86,12 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   auto &pars = artemis_pkg->Param<BeamParams>("beam_params");
   auto &pco = pmb->coords;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
   pmb->par_for(
       "pgen_beam", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
         // cell-centered coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const auto &xv = coords.GetCellCenter();
         // compute cell-centered conserved variables
         if (do_gas) {
@@ -149,12 +150,13 @@ inline void BeamInnerX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) 
   const auto &bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
   const auto &range = bounds.GetBoundsJ(IndexDomain::interior, TE::CC);
   const int js = range.s;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for_bndry(
       "BeamInnerX2", nb, IndexDomain::inner_x2, parthenon::TopologicalElement::CC, coarse,
       fine, KOKKOS_LAMBDA(const int &l, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const Real xf = coords.bnds.x1[0];
 
         // Gas Inner X2 BC
@@ -225,11 +227,12 @@ inline void BeamInnerX1(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) 
   const int is = range.s;
 
   auto &pars = artemis_pkg->Param<BeamParams>("beam_params");
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
   pmb->par_for_bndry(
       "BeamInnerX1", nb, IndexDomain::inner_x1, parthenon::TopologicalElement::CC, coarse,
       fine, KOKKOS_LAMBDA(const int &l, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const Real yf = coords.bnds.x2[0];
 
         // Gas Inner X1 BC

--- a/src/pgen/blast.hpp
+++ b/src/pgen/blast.hpp
@@ -170,12 +170,13 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
   auto &pco = pmb->coords;
   auto pars = blast_params;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   // setup uniform ambient medium with spherical over-pressured region
   pmb->par_for(
       "blast", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         Real total_vol = coords.Volume();
         const auto &xv = coords.GetCellCenter();
         Real den = pars.d0;

--- a/src/pgen/conduction.hpp
+++ b/src/pgen/conduction.hpp
@@ -85,7 +85,7 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   }
 
   // Problem specific params
-  const Real x1min = pin->GetReal("parthenon/mesh", "x1min");
+  const Real x1min = pin->GetReal("artemis/mesh", "x1min");
 
   // Packing and capture variables for kernel
   auto &md = pmb->meshblock_data.Get();

--- a/src/pgen/conduction.hpp
+++ b/src/pgen/conduction.hpp
@@ -101,12 +101,13 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
   auto &pco = pmb->coords;
   auto pars = cond_params;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for(
       "conduction", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
         if (do_gas) {
-          geometry::Coords<GEOM> coords(pco, k, j, i);
+          geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
           const auto &xv = coords.GetCellCenter();
 
           const Real P0 = eos_d.PressureFromDensityTemperature(pars.g_rho, pars.g_temp);
@@ -147,7 +148,7 @@ void CondBoundaryImpl(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) {
                                                  gas::prim::sie>(mbd);
   auto v = descriptors[coarse].GetPack(mbd.get());
   if (v.GetMaxNumberOfVars() == 0) return;
-
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
   // Indexing
   const auto &pco = (coarse) ? pmb->pmr->GetCoarseCoords() : pmb->coords;
   auto &dp = cond_params;
@@ -213,11 +214,11 @@ void CondBoundaryImpl(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) {
                            x1dir ? ((BDY == IndexDomain::inner_x1) ? is : ie) : i};
 
         // Extract coordinates at k, j, i
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const auto &xv = coords.GetCellCenter();
 
         // Extract coordinates at ia, im, ic
-        geometry::Coords<GEOM> ca(pco, ia[0], ia[1], ia[2]);
+        geometry::Coords<GEOM> ca(cpars, pco, ia[0], ia[1], ia[2]);
         const auto &xva = ca.GetCellCenter();
 
         const Real xma = (INNER ? -1. : 1.) * coords.Distance(xv, xva);

--- a/src/pgen/conduction.hpp
+++ b/src/pgen/conduction.hpp
@@ -85,7 +85,7 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   }
 
   // Problem specific params
-  const Real x1min = pin->GetReal("artemis/mesh", "x1min");
+  const Real x1min = pin->GetReal("parthenon/mesh", "x1min");
 
   // Packing and capture variables for kernel
   auto &md = pmb->meshblock_data.Get();

--- a/src/pgen/conduction.hpp
+++ b/src/pgen/conduction.hpp
@@ -85,7 +85,7 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   }
 
   // Problem specific params
-  const Real x1min = pin->GetReal("parthenon/mesh", "x1min");
+  const Real x1min = artemis_pkg->Param<Real>("x1min");
 
   // Packing and capture variables for kernel
   auto &md = pmb->meshblock_data.Get();

--- a/src/pgen/constant.hpp
+++ b/src/pgen/constant.hpp
@@ -100,11 +100,12 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   constant_params.input_system = geometry::CoordSelect(input_system, ndim);
   constant_params.system = geometry::CoordSelect(system, ndim);
 
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
   // setup uniform ambient medium
   pmb->par_for(
       "constant", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const auto &xi = coords.GetCellCenter();
 
         auto xo = NewArray<Real, 3>();

--- a/src/pgen/disk.hpp
+++ b/src/pgen/disk.hpp
@@ -68,6 +68,7 @@ struct DiskParams {
   bool do_gas, do_dust, do_moment, do_imc;
   bool nbody_temp;
   bool quiet_start;
+  bool log;
 };
 
 //----------------------------------------------------------------------------------------
@@ -141,7 +142,7 @@ ComputeDiskProfile(const struct DiskParams pgen, const parthenon::Coordinates_t 
                    const bool do_dust, Real &ddens, Real &dvel1, Real &dvel2, Real &dvel3,
                    ParArray1D<NBody::Particle> particles, const int npart) {
   // Extract coordinates
-  geometry::Coords<GEOM> coords(pco, k, j, i);
+  geometry::Coords<GEOM> coords(pgen.log, pco, k, j, i);
   const auto &xv = coords.GetCellCenter();
 
   const auto &[xcyl, ex1, ex2, ex3] = coords.ConvertToCylWithVec(xv);
@@ -258,6 +259,7 @@ inline void InitDiskParams(MeshBlock *pmb, ParameterInput *pin) {
   Params &params = artemis_pkg->AllParams();
   if (!(params.hasKey("disk_params"))) {
     DiskParams disk_params;
+    disk_params.log = artemis_pkg->Param<geometry::CoordParams>("coord_params").log;
     auto &grav_pkg = pmb->packages.Get("gravity");
     auto &gas_pkg = pmb->packages.Get("gas");
 
@@ -508,14 +510,14 @@ void DiskBoundaryVisc(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) {
         const int im1[3] = {k, j, (BDY == IndexDomain::inner_x1) ? is : ie - 1};
 
         // Extract coordinates at k, j, i
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(dp.log, pco, k, j, i);
         const auto &xv = coords.GetCellCenter();
         const auto &[xcyl, ex1, ex2, ex3] = coords.ConvertToCylWithVec(xv);
 
         // Extract coordinates at ia, im, ic
-        geometry::Coords<GEOM> ca(pco, ia[0], ia[1], ia[2]);
-        geometry::Coords<GEOM> cp1(pco, ip1[0], ip1[1], ip1[2]);
-        geometry::Coords<GEOM> cm1(pco, im1[0], im1[1], im1[2]);
+        geometry::Coords<GEOM> ca(dp.log, pco, ia[0], ia[1], ia[2]);
+        geometry::Coords<GEOM> cp1(dp.log, pco, ip1[0], ip1[1], ip1[2]);
+        geometry::Coords<GEOM> cm1(dp.log, pco, im1[0], im1[1], im1[2]);
         const auto &xva = ca.GetCellCenter();
         const auto &[xcyla, scr1, scr2, scr3] = ca.ConvertToCylWithVec(xva);
         const Real eRa[3] = {scr1[0], scr2[0], scr3[0]};
@@ -762,14 +764,14 @@ void DiskBoundaryExtrap(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) 
                               x1dir ? ((BDY == IndexDomain::inner_x1) ? is : ie - 1) : i};
 
           // Extract coordinates at k, j, i
-          geometry::Coords<GEOM> coords(pco, k, j, i);
+          geometry::Coords<GEOM> coords(dp.log, pco, k, j, i);
           const auto &xv = coords.GetCellCenter();
           const auto &[xcyl, ex1, ex2, ex3] = coords.ConvertToCylWithVec(xv);
 
           // Extract coordinates at ia, im, ic
-          geometry::Coords<GEOM> ca(pco, ia[0], ia[1], ia[2]);
-          geometry::Coords<GEOM> cp1(pco, ip1[0], ip1[1], ip1[2]);
-          geometry::Coords<GEOM> cm1(pco, im1[0], im1[1], im1[2]);
+          geometry::Coords<GEOM> ca(dp.log, pco, ia[0], ia[1], ia[2]);
+          geometry::Coords<GEOM> cp1(dp.log, pco, ip1[0], ip1[1], ip1[2]);
+          geometry::Coords<GEOM> cm1(dp.log, pco, im1[0], im1[1], im1[2]);
           const auto &xva = ca.GetCellCenter();
           const auto &[xcyla, scr1, scr2, scr3] = ca.ConvertToCylWithVec(xva);
           const Real eRa[3] = {scr1[0], scr2[0], scr3[0]};

--- a/src/pgen/gaussian_bump.hpp
+++ b/src/pgen/gaussian_bump.hpp
@@ -111,10 +111,13 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const bool three_d = (pm->ndim == 3);
   const Real gamma = pin->GetReal("gas", "gamma");
   const Real cv = 1.0 / (gamma - 1.);
+
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
   pmb->par_for(
       "constant", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const auto &xi = coords.GetCellCenter();
 
         auto xo = NewArray<Real, 3>();

--- a/src/pgen/linear_wave.hpp
+++ b/src/pgen/linear_wave.hpp
@@ -224,12 +224,14 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
   auto &pco = pmb->coords;
   auto lin = lwv;
+  const auto &cpars =
+      pmb->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for(
       "pgen_linwave1", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
         // cell-centered coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const auto &xv = coords.GetCellCenter();
         const Real x1v = xv[0];
         const Real x2v = xv[1];
@@ -280,6 +282,9 @@ inline void UserWorkAfterLoop(Mesh *pmesh, ParameterInput *pin, parthenon::SimTi
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);
   auto lin = lwv;
+  const auto &cpars =
+      pmesh->packages.Get("artemis")->template Param<geometry::CoordParams>(
+          "coord_params");
 
   ArtemisUtils::array_type<Real, nvars> l1_err;
   parthenon::par_reduce(
@@ -288,7 +293,7 @@ inline void UserWorkAfterLoop(Mesh *pmesh, ParameterInput *pin, parthenon::SimTi
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i,
                     ArtemisUtils::array_type<Real, nvars> &lsum) {
         // Capture coordinates this Meshblock
-        geometry::Coords<GEOM> coords(v.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, v.GetCoordinates(b), k, j, i);
         const auto &xv = coords.GetCellCenter();
         Real x1v = xv[0];
         Real x2v = xv[1];

--- a/src/pgen/rt.hpp
+++ b/src/pgen/rt.hpp
@@ -82,12 +82,12 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   Real gx = 0.0;
   Real zmin = Null<Real>(), zmax = Null<Real>();
   if (three_d) {
-    zmin = pin->GetReal("parthenon/mesh", "x3min");
-    zmax = pin->GetReal("parthenon/mesh", "x3max");
+    zmin = pin->GetReal("artemis/mesh", "x3min");
+    zmax = pin->GetReal("artemis/mesh", "x3max");
     if (do_grav) gx = grav_pkg->Param<Real>("gx3");
   } else {
-    zmin = pin->GetReal("parthenon/mesh", "x2min");
-    zmax = pin->GetReal("parthenon/mesh", "x2max");
+    zmin = pin->GetReal("artemis/mesh", "x2min");
+    zmax = pin->GetReal("artemis/mesh", "x2max");
     if (do_grav) gx = grav_pkg->Param<Real>("gx2");
   }
 

--- a/src/pgen/rt.hpp
+++ b/src/pgen/rt.hpp
@@ -82,12 +82,12 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   Real gx = 0.0;
   Real zmin = Null<Real>(), zmax = Null<Real>();
   if (three_d) {
-    zmin = pin->GetReal("artemis/mesh", "x3min");
-    zmax = pin->GetReal("artemis/mesh", "x3max");
+    zmin = pin->GetReal("parthenon/mesh", "x3min");
+    zmax = pin->GetReal("parthenon/mesh", "x3max");
     if (do_grav) gx = grav_pkg->Param<Real>("gx3");
   } else {
-    zmin = pin->GetReal("artemis/mesh", "x2min");
-    zmax = pin->GetReal("artemis/mesh", "x2max");
+    zmin = pin->GetReal("parthenon/mesh", "x2min");
+    zmax = pin->GetReal("parthenon/mesh", "x2max");
     if (do_grav) gx = grav_pkg->Param<Real>("gx2");
   }
 

--- a/src/pgen/rt.hpp
+++ b/src/pgen/rt.hpp
@@ -82,12 +82,12 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   Real gx = 0.0;
   Real zmin = Null<Real>(), zmax = Null<Real>();
   if (three_d) {
-    zmin = pin->GetReal("parthenon/mesh", "x3min");
-    zmax = pin->GetReal("parthenon/mesh", "x3max");
+    zmin = artemis_pkg->Param<Real>("x3min");
+    zmax = artemis_pkg->Param<Real>("x3max");
     if (do_grav) gx = grav_pkg->Param<Real>("gx3");
   } else {
-    zmin = pin->GetReal("parthenon/mesh", "x2min");
-    zmax = pin->GetReal("parthenon/mesh", "x2max");
+    zmin = artemis_pkg->Param<Real>("x2min");
+    zmax = artemis_pkg->Param<Real>("x2max");
     if (do_grav) gx = grav_pkg->Param<Real>("gx2");
   }
 

--- a/src/pgen/shock.hpp
+++ b/src/pgen/shock.hpp
@@ -103,12 +103,13 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   // Shock parameters
   auto shkp = artemis_pkg->Param<ShockParams>("shock_params");
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   // Setup shock state
   pmb->par_for(
       "shock", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const auto &xi = coords.GetCellCenter();
         const bool upwind = (xi[0] <= shkp.xdisc);
         const Real rho = upwind ? shkp.rhol : shkp.rhor;

--- a/src/pgen/strat.hpp
+++ b/src/pgen/strat.hpp
@@ -69,7 +69,7 @@ inline void InitStratParams(MeshBlock *pmb, ParameterInput *pin) {
   Params &params = artemis_pkg->AllParams();
   if (!(params.hasKey("strat_params"))) {
     StratParams strat_params;
-    strat_params.three_d = pin->GetInteger("parthenon/mesh", "nx3") > 1;
+    strat_params.three_d = pin->GetInteger("artemis/mesh", "nx3") > 1;
     strat_params.q = pmb->packages.Get("rotating_frame")->Param<Real>("qshear");
     strat_params.Om0 = pmb->packages.Get("rotating_frame")->Param<Real>("omega");
     strat_params.h = pin->GetOrAddReal("problem", "h", 1.0);

--- a/src/pgen/strat.hpp
+++ b/src/pgen/strat.hpp
@@ -69,7 +69,7 @@ inline void InitStratParams(MeshBlock *pmb, ParameterInput *pin) {
   Params &params = artemis_pkg->AllParams();
   if (!(params.hasKey("strat_params"))) {
     StratParams strat_params;
-    strat_params.three_d = pin->GetInteger("artemis/mesh", "nx3") > 1;
+    strat_params.three_d = pin->GetInteger("parthenon/mesh", "nx3") > 1;
     strat_params.q = pmb->packages.Get("rotating_frame")->Param<Real>("qshear");
     strat_params.Om0 = pmb->packages.Get("rotating_frame")->Param<Real>("omega");
     strat_params.h = pin->GetOrAddReal("problem", "h", 1.0);

--- a/src/pgen/strat.hpp
+++ b/src/pgen/strat.hpp
@@ -140,12 +140,13 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
   auto &pco = pmb->coords;
   const auto &pars = strat_params;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for(
       "strat", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const Real x = coords.x1v();
         const Real z = coords.x3v();
 
@@ -213,15 +214,16 @@ inline void ExtrapInnerX1(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse
   const auto &bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
   const auto &range = bounds.GetBoundsI(IndexDomain::interior, TE::CC);
   const int is = range.s;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for_bndry(
       "StratInnerX1", nb, IndexDomain::inner_x1, parthenon::TopologicalElement::CC,
       coarse, fine,
       KOKKOS_LAMBDA(const int &l, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
-        geometry::Coords<GEOM> coords_s(pco, k, j, is);
-        geometry::Coords<GEOM> coords_s1(pco, k, j, is + 1);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+        geometry::Coords<GEOM> coords_s(cpars, pco, k, j, is);
+        geometry::Coords<GEOM> coords_s1(cpars, pco, k, j, is + 1);
         const Real x = coords.x1v();
         const Real x0 = coords_s.x1v();
         const Real x1 = coords_s1.x1v();
@@ -304,15 +306,16 @@ inline void ExtrapOuterX1(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse
   const auto &bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
   const auto &range = bounds.GetBoundsI(IndexDomain::interior, TE::CC);
   const int ie = range.e;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for_bndry(
       "StratOuterX1", nb, IndexDomain::outer_x1, parthenon::TopologicalElement::CC,
       coarse, fine,
       KOKKOS_LAMBDA(const int &l, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
-        geometry::Coords<GEOM> coords_e(pco, k, j, ie);
-        geometry::Coords<GEOM> coords_e1(pco, k, j, ie - 1);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+        geometry::Coords<GEOM> coords_e(cpars, pco, k, j, ie);
+        geometry::Coords<GEOM> coords_e1(cpars, pco, k, j, ie - 1);
         const Real x0 = coords_e.x1v();
         const Real x1 = coords_e1.x1v();
         const Real dx = x0 - x1;
@@ -414,13 +417,14 @@ inline void ShearInnerX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
   const auto &bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
   const auto &range = bounds.GetBoundsJ(IndexDomain::interior, TE::CC);
   const int js = range.s;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for_bndry(
       "StratInnerX2", nb, IndexDomain::inner_x2, parthenon::TopologicalElement::CC,
       coarse, fine,
       KOKKOS_LAMBDA(const int &l, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const Real z = coords.x3v();
         const Real x = coords.x1v();
         const Real xf = coords.bnds.x1[0];
@@ -534,13 +538,14 @@ inline void ShearOuterX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
   const auto &bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
   const auto &range = bounds.GetBoundsJ(IndexDomain::interior, TE::CC);
   const int je = range.e;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for_bndry(
       "StratOuterX2", nb, IndexDomain::outer_x2, parthenon::TopologicalElement::CC,
       coarse, fine,
       KOKKOS_LAMBDA(const int &l, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
         const Real z = coords.x3v();
         const Real x = coords.x1v();
         const Real xf = coords.bnds.x1[0];
@@ -642,14 +647,15 @@ inline void ExtrapInnerX3(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse
   const auto &bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
   const auto &range = bounds.GetBoundsK(IndexDomain::interior, TE::CC);
   const int ks = range.s;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for_bndry(
       "StratInnerX3", nb, IndexDomain::inner_x3, parthenon::TopologicalElement::CC,
       coarse, fine,
       KOKKOS_LAMBDA(const int &l, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
-        geometry::Coords<GEOM> coords_s(pco, ks, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+        geometry::Coords<GEOM> coords_s(cpars, pco, ks, j, i);
 
         const Real z = coords.x3v();
         const Real z0 = coords_s.x3v();
@@ -742,14 +748,15 @@ inline void ExtrapOuterX3(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse
   const auto &bounds = coarse ? pmb->c_cellbounds : pmb->cellbounds;
   const auto &range = bounds.GetBoundsK(IndexDomain::interior, TE::CC);
   const int ke = range.e;
+  const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
   pmb->par_for_bndry(
       "StratOuterX3", nb, IndexDomain::outer_x3, parthenon::TopologicalElement::CC,
       coarse, fine,
       KOKKOS_LAMBDA(const int &l, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(pco, k, j, i);
-        geometry::Coords<GEOM> coords_e(pco, ke, j, i);
+        geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+        geometry::Coords<GEOM> coords_e(cpars, pco, ke, j, i);
 
         const Real z = coords.x3v();
         const Real z0 = coords_e.x3v();

--- a/src/radiation/moments/matter_coupling.hpp
+++ b/src/radiation/moments/matter_coupling.hpp
@@ -56,6 +56,8 @@ TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
   const auto inner_max = moments_pkg->template Param<int>("inner_iteration_max");
   const auto outer_tol = moments_pkg->template Param<Real>("outer_iteration_tol");
   const auto inner_tol = moments_pkg->template Param<Real>("inner_iteration_tol");
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   // Extract rotating frame quantities
   Real om0 = 0.0;
@@ -85,7 +87,7 @@ TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
       DEFAULT_LOOP_PATTERN, "MatterCoupling", DevExecSpace(), 0, u0->NumBlocks() - 1,
       kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-        geometry::Coords<GEOM> coords(v0.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, j, i);
         const auto &hx = coords.GetScaleFactors();
         // y = U^(0) + dt S(y)
 
@@ -218,6 +220,8 @@ TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
     qshear = rframe_pkg->template Param<Real>("qshear");
     om0 = rframe_pkg->template Param<Real>("omega");
   }
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   // Packing and indexing
   static auto desc =
@@ -239,7 +243,7 @@ TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
       DEFAULT_LOOP_PATTERN, "MatterCoupling", DevExecSpace(), 0, u0->NumBlocks() - 1,
       kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-        geometry::Coords<GEOM> coords(v0.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, j, i);
         const auto &hx = coords.GetScaleFactors();
         // y = U^(0) + dt S(y)
 

--- a/src/radiation/moments/moments.cpp
+++ b/src/radiation/moments/moments.cpp
@@ -125,7 +125,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   const int scr_level = pin->GetOrAddInteger("radiation/moment", "scr_level", 0);
   params.Add("scr_level", scr_level);
 
-  const bool log = pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic";
+  const bool log =
+      pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic";
 
   // Control field for sparse radiation fields
   std::string control_field = rad::cons::energy::name();

--- a/src/radiation/moments/moments.cpp
+++ b/src/radiation/moments/moments.cpp
@@ -125,6 +125,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   const int scr_level = pin->GetOrAddInteger("radiation/moment", "scr_level", 0);
   params.Add("scr_level", scr_level);
 
+  const bool log = pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic";
+
   // Control field for sparse radiation fields
   std::string control_field = rad::cons::energy::name();
 
@@ -132,7 +134,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   Metadata m = Metadata({Metadata::Cell, Metadata::Conserved, Metadata::Independent,
                          Metadata::WithFluxes, Metadata::Sparse, MetadataMoments,
                          MetadataOperatorSplit});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   moments->AddSparsePool<rad::cons::energy>(m, control_field, fluidids);
 
@@ -141,7 +143,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                 Metadata::Independent, Metadata::WithFluxes, Metadata::Sparse,
                 MetadataMoments, MetadataOperatorSplit},
                std::vector<int>({3}));
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   moments->AddSparsePool<rad::cons::flux>(m, control_field, fluidids);
 
@@ -149,7 +151,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::Intensive, Metadata::OneCopy,
                 Metadata::FillGhost, Metadata::Sparse, MetadataMoments,
                 MetadataOperatorSplit});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   moments->AddSparsePool<rad::prim::energy>(m, control_field, fluidids);
 
@@ -157,7 +159,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::Intensive, Metadata::OneCopy,
                 Metadata::WithFluxes, Metadata::Sparse, MetadataMoments,
                 MetadataOperatorSplit});
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   moments->AddSparsePool<rad::prim::pressure>(m, control_field, fluidids);
 
@@ -166,7 +168,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                 Metadata::OneCopy, Metadata::FillGhost, Metadata::Sparse, MetadataMoments,
                 MetadataOperatorSplit},
                std::vector<int>({3}));
-  ArtemisUtils::EnrollArtemisRefinementOps(m, coords);
+  ArtemisUtils::EnrollArtemisRefinementOps(m, coords, log);
   m.SetSparseThresholds(0.0, 0.0, 0.0);
   moments->AddSparsePool<rad::prim::flux>(m, control_field, fluidids);
 

--- a/src/radiation/moments/moments.hpp
+++ b/src/radiation/moments/moments.hpp
@@ -67,6 +67,9 @@ Real EstimateTimeStep(parthenon::Mesh *pmesh) {
       IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
       IndexRange kb = md->GetBoundsK(IndexDomain::interior);
       const auto ndim = pmesh->ndim;
+      const auto &cpars =
+          pmesh->packages.Get("artemis")->template Param<geometry::CoordParams>(
+              "coord_params");
 
       // Compute minimum dx
       Real min_dx = Big<Real>();
@@ -75,7 +78,7 @@ Real EstimateTimeStep(parthenon::Mesh *pmesh) {
           DevExecSpace(), 0, md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
           KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &ldx_m) {
             // Extract coordinates
-            geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+            geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
             const auto &dx = coords.GetCellWidths();
             for (int d = 0; d < ndim; d++) {
               ldx_m = std::min(ldx_m, dx[d]);

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -59,15 +59,17 @@ struct ReconInfo {
 
   ReconInfo() = default;
   template <typename V1>
-  KOKKOS_INLINE_FUNCTION ReconInfo(const V1 &v0, const int b, const int n, const int k,
-                                   const int j, const int i) {
-    fill(v0, b, n, k, j, i);
+  KOKKOS_INLINE_FUNCTION ReconInfo(const geometry::CoordParams &cpar, const V1 &v0,
+                                   const int b, const int n, const int k, const int j,
+                                   const int i) {
+    fill(cpar, v0, b, n, k, j, i);
   }
 
   template <typename V1>
-  KOKKOS_INLINE_FUNCTION void fill(const V1 &v0, const int b, const int n, const int k,
-                                   const int j, const int i) {
-    geometry::Coords<Coordinates::cartesian> coords(v0.GetCoordinates(b), k, j, i);
+  KOKKOS_INLINE_FUNCTION void fill(const geometry::CoordParams &cpar, const V1 &v0,
+                                   const int b, const int n, const int k, const int j,
+                                   const int i) {
+    geometry::Coords<Coordinates::cartesian> coords(cpar, v0.GetCoordinates(b), k, j, i);
     dx = coords.GetCellWidths();
     xc = coords.GetCellCenter();
     vol = coords.Volume();
@@ -160,11 +162,13 @@ RemapUpdate(const V1 &v0, const ReconInfo &rp, const ReconInfo &r, const Real vb
 //! \fn  RemapCons
 //! \brief
 template <Upwind UDIR, ReconstructionMethod R, typename V1>
-KOKKOS_INLINE_FUNCTION void RemapCons(const V1 &v0, const int multi_d, const int three_d,
+KOKKOS_INLINE_FUNCTION void RemapCons(const geometry::CoordParams &cpars, const V1 &v0,
+                                      const int multi_d, const int three_d,
                                       const Real dwdt, const int b, const int k,
                                       IndexRange jb, const int i) {
   // Extract coordinates
-  const geometry::Coords<Coordinates::cartesian> coords(v0.GetCoordinates(b), k, jb.s, i);
+  const geometry::Coords<Coordinates::cartesian> coords(cpars, v0.GetCoordinates(b), k,
+                                                        jb.s, i);
   const Real vb = dwdt * (coords.bnds.x1[0] + coords.bnds.x1[1]) * 0.5;
 
   // Integer gymnastics
@@ -183,17 +187,17 @@ KOKKOS_INLINE_FUNCTION void RemapCons(const V1 &v0, const int multi_d, const int
   const auto compare = (UDIR == Upwind::r) ? [](int j, int end) { return j >= end; }
                                            : [](int j, int end) { return j <= end; };
 
-  ArtemisUtils::ReconGradient<R> recon;
+  ArtemisUtils::ReconGradient<Coordinates::cartesian, R> recon;
   ReconInfo rd, rc, ru;
   for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
-    ru.fill(v0, b, n, k, jstart + joff, i);
-    rc.fill(v0, b, n, k, jstart, i);
+    ru.fill(cpars, v0, b, n, k, jstart + joff, i);
+    rc.fill(cpars, v0, b, n, k, jstart, i);
     // Correct the centroid of the cell due to the motion
     ru.xc[1] += dwdt * ru.xc[0];
     rc.xc[1] += dwdt * rc.xc[0];
-    ru.grad = recon(v0, ru.dx, multi_d, three_d, b, n, k, jstart + joff, i);
+    ru.grad = recon(cpars, v0, ru.dx, multi_d, three_d, b, n, k, jstart + joff, i);
     const auto qu = v0(b, n, k, jstart + joff, i);
-    rc.grad = recon(v0, rc.dx, multi_d, three_d, b, n, k, jstart, i);
+    rc.grad = recon(cpars, v0, rc.dx, multi_d, three_d, b, n, k, jstart, i);
     const auto qc = v0(b, n, k, jstart, i);
     // Correct the gradients due to the skew
     ru.grad[1] += dwdt * ru.grad[0];
@@ -203,9 +207,9 @@ KOKKOS_INLINE_FUNCTION void RemapCons(const V1 &v0, const int multi_d, const int
     for (int j = jstart; compare(j, jend); j -= joff) {
       const int jd = j - joff;
       if (compare(jd, jend)) {
-        rd.fill(v0, b, n, k, jd, i);
+        rd.fill(cpars, v0, b, n, k, jd, i);
         rd.xc[1] += dwdt * rd.xc[0];
-        rd.grad = recon(v0, rd.dx, multi_d, three_d, b, n, k, jd, i);
+        rd.grad = recon(cpars, v0, rd.dx, multi_d, three_d, b, n, k, jd, i);
         rd.grad[1] += dwdt * rd.grad[0];
       }
       RemapUpdate(v0, ru, rc, vb, dwdt, three_d, b, n, k, j, j + joff, i);
@@ -224,6 +228,9 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const Real dwdt) 
   PARTHENON_REQUIRE(multi_d, "Linear advection does not work in 1D");
   const int three_d = u0->GetNDim() == 3;
 
+  const auto &cpars = u0->GetParentPointer()
+                          ->packages.Get("artemis")
+                          ->template Param<geometry::CoordParams>("coord_params");
   IndexRange ib = u0->GetBoundsI(IndexDomain::interior);
   IndexRange jb = u0->GetBoundsJ(IndexDomain::interior);
   IndexRange kb = u0->GetBoundsK(IndexDomain::interior);
@@ -231,12 +238,13 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const Real dwdt) 
       DEFAULT_LOOP_PATTERN, "LagrangeRemap", parthenon::DevExecSpace(), 0,
       u0->NumBlocks() - 1, kb.s, kb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &i) {
-        geometry::Coords<Coordinates::cartesian> coords(v0.GetCoordinates(b), k, jb.s, i);
+        geometry::Coords<Coordinates::cartesian> coords(cpars, v0.GetCoordinates(b), k,
+                                                        jb.s, i);
         const Real vb = dwdt * 0.5 * (coords.bnds.x1[0] + coords.bnds.x1[1]);
         if (vb < 0.0) {
-          RemapCons<Upwind::r, R>(v0, multi_d, three_d, dwdt, b, k, jb, i);
+          RemapCons<Upwind::r, R>(cpars, v0, multi_d, three_d, dwdt, b, k, jb, i);
         } else if (vb > 0.0) {
-          RemapCons<Upwind::l, R>(v0, multi_d, three_d, dwdt, b, k, jb, i);
+          RemapCons<Upwind::l, R>(cpars, v0, multi_d, three_d, dwdt, b, k, jb, i);
         }
       });
   return TaskStatus::complete;

--- a/src/rotating_frame/rotating_frame_impl.hpp
+++ b/src/rotating_frame/rotating_frame_impl.hpp
@@ -51,12 +51,16 @@ TaskStatus ShearingBoxImpl(MeshData<Real> *md, const Real om0, const Real qshear
   const Real qm2_om = qom - two_om;
   const Real g3_over_x3 = (three_d) * (-SQR(om0));
 
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "ShearingBox", parthenon::DevExecSpace(), 0,
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Evaluate vertical gravity
-        geometry::Coords<Coordinates::cartesian> coords(vmesh.GetCoordinates(b), k, j, i);
+        geometry::Coords<Coordinates::cartesian> coords(cpars, vmesh.GetCoordinates(b), k,
+                                                        j, i);
         const Real g3 = g3_over_x3 * coords.x3v();
 
         if (do_gas) {
@@ -116,12 +120,14 @@ TaskStatus RotatingFrameImpl(MeshData<Real> *md, const Real om0, const bool do_g
 
   const Real omdt = om0 * dt;
   const Real om2dt = omdt * om0;
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "RotatingFrame", parthenon::DevExecSpace(), 0,
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(vf.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vf.GetCoordinates(b), k, j, i);
         const auto &xv = coords.GetCellCenter();
         const auto &[xcyl, ex1, ex2, ex3] = coords.ConvertToCylWithVec(xv);
 

--- a/src/utils/artemis_utils.cpp
+++ b/src/utils/artemis_utils.cpp
@@ -94,26 +94,55 @@ void PrintArtemisConfiguration(Packages_t &packages) {
 //----------------------------------------------------------------------------------------
 //! \fn void ArtemisUtils::EnrollArtemisRefinementOps
 //! \brief Registers custom prolongation and restriction operators on provided Metadata
-void EnrollArtemisRefinementOps(parthenon::Metadata &m, Coordinates coords) {
+void EnrollArtemisRefinementOps(parthenon::Metadata &m, Coordinates coords,
+                                const bool log) {
   typedef Coordinates G;
+
+  // log space
   if (coords == G::cartesian) {
-    m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::cartesian>,
-                            ArtemisUtils::RestrictAverage<G::cartesian>>();
+    m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::cartesian, false>,
+                            ArtemisUtils::RestrictAverage<G::cartesian, false>>();
   } else if (coords == G::spherical1D) {
-    m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical1D>,
-                            ArtemisUtils::RestrictAverage<G::spherical1D>>();
+    if (log) {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical1D, true>,
+                              ArtemisUtils::RestrictAverage<G::spherical1D, true>>();
+    } else {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical1D, false>,
+                              ArtemisUtils::RestrictAverage<G::spherical1D, false>>();
+    }
   } else if (coords == G::spherical2D) {
-    m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical2D>,
-                            ArtemisUtils::RestrictAverage<G::spherical2D>>();
+    if (log) {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical2D, true>,
+                              ArtemisUtils::RestrictAverage<G::spherical2D, true>>();
+    } else {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical2D, false>,
+                              ArtemisUtils::RestrictAverage<G::spherical2D, false>>();
+    }
   } else if (coords == G::spherical3D) {
-    m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical3D>,
-                            ArtemisUtils::RestrictAverage<G::spherical3D>>();
+    if (log) {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical3D, true>,
+                              ArtemisUtils::RestrictAverage<G::spherical3D, true>>();
+    } else {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::spherical3D, false>,
+                              ArtemisUtils::RestrictAverage<G::spherical3D, false>>();
+    }
   } else if (coords == G::cylindrical) {
-    m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::cylindrical>,
-                            ArtemisUtils::RestrictAverage<G::cylindrical>>();
+    if (log) {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::cylindrical, true>,
+                              ArtemisUtils::RestrictAverage<G::cylindrical, true>>();
+    } else {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::cylindrical, false>,
+                              ArtemisUtils::RestrictAverage<G::cylindrical, false>>();
+    }
   } else if (coords == G::axisymmetric) {
-    m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::axisymmetric>,
-                            ArtemisUtils::RestrictAverage<G::axisymmetric>>();
+    if (log) {
+      m.RegisterRefinementOps<ArtemisUtils::ProlongateSharedMinMod<G::axisymmetric, true>,
+                              ArtemisUtils::RestrictAverage<G::axisymmetric, true>>();
+    } else {
+      m.RegisterRefinementOps<
+          ArtemisUtils::ProlongateSharedMinMod<G::axisymmetric, false>,
+          ArtemisUtils::RestrictAverage<G::axisymmetric, false>>();
+    }
   } else {
     PARTHENON_FAIL("Invalid artemis/coordinate system!");
   }

--- a/src/utils/artemis_utils.hpp
+++ b/src/utils/artemis_utils.hpp
@@ -166,7 +166,8 @@ struct SumMyArray {
 //! Defined in artemis_utils.cpp
 //! NOTE(@pdmullen): We should likely move everything above to implementation file too...
 void PrintArtemisConfiguration(Packages_t &packages);
-void EnrollArtemisRefinementOps(parthenon::Metadata &m, Coordinates coords);
+void EnrollArtemisRefinementOps(parthenon::Metadata &m, Coordinates coords,
+                                const bool log);
 std::vector<std::vector<Real>> loadtxt(std::string fname);
 
 //----------------------------------------------------------------------------------------

--- a/src/utils/diffusion/diffusion.hpp
+++ b/src/utils/diffusion/diffusion.hpp
@@ -71,12 +71,15 @@ Real EstimateTimestep(MeshData<Real> *md, DiffCoeffParams &dp, PKG &pkg, const E
   IndexRange kb = md->GetBoundsK(IndexDomain::interior);
   const int ndim = pm->ndim;
 
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+
   Real min_dt = Big<Real>();
   parthenon::par_reduce(
       parthenon::loop_pattern_mdrange_tag, PARTHENON_AUTO_LABEL, DevExecSpace(), 0,
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &ldt) {
-        geometry::Coords<GEOM> coords(vprim.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, vprim.GetCoordinates(b), k, j, i);
         const auto &dx = coords.GetCellWidths();
         Real min_dx = Big<Real>();
         for (int d = 0; d < ndim; d++) {
@@ -118,6 +121,8 @@ TaskStatus DiffusionUpdateImpl(MeshData<Real> *md, PKG &pkg, SparsePackCons v0,
                           "Momentum diffusion only works with a gas fluid");
 
   auto pm = md->GetParentPointer();
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   const auto ib = md->GetBoundsI(IndexDomain::interior);
   const auto jb = md->GetBoundsJ(IndexDomain::interior);
@@ -134,7 +139,7 @@ TaskStatus DiffusionUpdateImpl(MeshData<Real> *md, PKG &pkg, SparsePackCons v0,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // extract coordinate information
         using parthenon::TopologicalElement;
-        geometry::Coords<GEOM> coords(v0.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, j, i);
 
         const auto ax1 = coords.GetFaceAreaX1();
         const auto ax2 = (multi_d) ? coords.GetFaceAreaX2() : NewArray<Real, 2>(0.0);

--- a/src/utils/diffusion/diffusion_coeff.hpp
+++ b/src/utils/diffusion/diffusion_coeff.hpp
@@ -99,7 +99,7 @@ struct DiffCoeffParams {
                   parthenon::ParameterInput *pin,
                   const ArtemisUtils::Constants &constants, const Packages_t &packages) {
     // Read the parameter file
-    log = pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic";
+    log = pin->GetOrAddString("artemis", "radial_spacing", "uniform") == "logarithmic";
     std::string type_ = pin->GetString(block_name, "type");
     type = ChooseDiffusion(dtype, type_);
     if (type == DiffType::null) {

--- a/src/utils/diffusion/diffusion_coeff.hpp
+++ b/src/utils/diffusion/diffusion_coeff.hpp
@@ -68,6 +68,7 @@ inline DiffAvg ChooseAveraging(std::string choice) {
 struct DiffCoeffParams {
   DiffType type;
   DiffAvg avg;
+  bool log;
 
   // Viscosity
   // -----------------
@@ -98,6 +99,7 @@ struct DiffCoeffParams {
                   parthenon::ParameterInput *pin,
                   const ArtemisUtils::Constants &constants, const Packages_t &packages) {
     // Read the parameter file
+    log = pin->GetOrAddString("artemis", "spacing", "uniform") == "logarithmic";
     std::string type_ = pin->GetString(block_name, "type");
     type = ChooseDiffusion(dtype, type_);
     if (type == DiffType::null) {
@@ -175,7 +177,7 @@ class DiffusionCoeff {
     PARTHENON_FAIL("No default implementation for diffusion coefficient");
   }
   KOKKOS_INLINE_FUNCTION Real Get(const DiffCoeffParams &dp,
-                                  geometry::Coords<GEOM> coords, const Real dens,
+                                  geometry::Coords<GEOM> &coords, const Real dens,
                                   const Real sie, const EOS &eos) const {
     PARTHENON_FAIL("No default implementation for diffusion coefficient");
   }
@@ -199,7 +201,7 @@ class DiffusionCoeff<DiffType::null, GEOM, FLUID_TYPE> {
   }
 
   KOKKOS_INLINE_FUNCTION Real Get(const DiffCoeffParams &dp,
-                                  geometry::Coords<GEOM> coords, const Real dens,
+                                  geometry::Coords<GEOM> &coords, const Real dens,
                                   const Real sie, const EOS &eos) const {
     return 0.0;
   }
@@ -230,7 +232,7 @@ class DiffusionCoeff<DiffType::viscosity_plaw, GEOM, FLUID_TYPE> {
     auto pco = p.GetCoordinates(b);
     parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu,
                              [&](const int i) {
-                               geometry::Coords<GEOM> coords(pco, k, j, i);
+                               geometry::Coords<GEOM> coords(dp.log, pco, k, j, i);
                                const Real &dens = p(b, gas::prim::density(n), k, j, i);
                                const auto &xv = coords.GetCellCenter();
                                const auto &xs = coords.ConvertToCyl(xv);
@@ -278,7 +280,7 @@ class DiffusionCoeff<DiffType::viscosity_alpha, GEOM, FLUID_TYPE> {
     auto pco = p.GetCoordinates(b);
     parthenon::par_for_inner(
         DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
-          geometry::Coords<GEOM> coords(pco, k, j, i);
+          geometry::Coords<GEOM> coords(dp.log, pco, k, j, i);
           const auto &xv = coords.GetCellCenter();
           const auto &xs = coords.ConvertToSph(xv);
           const Real Omk = dp.Omega0 * std::pow(xs[0] / dp.R0, -1.5);

--- a/src/utils/diffusion/momentum_diffusion.hpp
+++ b/src/utils/diffusion/momentum_diffusion.hpp
@@ -32,10 +32,11 @@ namespace Diffusion {
 template <Coordinates GEOM, Fluid FLUID_TYPE, parthenon::CoordinateDirection XDIR,
           typename SparsePack>
 KOKKOS_INLINE_FUNCTION void
-StrainTensorFace(parthenon::team_mbr_t const &member, const int b, const int n,
-                 const int k, const int j, const int il, const int iu, const int multi_d,
-                 const int three_d, const Real qshear, const Real om0,
-                 const SparsePack &vprim, const parthenon::ScratchPad2D<Real> &flx) {
+StrainTensorFace(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+                 const int b, const int n, const int k, const int j, const int il,
+                 const int iu, const int multi_d, const int three_d, const Real qshear,
+                 const Real om0, const SparsePack &vprim,
+                 const parthenon::ScratchPad2D<Real> &flx) {
   // Fill the flx array with the strain tensor on the specified face
   //
   //
@@ -69,7 +70,7 @@ StrainTensorFace(parthenon::team_mbr_t const &member, const int b, const int n,
                           "Only gas fluids have momentum diffusion");
   auto pco = vprim.GetCoordinates(b);
   parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
-    geometry::Coords<GEOM> coords(pco, k, j, i);
+    geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
     //  T_j^i = dv^i/dxj + hj^2/hi^2 dv^j/dxi  + v^k dhi/dxk / hi \delta_j^i
     const auto &xv = coords.GetCellCenter();
     const auto &hx = coords.GetScaleFactors();
@@ -96,16 +97,16 @@ StrainTensorFace(parthenon::team_mbr_t const &member, const int b, const int n,
       //      ym , yp, xmym, xmyp
       //      zm , zp, xmzm, xmzp
 
-      geometry::Coords<GEOM> coords_xm(pco, k, j, i - 1);
-      geometry::Coords<GEOM> coords_xmym(pco, k, j - multi_d, i - 1);
-      geometry::Coords<GEOM> coords_xmyp(pco, k, j + multi_d, i - 1);
-      geometry::Coords<GEOM> coords_ym(pco, k, j - multi_d, i);
-      geometry::Coords<GEOM> coords_yp(pco, k, j + multi_d, i);
+      geometry::Coords<GEOM> coords_xm(cpars, pco, k, j, i - 1);
+      geometry::Coords<GEOM> coords_xmym(cpars, pco, k, j - multi_d, i - 1);
+      geometry::Coords<GEOM> coords_xmyp(cpars, pco, k, j + multi_d, i - 1);
+      geometry::Coords<GEOM> coords_ym(cpars, pco, k, j - multi_d, i);
+      geometry::Coords<GEOM> coords_yp(cpars, pco, k, j + multi_d, i);
 
-      geometry::Coords<GEOM> coords_xmzm(pco, k - three_d, j, i - 1);
-      geometry::Coords<GEOM> coords_xmzp(pco, k + three_d, j, i - 1);
-      geometry::Coords<GEOM> coords_zm(pco, k - three_d, j, i);
-      geometry::Coords<GEOM> coords_zp(pco, k + three_d, j, i);
+      geometry::Coords<GEOM> coords_xmzm(cpars, pco, k - three_d, j, i - 1);
+      geometry::Coords<GEOM> coords_xmzp(cpars, pco, k + three_d, j, i - 1);
+      geometry::Coords<GEOM> coords_zm(cpars, pco, k - three_d, j, i);
+      geometry::Coords<GEOM> coords_zp(cpars, pco, k + three_d, j, i);
 
       const auto &xv_xm = coords_xm.GetCellCenter();
 
@@ -192,17 +193,17 @@ StrainTensorFace(parthenon::team_mbr_t const &member, const int b, const int n,
       //      xm , xp, xpym, xmym
       //      zm , zp, ymzm, ymzp
 
-      geometry::Coords<GEOM> coords_xp(pco, k, j, i + 1);
-      geometry::Coords<GEOM> coords_xm(pco, k, j, i - 1);
-      geometry::Coords<GEOM> coords_xpym(pco, k, j - 1, i + 1);
-      geometry::Coords<GEOM> coords_xmym(pco, k, j - 1, i - 1);
+      geometry::Coords<GEOM> coords_xp(cpars, pco, k, j, i + 1);
+      geometry::Coords<GEOM> coords_xm(cpars, pco, k, j, i - 1);
+      geometry::Coords<GEOM> coords_xpym(cpars, pco, k, j - 1, i + 1);
+      geometry::Coords<GEOM> coords_xmym(cpars, pco, k, j - 1, i - 1);
 
-      geometry::Coords<GEOM> coords_ym(pco, k, j - 1, i);
+      geometry::Coords<GEOM> coords_ym(cpars, pco, k, j - 1, i);
 
-      geometry::Coords<GEOM> coords_zp(pco, k + three_d, j, i);
-      geometry::Coords<GEOM> coords_zm(pco, k - three_d, j, i);
-      geometry::Coords<GEOM> coords_ymzp(pco, k + three_d, j - 1, i);
-      geometry::Coords<GEOM> coords_ymzm(pco, k - three_d, j - 1, i);
+      geometry::Coords<GEOM> coords_zp(cpars, pco, k + three_d, j, i);
+      geometry::Coords<GEOM> coords_zm(cpars, pco, k - three_d, j, i);
+      geometry::Coords<GEOM> coords_ymzp(cpars, pco, k + three_d, j - 1, i);
+      geometry::Coords<GEOM> coords_ymzm(cpars, pco, k - three_d, j - 1, i);
 
       const auto &xv_xm = coords_xm.GetCellCenter();
       const auto &xv_xp = coords_xp.GetCellCenter();
@@ -287,17 +288,17 @@ StrainTensorFace(parthenon::team_mbr_t const &member, const int b, const int n,
     } else if constexpr (XDIR == X3DIR) {
       // T_*^3  flx = { T_1^3 , T_2^3 , T_3^3 }
 
-      geometry::Coords<GEOM> coords_xp(pco, k, j, i + 1);
-      geometry::Coords<GEOM> coords_xm(pco, k, j, i - 1);
-      geometry::Coords<GEOM> coords_xpzm(pco, k - 1, j, i + 1);
-      geometry::Coords<GEOM> coords_xmzm(pco, k - 1, j, i - 1);
+      geometry::Coords<GEOM> coords_xp(cpars, pco, k, j, i + 1);
+      geometry::Coords<GEOM> coords_xm(cpars, pco, k, j, i - 1);
+      geometry::Coords<GEOM> coords_xpzm(cpars, pco, k - 1, j, i + 1);
+      geometry::Coords<GEOM> coords_xmzm(cpars, pco, k - 1, j, i - 1);
 
-      geometry::Coords<GEOM> coords_yp(pco, k, j + 1, i);
-      geometry::Coords<GEOM> coords_ym(pco, k, j - 1, i);
-      geometry::Coords<GEOM> coords_ypzm(pco, k - 1, j + 1, i);
-      geometry::Coords<GEOM> coords_ymzm(pco, k - 1, j - 1, i);
+      geometry::Coords<GEOM> coords_yp(cpars, pco, k, j + 1, i);
+      geometry::Coords<GEOM> coords_ym(cpars, pco, k, j - 1, i);
+      geometry::Coords<GEOM> coords_ypzm(cpars, pco, k - 1, j + 1, i);
+      geometry::Coords<GEOM> coords_ymzm(cpars, pco, k - 1, j - 1, i);
 
-      geometry::Coords<GEOM> coords_zm(pco, k - 1, j, i);
+      geometry::Coords<GEOM> coords_zm(cpars, pco, k - 1, j, i);
 
       const auto &xv_xm = coords_xm.GetCellCenter();
       const auto &xv_xp = coords_xp.GetCellCenter();
@@ -393,11 +394,12 @@ StrainTensorFace(parthenon::team_mbr_t const &member, const int b, const int n,
 template <Coordinates GEOM, Fluid FLUID_TYPE, typename SparsePackPrim,
           typename SparsePackFlux>
 KOKKOS_INLINE_FUNCTION void StressTensorFaceX1(
-    DiffCoeffParams dp, parthenon::team_mbr_t const &member, const int b, const int n,
-    const int k, const int j, const int il, const int iu, const int multi_d,
-    const int three_d, const int nspecies, const SparsePackPrim &p,
-    const SparsePackFlux &qf, const parthenon::ScratchPad1D<Real> &divu,
-    const parthenon::ScratchPad1D<Real> &mu, const parthenon::ScratchPad2D<Real> &flx) {
+    DiffCoeffParams dp, parthenon::team_mbr_t const &member,
+    const geometry::CoordParams &cpars, const int b, const int n, const int k,
+    const int j, const int il, const int iu, const int multi_d, const int three_d,
+    const int nspecies, const SparsePackPrim &p, const SparsePackFlux &qf,
+    const parthenon::ScratchPad1D<Real> &divu, const parthenon::ScratchPad1D<Real> &mu,
+    const parthenon::ScratchPad2D<Real> &flx) {
   // Fill the flx array with the stress tensor on the specified face
 
   PARTHENON_DEBUG_REQUIRE(FLUID_TYPE == Fluid::gas,
@@ -407,8 +409,8 @@ KOKKOS_INLINE_FUNCTION void StressTensorFaceX1(
   const bool havg = (dp.avg == DiffAvg::harmonic);
   parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
     //  T_j^i = dv^i/dxj + hj^2/hi^2 dv^j/dxi  + v^k dhi/dxk / hi \delta_j^i
-    geometry::Coords<GEOM> coords(pco, k, j, i);
-    geometry::Coords<GEOM> coords_xm(pco, k, j, i - 1);
+    geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+    geometry::Coords<GEOM> coords_xm(cpars, pco, k, j, i - 1);
     const auto &hx = coords.GetScaleFactors();
     const auto &hx_xm = coords_xm.GetScaleFactors();
 
@@ -453,10 +455,11 @@ KOKKOS_INLINE_FUNCTION void StressTensorFaceX1(
 template <Coordinates GEOM, Fluid FLUID_TYPE, typename SparsePackPrim,
           typename SparsePackFlux>
 KOKKOS_INLINE_FUNCTION void StressTensorFaceX2(
-    DiffCoeffParams dp, parthenon::team_mbr_t const &member, const int b, const int n,
-    const int k, const int j, const int il, const int iu, const int multi_d,
-    const int three_d, const int nspecies, const SparsePackPrim &p,
-    const SparsePackFlux &qf, const parthenon::ScratchPad1D<Real> &divu_jm1,
+    DiffCoeffParams dp, parthenon::team_mbr_t const &member,
+    const geometry::CoordParams &cpars, const int b, const int n, const int k,
+    const int j, const int il, const int iu, const int multi_d, const int three_d,
+    const int nspecies, const SparsePackPrim &p, const SparsePackFlux &qf,
+    const parthenon::ScratchPad1D<Real> &divu_jm1,
     const parthenon::ScratchPad1D<Real> &divu,
     const parthenon::ScratchPad1D<Real> &mu_jm1, const parthenon::ScratchPad1D<Real> &mu,
     const parthenon::ScratchPad2D<Real> &flx) {
@@ -468,8 +471,8 @@ KOKKOS_INLINE_FUNCTION void StressTensorFaceX2(
   const bool avg = dp.avg == DiffAvg::arithmetic;
   const bool havg = dp.avg == DiffAvg::harmonic;
   parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
-    geometry::Coords<GEOM> coords(p.GetCoordinates(b), k, j, i);
-    geometry::Coords<GEOM> coords_ym(p.GetCoordinates(b), k, j - 1, i);
+    geometry::Coords<GEOM> coords(cpars, p.GetCoordinates(b), k, j, i);
+    geometry::Coords<GEOM> coords_ym(cpars, p.GetCoordinates(b), k, j - 1, i);
     const auto &hx = coords.GetScaleFactors();
     const auto &hx_ym = coords_ym.GetScaleFactors();
 
@@ -515,10 +518,11 @@ KOKKOS_INLINE_FUNCTION void StressTensorFaceX2(
 template <Coordinates GEOM, Fluid FLUID_TYPE, typename SparsePackPrim,
           typename SparsePackFlux>
 KOKKOS_INLINE_FUNCTION void StressTensorFaceX3(
-    DiffCoeffParams dp, parthenon::team_mbr_t const &member, const int b, const int n,
-    const int k, const int j, const int il, const int iu, const int multi_d,
-    const int three_d, const int nspecies, const SparsePackPrim &p,
-    const SparsePackFlux &qf, const parthenon::ScratchPad1D<Real> &divu_km1,
+    DiffCoeffParams dp, parthenon::team_mbr_t const &member,
+    const geometry::CoordParams &cpars, const int b, const int n, const int k,
+    const int j, const int il, const int iu, const int multi_d, const int three_d,
+    const int nspecies, const SparsePackPrim &p, const SparsePackFlux &qf,
+    const parthenon::ScratchPad1D<Real> &divu_km1,
     const parthenon::ScratchPad1D<Real> &divu,
     const parthenon::ScratchPad1D<Real> &mu_km1, const parthenon::ScratchPad1D<Real> &mu,
     const parthenon::ScratchPad2D<Real> &flx) {
@@ -530,8 +534,8 @@ KOKKOS_INLINE_FUNCTION void StressTensorFaceX3(
   const bool avg = dp.avg == DiffAvg::arithmetic;
   const bool havg = dp.avg == DiffAvg::harmonic;
   parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
-    geometry::Coords<GEOM> coords(p.GetCoordinates(b), k, j, i);
-    geometry::Coords<GEOM> coords_zm(p.GetCoordinates(b), k - 1, j, i);
+    geometry::Coords<GEOM> coords(cpars, p.GetCoordinates(b), k, j, i);
+    geometry::Coords<GEOM> coords_zm(cpars, p.GetCoordinates(b), k - 1, j, i);
     const auto &hx = coords.GetScaleFactors();
     const auto &hx_zm = coords_zm.GetScaleFactors();
 
@@ -576,7 +580,8 @@ KOKKOS_INLINE_FUNCTION void StressTensorFaceX3(
 //! \brief Computes velocity divergence
 template <Coordinates GEOM, Fluid FLUID_TYPE, typename SparsePackPrim>
 KOKKOS_INLINE_FUNCTION void
-VelocityDivergence(parthenon::team_mbr_t const &member, const int b, const int n,
+VelocityDivergence(parthenon::team_mbr_t const &member,
+                   const geometry::CoordParams &cpars, const int b, const int n,
                    const int k, const int j, const int il, const int iu,
                    const int multi_d, const int three_d, const SparsePackPrim &q,
                    const parthenon::ScratchPad1D<Real> &divu) {
@@ -586,7 +591,7 @@ VelocityDivergence(parthenon::team_mbr_t const &member, const int b, const int n
                           "Only gas fluids have momentum diffusion");
   auto pco = q.GetCoordinates(b);
   parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
-    geometry::Coords<GEOM> coords(q.GetCoordinates(b), k, j, i);
+    geometry::Coords<GEOM> coords(cpars, q.GetCoordinates(b), k, j, i);
 
     const Real vol = coords.Volume();
     const auto area_x1 = coords.GetFaceAreaX1();
@@ -634,6 +639,8 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
     qshear = rframe_pkg->template Param<Real>("qshear");
     om0 = rframe_pkg->template Param<Real>("omega");
   }
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   const int scr_level = pkg->template Param<int>("scr_level");
 
@@ -663,12 +670,12 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
         for (int n = 0; n < nspecies; n++) {
 
           // 1. Compute the strain tensor at i-1/2
-          StrainTensorFace<GEOM, FLUID_TYPE, X1DIR>(mbr, b, n, k, j, il, iu, multi_d,
-                                                    three_d, qshear, om0, vprim, flx);
+          StrainTensorFace<GEOM, FLUID_TYPE, X1DIR>(
+              mbr, cpars, b, n, k, j, il, iu, multi_d, three_d, qshear, om0, vprim, flx);
 
           // 2. Compute div(u) on this pencil
-          VelocityDivergence<GEOM, FLUID_TYPE>(mbr, b, n, k, j, il - 1, iu, multi_d,
-                                               three_d, vprim, divu);
+          VelocityDivergence<GEOM, FLUID_TYPE>(mbr, cpars, b, n, k, j, il - 1, iu,
+                                               multi_d, three_d, vprim, divu);
           // 3. Viscosity values. No barrier
           DiffusionCoeff<DIFF, GEOM, FLUID_TYPE> diffcoeff;
           diffcoeff.evaluate(dp, mbr, b, n, k, j, il - 1, iu, vprim, eos_d, mu);
@@ -676,9 +683,9 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
           mbr.team_barrier();
 
           // 4. Fill the stress tensor from the strain tensor and viscosity
-          StressTensorFaceX1<GEOM, FLUID_TYPE>(dp, mbr, b, n, k, j, il, iu, multi_d,
-                                               three_d, nspecies, vprim, vf, divu, mu,
-                                               flx);
+          StressTensorFaceX1<GEOM, FLUID_TYPE>(dp, mbr, cpars, b, n, k, j, il, iu,
+                                               multi_d, three_d, nspecies, vprim, vf,
+                                               divu, mu, flx);
         }
       });
 
@@ -714,11 +721,12 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
                 divu_jm1 = scr3;
               }
               // 1. Compute the momentum fluxes at j+1/2
-              StrainTensorFace<GEOM, FLUID_TYPE, X2DIR>(mbr, b, n, k, j, il, iu, multi_d,
-                                                        three_d, qshear, om0, vprim, flx);
+              StrainTensorFace<GEOM, FLUID_TYPE, X2DIR>(mbr, cpars, b, n, k, j, il, iu,
+                                                        multi_d, three_d, qshear, om0,
+                                                        vprim, flx);
               // 2. Compute div(u) on this pencil
-              VelocityDivergence<GEOM, FLUID_TYPE>(mbr, b, n, k, j, il, iu, multi_d,
-                                                   three_d, vprim, divu_jm1);
+              VelocityDivergence<GEOM, FLUID_TYPE>(mbr, cpars, b, n, k, j, il, iu,
+                                                   multi_d, three_d, vprim, divu_jm1);
 
               // 2. Viscosity values. No barrier
               DiffusionCoeff<DIFF, GEOM, FLUID_TYPE> diffcoeff;
@@ -726,9 +734,9 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
 
               mbr.team_barrier();
               if (j > jl) {
-                StressTensorFaceX2<GEOM, FLUID_TYPE>(dp, mbr, b, n, k, j, il, iu, multi_d,
-                                                     three_d, nspecies, vprim, vf,
-                                                     divu_jm1, divu, mu_jm1, mu, flx);
+                StressTensorFaceX2<GEOM, FLUID_TYPE>(dp, mbr, cpars, b, n, k, j, il, iu,
+                                                     multi_d, three_d, nspecies, vprim,
+                                                     vf, divu_jm1, divu, mu_jm1, mu, flx);
               }
             }
           }
@@ -767,11 +775,12 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
                 divu_km1 = scr3;
               }
               // 1. Compute the momentum fluxes at k-1/2
-              StrainTensorFace<GEOM, FLUID_TYPE, X3DIR>(mbr, b, n, k, j, il, iu, multi_d,
-                                                        three_d, qshear, om0, vprim, flx);
+              StrainTensorFace<GEOM, FLUID_TYPE, X3DIR>(mbr, cpars, b, n, k, j, il, iu,
+                                                        multi_d, three_d, qshear, om0,
+                                                        vprim, flx);
               // 2. Compute div(u) on this pencil
-              VelocityDivergence<GEOM, FLUID_TYPE>(mbr, b, n, k, j, il, iu, multi_d,
-                                                   three_d, vprim, divu_km1);
+              VelocityDivergence<GEOM, FLUID_TYPE>(mbr, cpars, b, n, k, j, il, iu,
+                                                   multi_d, three_d, vprim, divu_km1);
 
               // 2. Viscosity values. No barrier
               DiffusionCoeff<DIFF, GEOM, FLUID_TYPE> diffcoeff;
@@ -779,9 +788,9 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
 
               mbr.team_barrier();
               if (k > kl) {
-                StressTensorFaceX3<GEOM, FLUID_TYPE>(dp, mbr, b, n, k, j, il, iu, multi_d,
-                                                     three_d, nspecies, vprim, vf,
-                                                     divu_km1, divu, mu_km1, mu, flx);
+                StressTensorFaceX3<GEOM, FLUID_TYPE>(dp, mbr, cpars, b, n, k, j, il, iu,
+                                                     multi_d, three_d, nspecies, vprim,
+                                                     vf, divu_km1, divu, mu_km1, mu, flx);
               }
             }
           }

--- a/src/utils/diffusion/thermal_diffusion.hpp
+++ b/src/utils/diffusion/thermal_diffusion.hpp
@@ -45,6 +45,9 @@ TaskStatus ThermalFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
   auto pm = md->GetParentPointer();
   auto eos_d = pkg->template Param<EOS>("eos_d");
 
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+
   const int scr_level = pkg->template Param<int>("scr_level");
 
   const auto ib = md->GetBoundsI(IndexDomain::interior);
@@ -80,8 +83,8 @@ TaskStatus ThermalFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
           parthenon::par_for_inner(
               DEFAULT_INNER_LOOP_PATTERN, mbr, il, iu, [&](const int i) {
                 // F = -K grad(T)
-                geometry::Coords<GEOM> coords(pco, k, j, i);
-                geometry::Coords<GEOM> coords_m(pco, k, j, i - 1);
+                geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+                geometry::Coords<GEOM> coords_m(cpars, pco, k, j, i - 1);
                 const auto &xv = coords.GetCellCenter();
                 const auto &xv_m = coords_m.GetCellCenter();
                 const Real dx1 = coords.Distance(xv, xv_m);
@@ -135,8 +138,8 @@ TaskStatus ThermalFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
                 parthenon::par_for_inner(
                     DEFAULT_INNER_LOOP_PATTERN, mbr, il, iu, [&](const int i) {
                       // F = -kappa * cv grad(T)
-                      geometry::Coords<GEOM> coords(pco, k, j, i);
-                      geometry::Coords<GEOM> coords_m(pco, k, j - 1, i);
+                      geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+                      geometry::Coords<GEOM> coords_m(cpars, pco, k, j - 1, i);
                       const auto &xv = coords.GetCellCenter();
                       const auto &xv_m = coords_m.GetCellCenter();
                       const Real dx2 = coords.Distance(xv, xv_m);
@@ -195,8 +198,8 @@ TaskStatus ThermalFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
                 parthenon::par_for_inner(
                     DEFAULT_INNER_LOOP_PATTERN, mbr, il, iu, [&](const int i) {
                       // F = -kappa * cv grad(T)
-                      geometry::Coords<GEOM> coords(pco, k, j, i);
-                      geometry::Coords<GEOM> coords_m(pco, k - 1, j, i);
+                      geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+                      geometry::Coords<GEOM> coords_m(cpars, pco, k - 1, j, i);
                       const auto &xv = coords.GetCellCenter();
                       const auto &xv_m = coords_m.GetCellCenter();
                       const Real dx3 = coords.Distance(xv, xv_m);

--- a/src/utils/fluxes/fluid_fluxes.hpp
+++ b/src/utils/fluxes/fluid_fluxes.hpp
@@ -33,6 +33,7 @@ namespace ArtemisUtils {
 //! \brief Scales the momentum fluxes by scale factors associated with relevant coord sys
 template <Coordinates G, Fluid F, int DIR, typename V3>
 KOKKOS_INLINE_FUNCTION void ScaleMomentumFlux(parthenon::team_mbr_t const &member,
+                                              const geometry::CoordParams &cpars,
                                               const int b, const int k, const int j,
                                               const int il, const int iu, const V3 &q) {
   // Immediately return if Cartesian (i.e., do not scale momentum flux)
@@ -56,7 +57,7 @@ KOKKOS_INLINE_FUNCTION void ScaleMomentumFlux(parthenon::team_mbr_t const &membe
     const int IVZ = nspecies + VI(n, 2);
     parthenon::par_for_inner(
         DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
-          geometry::Coords<G> coords(q.GetCoordinates(b), k, j, i);
+          geometry::Coords<G> coords(cpars, q.GetCoordinates(b), k, j, i);
           auto xf = NewArray<Real, 3>();
           if constexpr (DIR == X1DIR) {
             xf = coords.FaceCenX1(geometry::CellFace::lower);
@@ -97,6 +98,9 @@ TaskStatus CalculateFluxesImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, FLUX vflx,
     eos = pkg->template Param<EOS>("eos_d");
   }
 
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+
   // Speed of light (and reduced), if used
   Real chat = Null<Real>();
   Real c = Null<Real>();
@@ -124,7 +128,7 @@ TaskStatus CalculateFluxesImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, FLUX vflx,
 
         // Reconstruct qR[i] and qL[i+1]
         Reconstruction<RECON, X1DIR, G> recon;
-        recon(mbr, b, k, j, il - 1, iu, vp, wl, wr);
+        recon(mbr, cpars, b, k, j, il - 1, iu, vp, wl, wr);
         mbr.team_barrier();
 
         // NOTE(@adempsey): Moments radiation currently requires zeroing of reconstructed
@@ -141,7 +145,7 @@ TaskStatus CalculateFluxesImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, FLUX vflx,
         mbr.team_barrier();
 
         // Scale X1-momentum flux by appropriate scale factor for coord system
-        ScaleMomentumFlux<G, F, X1DIR>(mbr, b, k, j, il, iu, vflx);
+        ScaleMomentumFlux<G, F, X1DIR>(mbr, cpars, b, k, j, il, iu, vflx);
       });
 
   // X2-Flux
@@ -169,7 +173,7 @@ TaskStatus CalculateFluxesImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, FLUX vflx,
 
             // Reconstruct qR[j] and qL[j+1]
             Reconstruction<RECON, X2DIR, G> recon;
-            recon(mbr, b, k, j, il, iu, vp, wl_jp1, wr);
+            recon(mbr, cpars, b, k, j, il, iu, vp, wl_jp1, wr);
             mbr.team_barrier();
 
             // NOTE(@adempsey): See comments above
@@ -185,7 +189,7 @@ TaskStatus CalculateFluxesImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, FLUX vflx,
               mbr.team_barrier();
 
               // Scale X2-momentum flux by appropriate scale factor for coord system
-              ScaleMomentumFlux<G, F, X2DIR>(mbr, b, k, j, il, iu, vflx);
+              ScaleMomentumFlux<G, F, X2DIR>(mbr, cpars, b, k, j, il, iu, vflx);
             }
           }
         });
@@ -216,7 +220,7 @@ TaskStatus CalculateFluxesImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, FLUX vflx,
 
             // Reconstruct qR[k] and qL[k+1]
             Reconstruction<RECON, X3DIR, G> recon;
-            recon(mbr, b, k, j, il, iu, vp, wl_kp1, wr);
+            recon(mbr, cpars, b, k, j, il, iu, vp, wl_kp1, wr);
             mbr.team_barrier();
 
             // NOTE(@adempsey): See comments above
@@ -232,7 +236,7 @@ TaskStatus CalculateFluxesImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, FLUX vflx,
               mbr.team_barrier();
 
               // Scale X3-momentum flux by appropriate scale factor for coord system
-              ScaleMomentumFlux<G, F, X3DIR>(mbr, b, k, j, il, iu, vflx);
+              ScaleMomentumFlux<G, F, X3DIR>(mbr, cpars, b, k, j, il, iu, vflx);
             }
           }
         });
@@ -268,6 +272,9 @@ TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FAC
   if constexpr (F == Fluid::radiation) {
     hcchat = 0.5 * pkg->template Param<Real>("c") * pkg->template Param<Real>("chat");
   }
+  const auto &cpars = md->GetParentPointer()
+                          ->packages.Get("artemis")
+                          ->template Param<geometry::CoordParams>("coord_params");
 
   // Apply flux sources
   parthenon::par_for(
@@ -275,7 +282,7 @@ TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FAC
       md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<G> coords(vp.GetCoordinates(b), k, j, i);
+        geometry::Coords<G> coords(cpars, vp.GetCoordinates(b), k, j, i);
         const auto ax1 = coords.GetFaceAreaX1();
         const auto ax2 = (multi_d) ? coords.GetFaceAreaX2() : NewArray<Real, 2>(0.0);
         const auto ax3 = (three_d) ? coords.GetFaceAreaX3() : NewArray<Real, 2>(0.0);

--- a/src/utils/fluxes/reconstruction/pcm.hpp
+++ b/src/utils/fluxes/reconstruction/pcm.hpp
@@ -31,8 +31,9 @@ template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::pcm, X1DIR, GEOM> {
   template <typename V>
   KOKKOS_INLINE_FUNCTION void
-  operator()(parthenon::team_mbr_t const &member, const int b, const int k, const int j,
-             const int il, const int iu, const V &q, parthenon::ScratchPad2D<Real> &ql,
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql,
              parthenon::ScratchPad2D<Real> &qr) const {
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
       parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu,
@@ -50,11 +51,11 @@ struct Reconstruction<ReconstructionMethod::pcm, X1DIR, GEOM> {
 template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::pcm, X2DIR, GEOM> {
   template <typename V>
-  KOKKOS_INLINE_FUNCTION void operator()(parthenon::team_mbr_t const &member, const int b,
-                                         const int k, const int j, const int il,
-                                         const int iu, const V &q,
-                                         parthenon::ScratchPad2D<Real> &ql_jp1,
-                                         parthenon::ScratchPad2D<Real> &qr_j) const {
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql_jp1,
+             parthenon::ScratchPad2D<Real> &qr_j) const {
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
       parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu,
                                [&](const int i) {
@@ -71,11 +72,11 @@ struct Reconstruction<ReconstructionMethod::pcm, X2DIR, GEOM> {
 template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::pcm, X3DIR, GEOM> {
   template <typename V>
-  KOKKOS_INLINE_FUNCTION void operator()(parthenon::team_mbr_t const &member, const int b,
-                                         const int k, const int j, const int il,
-                                         const int iu, const V &q,
-                                         parthenon::ScratchPad2D<Real> &ql_kp1,
-                                         parthenon::ScratchPad2D<Real> &qr_k) const {
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql_kp1,
+             parthenon::ScratchPad2D<Real> &qr_k) const {
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
       parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, il, iu,
                                [&](const int i) {
@@ -86,13 +87,13 @@ struct Reconstruction<ReconstructionMethod::pcm, X3DIR, GEOM> {
   }
 };
 
-template <>
-struct ReconGradient<ReconstructionMethod::pcm> {
+template <Coordinates GEOM>
+struct ReconGradient<GEOM, ReconstructionMethod::pcm> {
   template <typename V>
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  operator()(const V &q, const std::array<Real, 3> &dx, const int multi_d,
-             const int three_d, const int b, const int n, const int k, const int j,
-             const int i) const {
+  operator()(const geometry::CoordParams &cpars, const V &q,
+             const std::array<Real, 3> &dx, const int multi_d, const int three_d,
+             const int b, const int n, const int k, const int j, const int i) const {
     return std::array<Real, 3>{
         (q(b, n, k, j, i + 1) - q(b, n, k, j, i - 1)) / (2.0 * dx[0]),
         (q(b, n, k, j + multi_d, i) - q(b, n, k, j - multi_d, i)) / (2.0 * dx[1]),

--- a/src/utils/fluxes/reconstruction/plm.hpp
+++ b/src/utils/fluxes/reconstruction/plm.hpp
@@ -78,8 +78,9 @@ template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::plm, X1DIR, GEOM> {
   template <typename V>
   KOKKOS_INLINE_FUNCTION void
-  operator()(parthenon::team_mbr_t const &member, const int b, const int k, const int j,
-             const int il, const int iu, const V &q, parthenon::ScratchPad2D<Real> &ql,
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql,
              parthenon::ScratchPad2D<Real> &qr) const {
     auto &pco = q.GetCoordinates(b);
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
@@ -89,9 +90,9 @@ struct Reconstruction<ReconstructionMethod::plm, X1DIR, GEOM> {
               PLM(q(b, n, k, j, i - 1), q(b, n, k, j, i), q(b, n, k, j, i + 1),
                   ql(n, i + 1), qr(n, i));
             } else {
-              geometry::Coords<GEOM> coords_m(pco, k, j, i - 1);
-              geometry::Coords<GEOM> coords_c(pco, k, j, i);
-              geometry::Coords<GEOM> coords_p(pco, k, j, i + 1);
+              geometry::Coords<GEOM> coords_m(cpars, pco, k, j, i - 1);
+              geometry::Coords<GEOM> coords_c(cpars, pco, k, j, i);
+              geometry::Coords<GEOM> coords_p(cpars, pco, k, j, i + 1);
               const Real xvm = coords_m.x1v();
               const Real xvc = coords_c.x1v();
               const Real xvp = coords_p.x1v();
@@ -110,11 +111,11 @@ struct Reconstruction<ReconstructionMethod::plm, X1DIR, GEOM> {
 template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::plm, X2DIR, GEOM> {
   template <typename V>
-  KOKKOS_INLINE_FUNCTION void operator()(parthenon::team_mbr_t const &member, const int b,
-                                         const int k, const int j, const int il,
-                                         const int iu, const V &q,
-                                         parthenon::ScratchPad2D<Real> &ql_jp1,
-                                         parthenon::ScratchPad2D<Real> &qr_j) const {
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql_jp1,
+             parthenon::ScratchPad2D<Real> &qr_j) const {
     auto &pco = q.GetCoordinates(b);
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
       parthenon::par_for_inner(
@@ -123,9 +124,9 @@ struct Reconstruction<ReconstructionMethod::plm, X2DIR, GEOM> {
               PLM(q(b, n, k, j - 1, i), q(b, n, k, j, i), q(b, n, k, j + 1, i),
                   ql_jp1(n, i), qr_j(n, i));
             } else {
-              geometry::Coords<GEOM> coords_m(pco, k, j - 1, i);
-              geometry::Coords<GEOM> coords_c(pco, k, j, i);
-              geometry::Coords<GEOM> coords_p(pco, k, j + 1, i);
+              geometry::Coords<GEOM> coords_m(cpars, pco, k, j - 1, i);
+              geometry::Coords<GEOM> coords_c(cpars, pco, k, j, i);
+              geometry::Coords<GEOM> coords_p(cpars, pco, k, j + 1, i);
               const Real xvm = coords_m.x2v();
               const Real xvc = coords_c.x2v();
               const Real xvp = coords_p.x2v();
@@ -144,11 +145,11 @@ struct Reconstruction<ReconstructionMethod::plm, X2DIR, GEOM> {
 template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::plm, X3DIR, GEOM> {
   template <typename V>
-  KOKKOS_INLINE_FUNCTION void operator()(parthenon::team_mbr_t const &member, const int b,
-                                         const int k, const int j, const int il,
-                                         const int iu, const V &q,
-                                         parthenon::ScratchPad2D<Real> &ql_kp1,
-                                         parthenon::ScratchPad2D<Real> &qr_k) const {
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql_kp1,
+             parthenon::ScratchPad2D<Real> &qr_k) const {
     auto &pco = q.GetCoordinates(b);
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
       parthenon::par_for_inner(
@@ -157,9 +158,9 @@ struct Reconstruction<ReconstructionMethod::plm, X3DIR, GEOM> {
               PLM(q(b, n, k - 1, j, i), q(b, n, k, j, i), q(b, n, k + 1, j, i),
                   ql_kp1(n, i), qr_k(n, i));
             } else {
-              geometry::Coords<GEOM> coords_m(pco, k - 1, j, i);
-              geometry::Coords<GEOM> coords_c(pco, k, j, i);
-              geometry::Coords<GEOM> coords_p(pco, k + 1, j, i);
+              geometry::Coords<GEOM> coords_m(cpars, pco, k - 1, j, i);
+              geometry::Coords<GEOM> coords_c(cpars, pco, k, j, i);
+              geometry::Coords<GEOM> coords_p(cpars, pco, k + 1, j, i);
               const Real xvm = coords_m.x3v();
               const Real xvc = coords_c.x3v();
               const Real xvp = coords_p.x3v();
@@ -172,13 +173,13 @@ struct Reconstruction<ReconstructionMethod::plm, X3DIR, GEOM> {
   }
 };
 
-template <>
-struct ReconGradient<ReconstructionMethod::plm> {
+template <Coordinates GEOM>
+struct ReconGradient<GEOM, ReconstructionMethod::plm> {
   template <typename V>
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  operator()(const V &q, const std::array<Real, 3> &dx, const int multi_d,
-             const int three_d, const int b, const int n, const int k, const int j,
-             const int i) const {
+  operator()(const geometry::CoordParams &cpars, const V &q,
+             const std::array<Real, 3> &dx, const int multi_d, const int three_d,
+             const int b, const int n, const int k, const int j, const int i) const {
     std::array<Real, 3> dqdx{0.0, 0.0, 0.0};
     Real wl = Null<Real>(), wr = Null<Real>();
 

--- a/src/utils/fluxes/reconstruction/ppm.hpp
+++ b/src/utils/fluxes/reconstruction/ppm.hpp
@@ -72,8 +72,9 @@ template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::ppm, X1DIR, GEOM> {
   template <typename V>
   KOKKOS_INLINE_FUNCTION void
-  operator()(parthenon::team_mbr_t const &member, const int b, const int k, const int j,
-             const int il, const int iu, const V &q, parthenon::ScratchPad2D<Real> &ql,
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql,
              parthenon::ScratchPad2D<Real> &qr) const {
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
       parthenon::par_for_inner(
@@ -91,11 +92,11 @@ struct Reconstruction<ReconstructionMethod::ppm, X1DIR, GEOM> {
 template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::ppm, X2DIR, GEOM> {
   template <typename V>
-  KOKKOS_INLINE_FUNCTION void operator()(parthenon::team_mbr_t const &member, const int b,
-                                         const int k, const int j, const int il,
-                                         const int iu, const V &q,
-                                         parthenon::ScratchPad2D<Real> &ql_jp1,
-                                         parthenon::ScratchPad2D<Real> &qr_j) const {
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql_jp1,
+             parthenon::ScratchPad2D<Real> &qr_j) const {
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
       parthenon::par_for_inner(
           DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
@@ -112,11 +113,11 @@ struct Reconstruction<ReconstructionMethod::ppm, X2DIR, GEOM> {
 template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::ppm, X3DIR, GEOM> {
   template <typename V>
-  KOKKOS_INLINE_FUNCTION void operator()(parthenon::team_mbr_t const &member, const int b,
-                                         const int k, const int j, const int il,
-                                         const int iu, const V &q,
-                                         parthenon::ScratchPad2D<Real> &ql_kp1,
-                                         parthenon::ScratchPad2D<Real> &qr_k) const {
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql_kp1,
+             parthenon::ScratchPad2D<Real> &qr_k) const {
     for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
       parthenon::par_for_inner(
           DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
@@ -127,13 +128,13 @@ struct Reconstruction<ReconstructionMethod::ppm, X3DIR, GEOM> {
   }
 };
 
-template <>
-struct ReconGradient<ReconstructionMethod::ppm> {
+template <Coordinates GEOM>
+struct ReconGradient<GEOM, ReconstructionMethod::ppm> {
   template <typename V>
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  operator()(const V &q, const std::array<Real, 3> &dx, const int multi_d,
-             const int three_d, const int b, const int n, const int k, const int j,
-             const int i) const {
+  operator()(const geometry::CoordParams &cpars, const V &q,
+             const std::array<Real, 3> &dx, const int multi_d, const int three_d,
+             const int b, const int n, const int k, const int j, const int i) const {
     std::array<Real, 3> dqdx{0.0, 0.0, 0.0};
     Real wl = Null<Real>(), wr = Null<Real>();
 

--- a/src/utils/fluxes/reconstruction/reconstruction.hpp
+++ b/src/utils/fluxes/reconstruction/reconstruction.hpp
@@ -23,20 +23,21 @@ template <ReconstructionMethod R, CoordinateDirection DIR, Coordinates GEOM>
 struct Reconstruction {
   template <typename V>
   KOKKOS_INLINE_FUNCTION void
-  operator()(parthenon::team_mbr_t const &member, const int b, const int k, const int j,
-             const int il, const int iu, const V &q, parthenon::ScratchPad2D<Real> &ql,
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V &q, parthenon::ScratchPad2D<Real> &ql,
              parthenon::ScratchPad2D<Real> &qr) const {
     PARTHENON_FAIL("No default implementation!");
   }
 };
 
-template <ReconstructionMethod R>
+template <Coordinates GEOM, ReconstructionMethod R>
 struct ReconGradient {
   template <typename V>
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-  operator()(const V &q, const std::array<Real, 3> &dx, const int multi_d,
-             const int three_d, const int b, const int n, const int k, const int j,
-             const int i) const {
+  operator()(const geometry::CoordParams &cpars, const V &q,
+             const std::array<Real, 3> &dx, const int multi_d, const int three_d,
+             const int b, const int n, const int k, const int j, const int i) const {
     PARTHENON_FAIL("No default implementation!");
   }
 };

--- a/src/utils/history.hpp
+++ b/src/utils/history.hpp
@@ -38,6 +38,9 @@ std::vector<Real> ReduceSpeciesVolumeIntegral(MeshData<Real> *md) {
   const int nblocks = md->NumBlocks();
   const int nspecies_total = vmesh.GetMaxNumberOfVars();
 
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+
   std::vector<Real> integrals(nspecies_total, 0.0);
   for (int n = 0; n < nspecies_total; n++) {
     parthenon::par_reduce(
@@ -45,7 +48,7 @@ std::vector<Real> ReduceSpeciesVolumeIntegral(MeshData<Real> *md) {
         parthenon::DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
                       Real &lint) {
-          geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+          geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
           const Real vv = coords.Volume();
           for (int nn = 0; nn < vmesh.GetSize(b, VAR()); nn++) {
             if (vmesh(b, VAR(nn)).sparse_id == n) {
@@ -77,6 +80,8 @@ std::vector<Real> ReduceSpeciesVectorVolumeIntegral(MeshData<Real> *md) {
   const auto kb = md->GetBoundsK(IndexDomain::interior);
   const int nblocks = md->NumBlocks();
   const int nspecies_total = vmesh.GetMaxNumberOfVars() / 3;
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   std::vector<Real> integrals(nspecies_total, 0.0);
   for (int n = 0; n < nspecies_total; n++) {
@@ -85,7 +90,7 @@ std::vector<Real> ReduceSpeciesVectorVolumeIntegral(MeshData<Real> *md) {
         parthenon::DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
                       Real &lint) {
-          geometry::Coords<GEOM> coords(vmesh.GetCoordinates(b), k, j, i);
+          geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
           const Real vv = coords.Volume();
           for (int nn = 0; nn < vmesh.GetSize(b, VAR()) / 3; nn++) {
             if (vmesh(b, VAR(VI(nn, DIR - 1))).sparse_id == n) {

--- a/src/utils/integrators/artemis_integrator.hpp
+++ b/src/utils/integrators/artemis_integrator.hpp
@@ -70,13 +70,15 @@ TaskStatus ApplyUpdate(MeshData<Real> *u0, MeshData<Real> *u1, const Real g0,
   const auto kb = u0->GetBoundsK(IndexDomain::interior);
   const bool multi_d = (pm->ndim > 1);
   const bool three_d = (pm->ndim > 2);
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
 
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "ApplyUpdate", parthenon::DevExecSpace(), 0,
       u0->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         // Extract coordinates
-        geometry::Coords<GEOM> coords(v0.GetCoordinates(b), k, j, i);
+        geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, j, i);
         const auto ax1 = coords.GetFaceAreaX1();
         const auto ax2 = (multi_d) ? coords.GetFaceAreaX2() : NewArray<Real, 2>(0.0);
         const auto ax3 = (three_d) ? coords.GetFaceAreaX3() : NewArray<Real, 2>(0.0);

--- a/src/utils/refinement/amr_criteria.hpp
+++ b/src/utils/refinement/amr_criteria.hpp
@@ -45,6 +45,9 @@ AmrTag ScalarFirstDerivative(MeshBlockData<Real> *md) {
   IndexRange kb = md->GetBoundsK(IndexDomain::interior);
   const int ndim = pmb->pmy_mesh->ndim;
 
+  const auto &cpars =
+      pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+
   Real maxeps = 0.0;
   if (ndim == 3) {
     parthenon::par_reduce(
@@ -52,12 +55,12 @@ AmrTag ScalarFirstDerivative(MeshBlockData<Real> *md) {
         kb.s - 1, kb.e + 1, jb.s - 1, jb.e + 1, ib.s - 1, ib.e + 1,
         KOKKOS_LAMBDA(const int k, const int j, const int i, Real &lmaxeps) {
           // Get coordinate positions
-          geometry::Coords<GEOM> coords_ip1(pco, k, j, i + 1);
-          geometry::Coords<GEOM> coords_im1(pco, k, j, i - 1);
-          geometry::Coords<GEOM> coords_jp1(pco, k, j + 1, i);
-          geometry::Coords<GEOM> coords_jm1(pco, k, j - 1, i);
-          geometry::Coords<GEOM> coords_kp1(pco, k + 1, j, i);
-          geometry::Coords<GEOM> coords_km1(pco, k - 1, j, i);
+          geometry::Coords<GEOM> coords_ip1(cpars, pco, k, j, i + 1);
+          geometry::Coords<GEOM> coords_im1(cpars, pco, k, j, i - 1);
+          geometry::Coords<GEOM> coords_jp1(cpars, pco, k, j + 1, i);
+          geometry::Coords<GEOM> coords_jm1(cpars, pco, k, j - 1, i);
+          geometry::Coords<GEOM> coords_kp1(cpars, pco, k + 1, j, i);
+          geometry::Coords<GEOM> coords_km1(cpars, pco, k - 1, j, i);
           const auto &ip1 = coords_ip1.GetCellCenter();
           const auto &im1 = coords_im1.GetCellCenter();
           const auto &jp1 = coords_jp1.GetCellCenter();
@@ -70,7 +73,7 @@ AmrTag ScalarFirstDerivative(MeshBlockData<Real> *md) {
           const Real sdx2 = jp1[1] - jm1[1];
           const Real sdx3 = kp1[2] - km1[2];
           // Get scale factors
-          geometry::Coords<GEOM> coords(pco, k, j, i);
+          geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
           const auto &cc = coords.GetCellCenter();
           const auto &hx = coords.GetScaleFactors();
           // NOTE(PDM): here, if passed a SparsePool, we will only be accessing the first
@@ -93,10 +96,10 @@ AmrTag ScalarFirstDerivative(MeshBlockData<Real> *md) {
         jb.s - 1, jb.e + 1, ib.s - 1, ib.e + 1,
         KOKKOS_LAMBDA(const int j, const int i, Real &lmaxeps) {
           // Get coordinate positions
-          geometry::Coords<GEOM> coords_ip1(pco, k, j, i + 1);
-          geometry::Coords<GEOM> coords_im1(pco, k, j, i - 1);
-          geometry::Coords<GEOM> coords_jp1(pco, k, j + 1, i);
-          geometry::Coords<GEOM> coords_jm1(pco, k, j - 1, i);
+          geometry::Coords<GEOM> coords_ip1(cpars, pco, k, j, i + 1);
+          geometry::Coords<GEOM> coords_im1(cpars, pco, k, j, i - 1);
+          geometry::Coords<GEOM> coords_jp1(cpars, pco, k, j + 1, i);
+          geometry::Coords<GEOM> coords_jm1(cpars, pco, k, j - 1, i);
           const auto &ip1 = coords_ip1.GetCellCenter();
           const auto &im1 = coords_im1.GetCellCenter();
           const auto &jp1 = coords_jp1.GetCellCenter();
@@ -106,7 +109,7 @@ AmrTag ScalarFirstDerivative(MeshBlockData<Real> *md) {
           const Real sdx1 = ip1[0] - im1[0];
           const Real sdx2 = jp1[1] - jm1[1];
           // Get scale factors
-          geometry::Coords<GEOM> coords(pco, k, j, i);
+          geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
           const auto &cc = coords.GetCellCenter();
           const Real hx1 = coords.hx1(cc[0], cc[1], cc[2]);
           const Real hx2 = coords.hx2(cc[0], cc[1], cc[2]);

--- a/src/utils/refinement/prolongation.hpp
+++ b/src/utils/refinement/prolongation.hpp
@@ -38,17 +38,17 @@ namespace ArtemisUtils {
 //!        coordinate direction. Do so for both coarse and fine grids.
 template <Coordinates C, int DIM>
 KOKKOS_FORCEINLINE_FUNCTION void
-GetGridSpacings(const Coordinates_t &coords, const Coordinates_t &coarse_coords, int k,
-                int j, int i, int fk, int fj, int fi, Real *dxm, Real *dxp, Real *dxfm,
-                Real *dxfp) {
+GetGridSpacings(const Coordinates_t &coords, const Coordinates_t &coarse_coords,
+                const bool log, int k, int j, int i, int fk, int fj, int fi, Real *dxm,
+                Real *dxp, Real *dxfm, Real *dxfp) {
   namespace gg = geometry;
   Real xm = Null<Real>(), xc = Null<Real>(), xp = Null<Real>();
   Real fxm = Null<Real>(), fxp = Null<Real>();
-  gg::Coords<C> cc(coarse_coords, k, j, i);
-  gg::Coords<C> cm(coarse_coords, k - (DIM == 3), j - (DIM == 2), i - (DIM == 1));
-  gg::Coords<C> cp(coarse_coords, k + (DIM == 3), j + (DIM == 2), i + (DIM == 1));
-  gg::Coords<C> fm(coords, fk, fj, fi);
-  gg::Coords<C> fp(coords, fk + (DIM == 3), fj + (DIM == 2), fi + (DIM == 1));
+  gg::Coords<C> cc(log, coarse_coords, k, j, i);
+  gg::Coords<C> cm(log, coarse_coords, k - (DIM == 3), j - (DIM == 2), i - (DIM == 1));
+  gg::Coords<C> cp(log, coarse_coords, k + (DIM == 3), j + (DIM == 2), i + (DIM == 1));
+  gg::Coords<C> fm(log, coords, fk, fj, fi);
+  gg::Coords<C> fp(log, coords, fk + (DIM == 3), fj + (DIM == 2), fi + (DIM == 1));
   if constexpr (DIM == 1) {
     xm = cm.x1v(), xc = cc.x1v(), xp = cp.x1v();
     fxm = fm.x1v(), fxp = fp.x1v();
@@ -79,7 +79,7 @@ Real GradMinMod(const Real fc, const Real fm, const Real fp, const Real dxm,
 //----------------------------------------------------------------------------------------
 //! \struct  ArtemisUtils::ProlongateSharedMinMod
 //! \brief
-template <Coordinates GEOM>
+template <Coordinates GEOM, bool log>
 struct ProlongateSharedMinMod {
   static constexpr bool OperationRequired(TopologicalElement fel,
                                           TopologicalElement cel) {
@@ -117,8 +117,8 @@ struct ProlongateSharedMinMod {
     [[maybe_unused]] Real gx1m = 0, gx1p = 0;
     if constexpr (INCLUDE_X1) {
       Real dx1m, dx1p;
-      ArtemisUtils::GetGridSpacings<GEOM, 1>(coords, coarse_coords, k, j, i, fk, fj, fi,
-                                             &dx1m, &dx1p, &dx1fm, &dx1fp);
+      ArtemisUtils::GetGridSpacings<GEOM, 1>(coords, coarse_coords, log, k, j, i, fk, fj,
+                                             fi, &dx1m, &dx1p, &dx1fm, &dx1fp);
 
       Real gx1c = ArtemisUtils::GradMinMod(fc, coarse(element_idx, l, m, n, k, j, i - 1),
                                            coarse(element_idx, l, m, n, k, j, i + 1),
@@ -132,8 +132,8 @@ struct ProlongateSharedMinMod {
     [[maybe_unused]] Real gx2m = 0, gx2p = 0;
     if constexpr (INCLUDE_X2) {
       Real dx2m, dx2p;
-      ArtemisUtils::GetGridSpacings<GEOM, 2>(coords, coarse_coords, k, j, i, fk, fj, fi,
-                                             &dx2m, &dx2p, &dx2fm, &dx2fp);
+      ArtemisUtils::GetGridSpacings<GEOM, 2>(coords, coarse_coords, log, k, j, i, fk, fj,
+                                             fi, &dx2m, &dx2p, &dx2fm, &dx2fp);
       Real gx2c = ArtemisUtils::GradMinMod(fc, coarse(element_idx, l, m, n, k, j - 1, i),
                                            coarse(element_idx, l, m, n, k, j + 1, i),
                                            dx2m, dx2p, gx2m, gx2p);
@@ -146,8 +146,8 @@ struct ProlongateSharedMinMod {
     [[maybe_unused]] Real gx3m = 0, gx3p = 0;
     if constexpr (INCLUDE_X3) {
       Real dx3m, dx3p;
-      ArtemisUtils::GetGridSpacings<GEOM, 3>(coords, coarse_coords, k, j, i, fk, fj, fi,
-                                             &dx3m, &dx3p, &dx3fm, &dx3fp);
+      ArtemisUtils::GetGridSpacings<GEOM, 3>(coords, coarse_coords, log, k, j, i, fk, fj,
+                                             fi, &dx3m, &dx3p, &dx3fm, &dx3fp);
       Real gx3c = ArtemisUtils::GradMinMod(fc, coarse(element_idx, l, m, n, k - 1, j, i),
                                            coarse(element_idx, l, m, n, k + 1, j, i),
                                            dx3m, dx3p, gx3m, gx3p);

--- a/src/utils/refinement/restriction.hpp
+++ b/src/utils/refinement/restriction.hpp
@@ -38,7 +38,7 @@ namespace ArtemisUtils {
 //----------------------------------------------------------------------------------------
 //! \struct  ArtemisUtils::RestrictAverage
 //! \brief
-template <Coordinates GEOM>
+template <Coordinates GEOM, bool log_space>
 struct RestrictAverage {
   static constexpr bool OperationRequired(TopologicalElement fel,
                                           TopologicalElement cel) {
@@ -86,7 +86,7 @@ struct RestrictAverage {
     for (int ok = 0; ok < 1 + INCLUDE_X3; ++ok) {
       for (int oj = 0; oj < 1 + INCLUDE_X2; ++oj) {
         for (int oi = 0; oi < 1 + INCLUDE_X1; ++oi) {
-          geometry::Coords<GEOM> coords(pco, k + ok, j + oj, i + oi);
+          geometry::Coords<GEOM> coords(log_space, pco, k + ok, j + oj, i + oi);
           if constexpr (el == TE::CC) {
             vol[ok][oj][oi] = coords.Volume();
           } else if constexpr (el == TE::F1) {

--- a/tst/scripts/binary/binary.py
+++ b/tst/scripts/binary/binary.py
@@ -46,6 +46,8 @@ def run(**kwargs):
         "parthenon/job/problem_id=" + _file_id,
         "parthenon/time/tlim={:.16f}".format(2.0 * np.pi),
     ]
+
+
     artemis.run(_nranks, "disk/binary_cyl.in", arguments)
 
 
@@ -55,10 +57,19 @@ def analyze():
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, r, phi, z, [d, u, v, w, T] = analysis.load_level(
+    time, x, phi, z, [d, u, v, w, T], logx = analysis.load_level(
         "final", base="{}.out1".format(_file_id), dir=artemis.get_data_dir()
     )
-    rc = 0.5 * (r[1:] + r[:-1])
+    if logx:
+        r = np.exp(x)
+    else:
+        r = x
+
+    rc = (2.0 / 3.0) * (r[1:] ** 3 - r[:-1] ** 3) / (r[1:] ** 2 - r[:-1] ** 2)
+    if logx:
+        xc = np.log(rc)
+    else:
+        xc = rc
     pc = 0.5 * (phi[1:] + phi[:-1])
 
     h = 0.05
@@ -79,8 +90,12 @@ def analyze():
     axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
 
     # Indices for the inner and outer evalulation rings
-    ii = np.argwhere(rc >= 1 - 0.1)[0][0]
-    io = np.argwhere(rc >= 1 + 0.1)[0][0]
+    if logx:
+        ii = np.argwhere(xc >= np.log(1 - 0.1))[0][0]
+        io = np.argwhere(xc >= np.log(1 + 0.1))[0][0]
+    else:
+        ii = np.argwhere(rc >= 1 - 0.1)[0][0]
+        io = np.argwhere(rc >= 1 + 0.1)[0][0]
 
     # the azimuthal locations of the spirals approximated as
     # where the max occurs
@@ -125,7 +140,7 @@ def analyze():
     tnorm = np.exp(fit[1])
 
     names.append("Temp plaw")
-    tols.append(2e-4)
+    tols.append(7e-4)
     errs.append(abs(plaw - plaw_ans))
     names.append("Temp norm")
     tols.append(5e-3)

--- a/tst/scripts/binary/binary.py
+++ b/tst/scripts/binary/binary.py
@@ -47,7 +47,6 @@ def run(**kwargs):
         "parthenon/time/tlim={:.16f}".format(2.0 * np.pi),
     ]
 
-
     artemis.run(_nranks, "disk/binary_cyl.in", arguments)
 
 

--- a/tst/scripts/binary_adi/binary_adi.py
+++ b/tst/scripts/binary_adi/binary_adi.py
@@ -71,10 +71,23 @@ def analyze():
         for fv in _flux:
             for dv in _de_switch:
                 problem_id = _file_id + "_{}_de{:d}_{}".format(fv, int(10 * dv), cv)
-                time, r, phi, z, [d, u, v, w, T] = analysis.load_level(
+                time, x, phi, z, [d, u, v, w, T], logx = analysis.load_level(
                     "final", dir=artemis.get_data_dir(), base=problem_id + ".out1"
                 )
-                rc = 0.5 * (r[1:] + r[:-1])
+                if logx:
+                    r = np.exp(x)
+                else:
+                    r = x
+
+                rc = (
+                    (2.0 / 3.0)
+                    * (r[1:] ** 3 - r[:-1] ** 3)
+                    / (r[1:] ** 2 - r[:-1] ** 2)
+                )
+                if logx:
+                    xc = np.log(rc)
+                else:
+                    xc = rc
                 pc = 0.5 * (phi[1:] + phi[:-1])
 
                 h = 0.05
@@ -95,8 +108,12 @@ def analyze():
                 axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
 
                 # Indices for the inner and outer evalulation rings
-                ii = np.argwhere(rc >= 1 - 0.1)[0][0]
-                io = np.argwhere(rc >= 1 + 0.1)[0][0]
+                if logx:
+                    ii = np.argwhere(xc >= np.log(1 - 0.1))[0][0]
+                    io = np.argwhere(xc >= np.log(1 + 0.1))[0][0]
+                else:
+                    ii = np.argwhere(rc >= 1 - 0.1)[0][0]
+                    io = np.argwhere(rc >= 1 + 0.1)[0][0]
 
                 # the azimuthal locations of the spirals approximated as
                 # where the max occurs

--- a/tst/scripts/diffusion/alpha_disk.py
+++ b/tst/scripts/diffusion/alpha_disk.py
@@ -85,7 +85,7 @@ def analyze():
     logger.debug("Analyzing test " + __name__ + " {:d}D".format(d))
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
 
-    time, x, y, z, [dens, u, v, w, T] = analysis.load_level(
+    time, x, y, z, [dens, u, v, w, T], _ = analysis.load_level(
         "final", dir=artemis.get_data_dir(), base=base + ".out1"
     )
     r = 0.5 * (x[1:] + x[:-1])

--- a/tst/scripts/diffusion/thermal_diffusion.py
+++ b/tst/scripts/diffusion/thermal_diffusion.py
@@ -92,7 +92,7 @@ def analyze():
     errors = []
     for ax, g in zip(axes, _geom):
         name = "{}_{}".format(_file_id, g[:3])
-        time, x, y, z, [d, u, v, w, T] = analysis.load_level(
+        time, x, y, z, [d, u, v, w, T], _ = analysis.load_level(
             "final", dir=artemis.get_data_dir(), base="{}.out1".format(name)
         )
         xc = 0.5 * (x[1:] + x[:-1])

--- a/tst/scripts/diffusion/viscous_diffusion.py
+++ b/tst/scripts/diffusion/viscous_diffusion.py
@@ -91,13 +91,13 @@ def analyze():
         logger.debug("Analyzing test " + __name__ + " {:d}D".format(d))
         os.makedirs(artemis.get_fig_dir(), exist_ok=True)
 
-        time, x, y, z, [dens, u, v, w, T] = analysis.load_level(
+        time, x, y, z, [dens, u, v, w, T], _ = analysis.load_level(
             "final", dir=artemis.get_data_dir(), base=base + ".out1"
         )
         xc = 0.5 * (x[1:] + x[:-1])
         yc = 0.5 * (y[1:] + y[:-1])
 
-        time0, x0, y0, z0, [dens0, u0, v0, w0, T0] = analysis.load_level(
+        time0, x0, y0, z0, [dens0, u0, v0, w0, T0], _ = analysis.load_level(
             0, dir=artemis.get_data_dir(), base=base + ".out1"
         )
 

--- a/tst/scripts/nbody/nbody.py
+++ b/tst/scripts/nbody/nbody.py
@@ -64,7 +64,7 @@ def analyze():
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, r, phi, z, [d, u, v, w, T] = analysis.load_level(
+    time, r, phi, z, [d, u, v, w, T], _ = analysis.load_level(
         "final", base="{}.out1".format(_file_id), dir=artemis.get_data_dir()
     )
     rc = 0.5 * (r[1:] + r[:-1])

--- a/tst/scripts/ssheet/ssheet.py
+++ b/tst/scripts/ssheet/ssheet.py
@@ -53,7 +53,7 @@ def analyze():
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, x, y, z, [d, u, v, w, T] = analysis.load_level(
+    time, x, y, z, [d, u, v, w, T], _ = analysis.load_level(
         "final", dir=artemis.get_data_dir(), base="{}.out1".format(_file_id)
     )
     xc = 0.5 * (x[1:] + x[:-1])

--- a/tst/scripts/utils/analysis.py
+++ b/tst/scripts/utils/analysis.py
@@ -35,6 +35,12 @@ def load_level(n, base, dir="./", off=0):
 
     with h5py.File(fname, "r") as f:
         time = f["Info"].attrs["Time"]
+        logx = False
+        for line in f["Input"].attrs["File"].split("\n"):
+            if len(line.strip()) > 0:
+                if line.strip()[0] != "#":
+                    if "spacing" in line:
+                        logx = line.split("=")[1].split("#")[0].strip() == "logarithmic"
 
         lvl = f["Levels"][...]
         ind = lvl == max(lvl.max() - off, 0)
@@ -99,7 +105,7 @@ def load_level(n, base, dir="./", off=0):
     x = np.linspace(x.min(), x.max(), nx + 1)
     y = np.linspace(y.min(), y.max(), ny + 1)
     z = np.linspace(z.min(), z.max(), nz + 1)
-    return time, x, y, z, [d, u, v, w, p / d]
+    return time, x, y, z, [d, u, v, w, p / d], logx
 
 
 # Associated functions for plotting Artemis data


### PR DESCRIPTION
## Background

Adds the ability to run spherical/cylindrical/axisymmetric in log-r space. 

Instead of adding more coordinate systems (and thus more templates), I've instead created a coordinate parameters struct that is now required by the `Coords` constructor. 95% of this MR is changing all the calls to `Coords` to pass this new struct.

I've changed the binary and binary_adi tests to use log-r coordinates and everything looks good. 

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
