### PR TITLE
Update jaybenne version and RadiationStep arguments.

### DIFF
--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -124,7 +124,7 @@ TaskListStatus ArtemisDriver<GEOM>::Step() {
   if (status != TaskListStatus::complete) return status;
 
   // Operator split, IMC/DDMC radiation with Jaybenne
-  if (do_imc) status = IMC::JaybenneIMC<GEOM>(pmesh, tm.time, tm.dt);
+  if (do_imc) status = IMC::JaybenneIMC<GEOM>(pmesh, tm, tm.dt);
   if (status != TaskListStatus::complete) return status;
 
   // Operator split, moments subcyling (M1 or P1)

--- a/src/radiation/imc/imc.hpp
+++ b/src/radiation/imc/imc.hpp
@@ -19,7 +19,7 @@
 namespace IMC {
 
 template <Coordinates GEOM>
-TaskListStatus JaybenneIMC(Mesh *pmesh, const Real time, const Real dt);
+TaskListStatus JaybenneIMC(Mesh *pmesh, const SimTime &time, const Real dt);
 
 } // namespace IMC
 

--- a/src/radiation/imc/imc_driver.cpp
+++ b/src/radiation/imc/imc_driver.cpp
@@ -41,11 +41,12 @@ TaskListStatus JaybenneIMC(Mesh *pmesh, const SimTime &tm, const Real dt) {
 //! template instantiations
 typedef Coordinates G;
 typedef Mesh M;
-template TaskListStatus JaybenneIMC<G::cartesian>(M *pm, const SimTime &tm, const Real dt);
-template TaskListStatus JaybenneIMC<G::cylindrical>(M *pm, const SimTime &tm, const Real dt);
-template TaskListStatus JaybenneIMC<G::spherical1D>(M *pm, const SimTime &tm, const Real dt);
-template TaskListStatus JaybenneIMC<G::spherical2D>(M *pm, const SimTime &tm, const Real dt);
-template TaskListStatus JaybenneIMC<G::spherical3D>(M *pm, const SimTime &tm, const Real dt);
-template TaskListStatus JaybenneIMC<G::axisymmetric>(M *pm, const SimTime &tm, const Real dt);
+typedef SimTime ST;
+template TaskListStatus JaybenneIMC<G::cartesian>(M *pm, const ST &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::cylindrical>(M *pm, const ST &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::spherical1D>(M *pm, const ST &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::spherical2D>(M *pm, const ST &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::spherical3D>(M *pm, const ST &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::axisymmetric>(M *pm, const ST &tm, const Real dt);
 
 } // namespace IMC

--- a/src/radiation/imc/imc_driver.cpp
+++ b/src/radiation/imc/imc_driver.cpp
@@ -28,12 +28,12 @@ namespace IMC {
 //! \fn TaskListStatus IMC::JaybenneIMC
 //! \brief Executes thermal IMC transport (Jaybenne) and syncs updated fields
 template <Coordinates GEOM>
-TaskListStatus JaybenneIMC(Mesh *pmesh, const Real time, const Real dt) {
+TaskListStatus JaybenneIMC(Mesh *pmesh, const SimTime &tm, const Real dt) {
   auto status = Radiation::UpdateRadiationFields(pmesh).Execute();
   if (status != TaskListStatus::complete) return status;
-  status = jaybenne::RadiationStep(pmesh, time, dt).Execute();
+  status = jaybenne::RadiationStep(pmesh, tm, dt).Execute();
   if (status != TaskListStatus::complete) return status;
-  status = ArtemisDerived::SyncFields<GEOM>(pmesh, time, dt).Execute();
+  status = ArtemisDerived::SyncFields<GEOM>(pmesh, tm.time, dt).Execute();
   return status;
 }
 
@@ -41,11 +41,11 @@ TaskListStatus JaybenneIMC(Mesh *pmesh, const Real time, const Real dt) {
 //! template instantiations
 typedef Coordinates G;
 typedef Mesh M;
-template TaskListStatus JaybenneIMC<G::cartesian>(M *pm, const Real t, const Real dt);
-template TaskListStatus JaybenneIMC<G::cylindrical>(M *pm, const Real t, const Real dt);
-template TaskListStatus JaybenneIMC<G::spherical1D>(M *pm, const Real t, const Real dt);
-template TaskListStatus JaybenneIMC<G::spherical2D>(M *pm, const Real t, const Real dt);
-template TaskListStatus JaybenneIMC<G::spherical3D>(M *pm, const Real t, const Real dt);
-template TaskListStatus JaybenneIMC<G::axisymmetric>(M *pm, const Real t, const Real dt);
+template TaskListStatus JaybenneIMC<G::cartesian>(M *pm, const SimTime &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::cylindrical>(M *pm, const SimTime &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::spherical1D>(M *pm, const SimTime &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::spherical2D>(M *pm, const SimTime &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::spherical3D>(M *pm, const SimTime &tm, const Real dt);
+template TaskListStatus JaybenneIMC<G::axisymmetric>(M *pm, const SimTime &tm, const Real dt);
 
 } // namespace IMC


### PR DESCRIPTION
## Background

* Jaybenne has been updated to print particle diagnostic data (source and active populations) every N time steps.

## Description of Changes

+ RadiationStep now takes the full SimTime object as an argument.

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
