### PR TITLE
[Bugfix] NBody Particles + AMR

### DIFF
--- a/src/nbody/nbody.cpp
+++ b/src/nbody/nbody.cpp
@@ -307,7 +307,9 @@ AmrTag DistanceRefinement(MeshBlockData<Real> *md) {
 
         // Each particle returns the distance normalized to it's target radius
         for (int n = 0; n < npart; n++) {
-          ldist = std::min(ldist, particles(n).refine_distance(xcart));
+          if (particles(n).alive) {
+            ldist = std::min(ldist, particles(n).refine_distance(xcart));
+          }
         }
       },
       Kokkos::Min<Real>(min_dist));


### PR DESCRIPTION
## Background

All particles were participating in the refinement check, but only particles that are alive should be doing that. This was causing frozen refined patches when, e.g., a merge happens.

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
