### PR TITLE
Add crooked pipe

### DIFF
--- a/analysis/plot.py
+++ b/analysis/plot.py
@@ -19,6 +19,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 import ahdf
+import h5py
 
 
 # Plot a 2D slice of a variable to a provided axis.
@@ -36,6 +37,11 @@ def plot(
     scale,
 ):
     dump = ahdf.ahdf(filename)
+
+    time = 0.0
+    with h5py.File(filename, 'r') as f:
+      info_group = f["Info"]
+      time = info_group.attrs["Time"]
 
     # Coordinate-dependent defaults
     if dump.coordinates == "cartesian":
@@ -88,6 +94,12 @@ def plot(
                 assert idx >= 0 and idx < dump.NX2, "Slice index is out of bounds!"
                 vmin = min(vmin, np.min(variable[b, :, idx, :]))
                 vmax = max(vmax, np.max(variable[b, :, idx, :]))
+    print("vmin: {0}, vmax: {1}".format(vmin, vmax))
+    if vmin <= 0:
+      vmin = 0.01
+      vmin = vmax / 1.0e7
+      #vmin = np.log(vmax)/2.0
+      print("rescaled vmin: {0}".format(vmin))
 
     # Plot all meshblocks within slice
     for b in range(dump.NumBlocks):
@@ -135,7 +147,7 @@ def plot(
     fig.colorbar(im, cax=cax, orientation="vertical")
 
     # Label axes
-    ax.set_title(f"{variable_name}")
+    ax.set_title("{0} at {1}".format(variable_name, time))
     if coords == "cartesian":
         if slice == "xy":
             ax.set_xlabel("x")
@@ -341,7 +353,6 @@ if __name__ == "__main__":
     )
 
     if args.show:
-        print("Showing figure ...")
         plt.show()
     else:
         savename = os.path.basename(args.filename)[:-5] + ".png"

--- a/analysis/plot.py
+++ b/analysis/plot.py
@@ -19,7 +19,6 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 import ahdf
-import h5py
 
 
 # Plot a 2D slice of a variable to a provided axis.
@@ -37,11 +36,6 @@ def plot(
     scale,
 ):
     dump = ahdf.ahdf(filename)
-
-    time = 0.0
-    with h5py.File(filename, "r") as f:
-        info_group = f["Info"]
-        time = info_group.attrs["Time"]
 
     # Coordinate-dependent defaults
     if dump.coordinates == "cartesian":
@@ -94,12 +88,6 @@ def plot(
                 assert idx >= 0 and idx < dump.NX2, "Slice index is out of bounds!"
                 vmin = min(vmin, np.min(variable[b, :, idx, :]))
                 vmax = max(vmax, np.max(variable[b, :, idx, :]))
-    print("vmin: {0}, vmax: {1}".format(vmin, vmax))
-    if vmin <= 0:
-        vmin = 0.01
-        vmin = vmax / 1.0e7
-        # vmin = np.log(vmax)/2.0
-        print("rescaled vmin: {0}".format(vmin))
 
     # Plot all meshblocks within slice
     for b in range(dump.NumBlocks):
@@ -147,7 +135,7 @@ def plot(
     fig.colorbar(im, cax=cax, orientation="vertical")
 
     # Label axes
-    ax.set_title("{0} at {1}".format(variable_name, time))
+    ax.set_title(f"{variable_name}")
     if coords == "cartesian":
         if slice == "xy":
             ax.set_xlabel("x")
@@ -353,6 +341,7 @@ if __name__ == "__main__":
     )
 
     if args.show:
+        print("Showing figure ...")
         plt.show()
     else:
         savename = os.path.basename(args.filename)[:-5] + ".png"

--- a/analysis/plot.py
+++ b/analysis/plot.py
@@ -39,9 +39,9 @@ def plot(
     dump = ahdf.ahdf(filename)
 
     time = 0.0
-    with h5py.File(filename, 'r') as f:
-      info_group = f["Info"]
-      time = info_group.attrs["Time"]
+    with h5py.File(filename, "r") as f:
+        info_group = f["Info"]
+        time = info_group.attrs["Time"]
 
     # Coordinate-dependent defaults
     if dump.coordinates == "cartesian":
@@ -96,10 +96,10 @@ def plot(
                 vmax = max(vmax, np.max(variable[b, :, idx, :]))
     print("vmin: {0}, vmax: {1}".format(vmin, vmax))
     if vmin <= 0:
-      vmin = 0.01
-      vmin = vmax / 1.0e7
-      #vmin = np.log(vmax)/2.0
-      print("rescaled vmin: {0}".format(vmin))
+        vmin = 0.01
+        vmin = vmax / 1.0e7
+        # vmin = np.log(vmax)/2.0
+        print("rescaled vmin: {0}".format(vmin))
 
     # Plot all meshblocks within slice
     for b in range(dump.NumBlocks):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,9 +27,7 @@ def open_close_div(count, title, css="art_node", disp="art_hide"):
     {}
    </div>
   <div id=\"menu.{:d}\" class=\"{}\">
-""".format(
-        css, count, title, count, disp
-    )
+""".format(css, count, title, count, disp)
 
 
 def add_card(title, card, count, tabs=0, debug=False):

--- a/inputs/radiation/crooked_pipe.in
+++ b/inputs/radiation/crooked_pipe.in
@@ -1,3 +1,16 @@
+
+//========================================================================================
+// (C) (or copyright) 2026. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
 <artemis>
 problem = crooked_pipe  # name of the pgen
 coordinates = cartesian

--- a/inputs/radiation/crooked_pipe.in
+++ b/inputs/radiation/crooked_pipe.in
@@ -2,7 +2,7 @@
 problem = crooked_pipe  # name of the pgen
 coordinates = cartesian
 physical_units = cgs     # not scale-free
-unit_conversion = ppd   # [L/T/M/Temp] = 1
+unit_conversion = base   # [L/T/M/Temp] = 1
 
 <parthenon/job>
 problem_id = crooked_pipe  # problem ID: basename of output filenames
@@ -13,38 +13,34 @@ variables = gas.prim.density,   &
             gas.prim.sie,      &
             field.jaybenne.energy_tally
 file_type = hdf5  # HDF5 data dump
-dt        = 1.0e-11 # time increment between outputs
+dt        = 5.0e-8 # time increment between outputs, 5 shakes (50 nanoseconds)
 #ghost_zones = true # output ghost zones
 use_final_label  = false
 
 <parthenon/time>
-nlim       = 10     # cycle limit
-tlim       = 1.0e-6 # time limit
+nlim       = 3000   # cycle limit
+tlim       = 2.5e-6 # time limit, 250 shakes
 integrator = rk2    # time integration algorithm
 ncycle_out = 1      # interval for stdout summary info
-dt_force = 1.0e-10
-
-<crooked_pipe>
-t_init = 1.1e4
-t_source = 5.8e6
-rho_thin = 1.0
-rho_thick = 100.0
+dt_init = 1.0e-11
+dt_factor = 1.1
+dt_ceil = 1.0e-8
 
 <parthenon/mesh>
 #refinement = static # Enable static mesh refinement
-nx1 = 900
+nx1 = 180
 x1min  = -2.0      # minimum value of X1
 x1max  = 7.0    # maximum value of X1
 ix1_bc = reflecting  # Inner-X1 boundary condition flag
 ox1_bc = outflow    # Outer-X1 boundary condition flag
-nx2    = 400        # Number of zones in X2-direction
+nx2    = 80        # Number of zones in X2-direction
 x2min  = -2.0       # minimum value of X2
 x2max  = 2.0       # maximum value of X2
 ix2_bc = reflecting   # Inner-X2 boundary condition flag
 ox2_bc = outflow   # Outer-X2 boundary condition flag
 nx3    = 1        # Number of zones in X3-direction
-x3min  = 0      # minimum value of X3
-x3max  = 1   # maximum value of X3
+x3min  = -0.5      # minimum value of X3
+x3max  = 0.5   # maximum value of X3
 ix3_bc = reflecting  # Inner-X3 boundary condition flag
 ox3_bc = reflecting  # Outer-X3 boundary condition flag
 nghost = 2
@@ -52,8 +48,8 @@ nghost = 2
 #numlevel = 2
 
 <parthenon/meshblock>
-nx1 = 90  # Number of cells in each MeshBlock, X1-dir
-nx2 = 40  # Number of cells in each MeshBlock, X2-dir
+nx1 = 20  # Number of cells in each MeshBlock, X1-dir
+nx2 = 20  # Number of cells in each MeshBlock, X2-dir
 nx3 = 1   # Number of cells in each MeshBlock, X3-dir
 
 <physics>
@@ -76,12 +72,17 @@ gamma = 1.4  # adiabatic index
 mu = 28.96   # mean molecular weight
 <gas/opacity/absorption>
 opacity_model = constant
-kappa_a = 2.0
+kappa_a = 0.2
 
 # from thermalization
 <problem>
 rho0 = 1.0
 h  = 0.1
+t_init = 1.1e4
+t_source = 5.8e6
+rho_thin = 0.01
+#rho_thick = 10.0 // trying 10x less to get wave propagation
+rho_thick = 1.0
 
 <parthenon/swarm>
 ix1_bc = jaybenne_reflecting # inner-X1 boundary flag for swarms
@@ -91,8 +92,10 @@ ox2_bc = outflow  # outer-X2 boundary flag for swarms
 ix3_bc = jaybenne_reflecting # inner-X3 boundary flag for swarms
 ox3_bc = jaybenne_reflecting # outer-X3 boundary flag for swarms
 
+<crooked_pipe>
+
 <radiation/imc>
 do_emission = true
-num_particles = 32000000 # particle resolution
+num_particles = 4000000 # particle resolution
 use_ddmc = true          # use DDMC?
 #min_swarm_occupancy = 0.5

--- a/inputs/radiation/crooked_pipe.in
+++ b/inputs/radiation/crooked_pipe.in
@@ -1,0 +1,98 @@
+<artemis>
+problem = crooked_pipe  # name of the pgen
+coordinates = cartesian
+physical_units = cgs     # not scale-free
+unit_conversion = ppd   # [L/T/M/Temp] = 1
+
+<parthenon/job>
+problem_id = crooked_pipe  # problem ID: basename of output filenames
+<parthenon/output1>
+variables = gas.prim.density,   &
+            gas.prim.velocity,  &
+            gas.prim.pressure, &
+            gas.prim.sie,      &
+            field.jaybenne.energy_tally
+file_type = hdf5  # HDF5 data dump
+dt        = 1.0e-11 # time increment between outputs
+#ghost_zones = true # output ghost zones
+use_final_label  = false
+
+<parthenon/time>
+nlim       = 10     # cycle limit
+tlim       = 1.0e-6 # time limit
+integrator = rk2    # time integration algorithm
+ncycle_out = 1      # interval for stdout summary info
+dt_force = 1.0e-10
+
+<crooked_pipe>
+t_init = 1.1e4
+t_source = 5.8e6
+rho_thin = 1.0
+rho_thick = 100.0
+
+<parthenon/mesh>
+#refinement = static # Enable static mesh refinement
+nx1 = 900
+x1min  = -2.0      # minimum value of X1
+x1max  = 7.0    # maximum value of X1
+ix1_bc = reflecting  # Inner-X1 boundary condition flag
+ox1_bc = outflow    # Outer-X1 boundary condition flag
+nx2    = 400        # Number of zones in X2-direction
+x2min  = -2.0       # minimum value of X2
+x2max  = 2.0       # maximum value of X2
+ix2_bc = reflecting   # Inner-X2 boundary condition flag
+ox2_bc = outflow   # Outer-X2 boundary condition flag
+nx3    = 1        # Number of zones in X3-direction
+x3min  = 0      # minimum value of X3
+x3max  = 1   # maximum value of X3
+ix3_bc = reflecting  # Inner-X3 boundary condition flag
+ox3_bc = reflecting  # Outer-X3 boundary condition flag
+nghost = 2
+#refinement = adaptive
+#numlevel = 2
+
+<parthenon/meshblock>
+nx1 = 90  # Number of cells in each MeshBlock, X1-dir
+nx2 = 40  # Number of cells in each MeshBlock, X2-dir
+nx3 = 1   # Number of cells in each MeshBlock, X3-dir
+
+<physics>
+gas = true
+gravity = false
+rotating_frame = false
+radiation = true
+
+# from thermalization
+<gas>
+cfl = 0.8
+reconstruct = plm
+riemann = hllc-general
+dfloor = 1.0e-10
+siefloor = 1.0e-10
+
+# from thermalization
+<gas/eos/ideal>
+gamma = 1.4  # adiabatic index
+mu = 28.96   # mean molecular weight
+<gas/opacity/absorption>
+opacity_model = constant
+kappa_a = 2.0
+
+# from thermalization
+<problem>
+rho0 = 1.0
+h  = 0.1
+
+<parthenon/swarm>
+ix1_bc = jaybenne_reflecting # inner-X1 boundary flag for swarms
+ox1_bc = outflow  # outer-X1 boundary flag for swarms
+ix2_bc = jaybenne_reflecting  # inner-X2 boundary flag for swarms
+ox2_bc = outflow  # outer-X2 boundary flag for swarms
+ix3_bc = jaybenne_reflecting # inner-X3 boundary flag for swarms
+ox3_bc = jaybenne_reflecting # outer-X3 boundary flag for swarms
+
+<radiation/imc>
+do_emission = true
+num_particles = 32000000 # particle resolution
+use_ddmc = true          # use DDMC?
+#min_swarm_occupancy = 0.5

--- a/inputs/radiation/crooked_pipe.in
+++ b/inputs/radiation/crooked_pipe.in
@@ -13,13 +13,13 @@ variables = gas.prim.density,   &
             gas.prim.sie,      &
             field.jaybenne.energy_tally
 file_type = hdf5  # HDF5 data dump
-dt        = 5.0e-8 # time increment between outputs, 5 shakes (50 nanoseconds)
+dt        = 5.0e-8 # time increment between outputs
 #ghost_zones = true # output ghost zones
 use_final_label  = false
 
 <parthenon/time>
-nlim       = 3000   # cycle limit
-tlim       = 2.5e-6 # time limit, 250 shakes
+nlim       = 1500   # cycle limit
+tlim       = 2.5e-6 # time limit
 integrator = rk2    # time integration algorithm
 ncycle_out = 1      # interval for stdout summary info
 dt_init = 1.0e-11
@@ -65,6 +65,7 @@ reconstruct = plm
 riemann = hllc-general
 dfloor = 1.0e-10
 siefloor = 1.0e-10
+update_fluxes= false # radiation only problem
 
 # from thermalization
 <gas/eos/ideal>
@@ -81,8 +82,7 @@ h  = 0.1
 t_init = 1.1e4
 t_source = 5.8e6
 rho_thin = 0.01
-#rho_thick = 10.0 // trying 10x less to get wave propagation
-rho_thick = 1.0
+rho_thick = 10.0
 
 <parthenon/swarm>
 ix1_bc = jaybenne_reflecting # inner-X1 boundary flag for swarms
@@ -96,6 +96,8 @@ ox3_bc = jaybenne_reflecting # outer-X3 boundary flag for swarms
 
 <radiation/imc>
 do_emission = true
-num_particles = 4000000 # particle resolution
-use_ddmc = true          # use DDMC?
+num_particles = 8000000 # particle resolution
+use_ddmc = false          # use DDMC?
+cutoff = 1.0e-6           # default is 1.0e-6
+emit_temp_threshold = 1.2e4 # from ryan, 1.1e4 is background
 #min_swarm_occupancy = 0.5

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -106,6 +106,7 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   const bool do_moment = do_radiation && pin->DoesBlockExist("radiation/moment");
   const bool do_shear =
       do_rotating_frame ? (pin->GetOrAddReal("rotating_frame", "qshear", 0) > 0) : false;
+  const bool update_fluxes= pin->GetOrAddBoolean("gas", "update_fluxes", true);
 
   // Check configuration selection compatibility
   PARTHENON_REQUIRE(!(do_cooling) || (do_cooling && do_gas),
@@ -140,6 +141,7 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   artemis->AddParam("do_moment", do_moment);
   artemis->AddParam("do_shear", do_shear);
   artemis->AddParam("do_raytrace", do_raytrace);
+  artemis->AddParam("update_fluxes", update_fluxes);
 
   // Set coordinate system
   const int ndim = ProblemDimension(pin.get());

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -106,7 +106,7 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   const bool do_moment = do_radiation && pin->DoesBlockExist("radiation/moment");
   const bool do_shear =
       do_rotating_frame ? (pin->GetOrAddReal("rotating_frame", "qshear", 0) > 0) : false;
-  const bool update_fluxes= pin->GetOrAddBoolean("gas", "update_fluxes", true);
+  const bool update_fluxes = pin->GetOrAddBoolean("gas", "update_fluxes", true);
 
   // Check configuration selection compatibility
   PARTHENON_REQUIRE(!(do_cooling) || (do_cooling && do_gas),

--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -74,8 +74,8 @@ ArtemisDriver<GEOM>::ArtemisDriver(ParameterInput *pin, ApplicationInput *app_in
   do_coagulation = artemis_pkg->template Param<bool>("do_coagulation");
   do_raytrace = artemis_pkg->template Param<bool>("do_raytrace");
 
-  // Update fluxes option--gas fields are needed for radiation temperature updates but for rad-only
-  // test problems turn off advection
+  // Update fluxes option--gas fields are needed for radiation temperature updates but for
+  // rad-only test problems turn off advection
   update_fluxes = artemis_pkg->template Param<bool>("update_fluxes");
 
   // Moments integrator
@@ -249,7 +249,8 @@ TaskCollection ArtemisDriver<GEOM>::StepTasks() {
       // NOTE(@adempsey): 1st stage of VL2 uses piecewise constant reconstruction
       const bool do_pcm = ((stage == 1) && (integrator->GetName() == "vl2"));
       TaskID gas_flx = none, dust_flx = none;
-      if (do_gas && update_fluxes) gas_flx = tl.AddTask(none, Gas::CalculateFluxes, u0.get(), do_pcm);
+      if (do_gas && update_fluxes)
+        gas_flx = tl.AddTask(none, Gas::CalculateFluxes, u0.get(), do_pcm);
       if (do_dust) dust_flx = tl.AddTask(none, Dust::CalculateFluxes, u0.get(), do_pcm);
 
       // Compute (gas) diffusive fluxes

--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -74,6 +74,10 @@ ArtemisDriver<GEOM>::ArtemisDriver(ParameterInput *pin, ApplicationInput *app_in
   do_coagulation = artemis_pkg->template Param<bool>("do_coagulation");
   do_raytrace = artemis_pkg->template Param<bool>("do_raytrace");
 
+  // Update fluxes option--gas fields are needed for radiation temperature updates but for rad-only
+  // test problems turn off advection
+  update_fluxes = artemis_pkg->template Param<bool>("update_fluxes");
+
   // Moments integrator
   if (do_moment) {
     auto rad_int = pin->GetOrAddString("radiation/moment", "integrator", "rk2");
@@ -245,7 +249,7 @@ TaskCollection ArtemisDriver<GEOM>::StepTasks() {
       // NOTE(@adempsey): 1st stage of VL2 uses piecewise constant reconstruction
       const bool do_pcm = ((stage == 1) && (integrator->GetName() == "vl2"));
       TaskID gas_flx = none, dust_flx = none;
-      //if (do_gas) gas_flx = tl.AddTask(none, Gas::CalculateFluxes, u0.get(), do_pcm);
+      if (do_gas && update_fluxes) gas_flx = tl.AddTask(none, Gas::CalculateFluxes, u0.get(), do_pcm);
       if (do_dust) dust_flx = tl.AddTask(none, Dust::CalculateFluxes, u0.get(), do_pcm);
 
       // Compute (gas) diffusive fluxes

--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -245,7 +245,7 @@ TaskCollection ArtemisDriver<GEOM>::StepTasks() {
       // NOTE(@adempsey): 1st stage of VL2 uses piecewise constant reconstruction
       const bool do_pcm = ((stage == 1) && (integrator->GetName() == "vl2"));
       TaskID gas_flx = none, dust_flx = none;
-      if (do_gas) gas_flx = tl.AddTask(none, Gas::CalculateFluxes, u0.get(), do_pcm);
+      //if (do_gas) gas_flx = tl.AddTask(none, Gas::CalculateFluxes, u0.get(), do_pcm);
       if (do_dust) dust_flx = tl.AddTask(none, Dust::CalculateFluxes, u0.get(), do_pcm);
 
       // Compute (gas) diffusive fluxes

--- a/src/artemis_driver.hpp
+++ b/src/artemis_driver.hpp
@@ -56,6 +56,7 @@ class ArtemisDriver : public EvolutionDriver {
   bool do_gravity, do_nbody, do_rotating_frame, do_shear;
   bool do_cooling, do_drag, do_viscosity, do_conduction, do_diffusion;
   bool do_coagulation, do_raytrace;
+  bool update_fluxes;
   const bool is_restart;
 };
 

--- a/src/pgen/crooked_pipe.hpp
+++ b/src/pgen/crooked_pipe.hpp
@@ -44,9 +44,9 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const bool do_radiation = artemis_pkg->Param<bool>("do_radiation");
   const bool do_imc = artemis_pkg->Param<bool>("do_imc");
   const bool do_moment = artemis_pkg->Param<bool>("do_moment");
-  //PARTHENON_REQUIRE(do_gas, "Thermalization problem requires gas!");
+  PARTHENON_REQUIRE(do_gas, "Crooked pipe problem requires gas!");
   PARTHENON_REQUIRE(!(do_dust), "Crooked pipe problem does not permit dust!");
-  PARTHENON_REQUIRE(!(do_gas), "Crooked pipe problem does not permit gas!");
+  //PARTHENON_REQUIRE(!(do_gas), "Crooked pipe problem does not permit gas!");
   auto gas_pkg = pmb->packages.Get("gas");
   const auto eos = gas_pkg->Param<EOS>("eos_d");
   Real ar = Null<Real>();
@@ -72,7 +72,7 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
       MakePackDescriptor<gas::prim::density, gas::prim::velocity, gas::prim::sie,
                          rad::prim::energy, rad::prim::flux>(
           (pmb->resolved_packages).get());
-  auto v = desc.GetPack(pmb);
+  auto v = desc.GetPack(md.get());
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);

--- a/src/pgen/crooked_pipe.hpp
+++ b/src/pgen/crooked_pipe.hpp
@@ -47,7 +47,8 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const bool update_fluxes = artemis_pkg->Param<bool>("update_fluxes");
   PARTHENON_REQUIRE(do_gas, "Crooked pipe problem requires gas!");
   PARTHENON_REQUIRE(!(do_dust), "Crooked pipe problem does not permit dust!");
-  PARTHENON_REQUIRE(!(update_fluxes), "Crooked pipe problem requires update fluxes to be off!");
+  PARTHENON_REQUIRE(!(update_fluxes),
+                    "Crooked pipe problem requires update fluxes to be off!");
   auto gas_pkg = pmb->packages.Get("gas");
   const auto eos = gas_pkg->Param<EOS>("eos_d");
   Real ar = Null<Real>();

--- a/src/pgen/crooked_pipe.hpp
+++ b/src/pgen/crooked_pipe.hpp
@@ -78,13 +78,14 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   std::vector<std::array<double, 4>> thick_regions = {{3.0,4.0, -1.0,1.0},
-                                                      {-2.0,2.5, -2.0, 0.5}, // extended xl to -2 for thick region above source
+                                                      {-2.0,2.5, -2.0, -0.5}, // extended xl to -2 for thick region above source
                                                       {-2.0, 2.5, 0.5, 2.0}, // extended xl to -2 for thick region above source
-                                                      {4.5, 7.0, -2.0, 0.5},
+                                                      {4.5, 7.0, -2.0, -0.5},
                                                       {4.5, 7.0, 0.5, 2.0},
+                                                      {2.5, 4.5, -2.0, -1.5},
                                                       {2.5, 4.5, 1.5, 2.5}};
 
-  std::vector<std::array<double, 4>> thin_source_regions= {{-2.0,0.0,-1.0,1.0}};
+  std::vector<std::array<double, 4>> thin_source_regions= {{-2.0,0.0,-0.5,0.5}};
 
   const auto &cpars =
       pmb->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
@@ -118,15 +119,14 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
           eos.InternalEnergyFromDensityTemperature(rho_thin, t_init);
 
       for( const auto &iregion : thick_regions) {
-        if (xl >= iregion[0] && xu < iregion[1] && yl >= iregion[2] && yu <= iregion[3]) {
+        if (xl >= iregion[0] && xu <= iregion[1] && yl >= iregion[2] && yu <= iregion[3]) {
           v(0, gas::prim::density(), k, j, i) = rho_thick;
           v(0, gas::prim::sie(), k, j, i) =
               eos.InternalEnergyFromDensityTemperature(rho_thick, t_init);
         }
       }
       for( const auto &iregion : thin_source_regions) {
-        if (xl >= iregion[0] && xu < iregion[1] && yl >= iregion[2] && yu <= iregion[3]) {
-          v(0, gas::prim::density(), k, j, i) = rho_thin;
+        if (xl >= iregion[0] && xu <= iregion[1] && yl >= iregion[2] && yu <= iregion[3]) {
           v(0, gas::prim::sie(), k, j, i) =
               eos.InternalEnergyFromDensityTemperature(rho_thin, t_source);
         }

--- a/src/pgen/crooked_pipe.hpp
+++ b/src/pgen/crooked_pipe.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/pgen/crooked_pipe.hpp
+++ b/src/pgen/crooked_pipe.hpp
@@ -1,0 +1,162 @@
+//========================================================================================
+// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#ifndef PGEN_CROOKED_PIPE_HPP_
+#define PGEN_CROOKED_PIPE_HPP_
+//! \file crooked_pipe.hpp
+//! \brief
+
+// artemis headers
+#include "artemis.hpp"
+#include "geometry/geometry.hpp"
+#include "pgen/pgen.hpp"
+#include "utils/artemis_utils.hpp"
+#include "utils/eos/eos.hpp"
+
+// jaybenne includes
+#include "jaybenne.hpp"
+
+using ArtemisUtils::EOS;
+
+namespace crooked_pipe {
+
+//----------------------------------------------------------------------------------------
+//! \fn void ProblemGenerator::Crooked_Pipe()
+//! \brief Sets initial conditions for crooked pipe radiation flow problem
+template <Coordinates GEOM>
+inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
+  PARTHENON_INSTRUMENT
+  using parthenon::MakePackDescriptor;
+
+  // Extract parameters from packages
+  auto artemis_pkg = pmb->packages.Get("artemis");
+  const bool do_gas = artemis_pkg->Param<bool>("do_gas");
+  const bool do_dust = artemis_pkg->Param<bool>("do_dust");
+  const bool do_radiation = artemis_pkg->Param<bool>("do_radiation");
+  const bool do_imc = artemis_pkg->Param<bool>("do_imc");
+  const bool do_moment = artemis_pkg->Param<bool>("do_moment");
+  //PARTHENON_REQUIRE(do_gas, "Thermalization problem requires gas!");
+  PARTHENON_REQUIRE(!(do_dust), "Crooked pipe problem does not permit dust!");
+  PARTHENON_REQUIRE(!(do_gas), "Crooked pipe problem does not permit gas!");
+  auto gas_pkg = pmb->packages.Get("gas");
+  const auto eos = gas_pkg->Param<EOS>("eos_d");
+  Real ar = Null<Real>();
+  if (do_moment) {
+    auto rad_pkg = pmb->packages.Get("moments");
+    ar = rad_pkg->Param<Real>("arad");
+  }
+
+  // Initial conditions
+  const Real rho_thin = pin->GetOrAddReal("problem", "rho_thin", 1.0);
+  const Real rho_thick = pin->GetOrAddReal("problem", "rho_thick", 1000.0);
+  const Real t_source = pin->GetOrAddReal("problem", "t_source", 0.3); // put in K?
+  const Real t_init = pin->GetOrAddReal("problem", "t_init", 0.01); // put in K?
+
+  // Allocate sparse
+  auto &md = pmb->meshblock_data.Get();
+  for (auto &var : md->GetVariableVector()) {
+    if (!var->IsAllocated()) pmb->AllocateSparse(var->label());
+  }
+
+  // packing and capture variables for kernel
+  static auto desc =
+      MakePackDescriptor<gas::prim::density, gas::prim::velocity, gas::prim::sie,
+                         rad::prim::energy, rad::prim::flux>(
+          (pmb->resolved_packages).get());
+  auto v = desc.GetPack(pmb);
+  IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
+  IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
+  IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+
+  std::vector<std::array<double, 4>> thick_regions = {{3.0,4.0, -1.0,1.0},
+                                                      {-2.0,2.5, -2.0, 0.5}, // extended xl to -2 for thick region above source
+                                                      {-2.0, 2.5, 0.5, 2.0}, // extended xl to -2 for thick region above source
+                                                      {4.5, 7.0, -2.0, 0.5},
+                                                      {4.5, 7.0, 0.5, 2.0},
+                                                      {2.5, 4.5, 1.5, 2.5}};
+
+  std::vector<std::array<double, 4>> thin_source_regions= {{-2.0,0.0,-1.0,1.0}};
+
+  const auto &cpars =
+      pmb->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
+  auto &pco = pmb->coords;
+
+  static auto desc_g = MakePackDescriptor<geom::vol, geom::x1v, geom::x2v, geom::x3v>(
+      (pmb->resolved_packages).get());
+  auto vg = desc_g.GetPack(md.get());
+
+  // Set state vector to initialize:
+  // * source radiation and material temperatureradiation field via t_source
+  // * density of thin regions using rho_thin
+  // * density of thick regions using rho_thick
+  // * initial material and radiation temperature of all cell using t_init
+  if (do_imc) {
+    pmb->par_for(
+      "crooked_pipe::trad", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int k, const int j, const int i) {
+
+      geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+      const auto &xv = coords.GetCellCenter(vg, 0, k, j, i);
+
+      const Real xl = xv[0];
+      const Real xu = xv[0];
+      const Real yl = xv[1];
+      const Real yu = xv[1];
+
+      // default thin cell
+      v(0, gas::prim::density(), k, j, i) = rho_thin;
+      v(0, gas::prim::sie(), k, j, i) =
+          eos.InternalEnergyFromDensityTemperature(rho_thin, t_init);
+
+      for( const auto &iregion : thick_regions) {
+        if (xl >= iregion[0] && xu < iregion[1] && yl >= iregion[2] && yu <= iregion[3]) {
+          v(0, gas::prim::density(), k, j, i) = rho_thick;
+          v(0, gas::prim::sie(), k, j, i) =
+              eos.InternalEnergyFromDensityTemperature(rho_thick, t_init);
+        }
+      }
+      for( const auto &iregion : thin_source_regions) {
+        if (xl >= iregion[0] && xu < iregion[1] && yl >= iregion[2] && yu <= iregion[3]) {
+          v(0, gas::prim::density(), k, j, i) = rho_thin;
+          v(0, gas::prim::sie(), k, j, i) =
+              eos.InternalEnergyFromDensityTemperature(rho_thin, t_source);
+        }
+      }
+    });
+    jaybenne::InitializeRadiation(md.get(), true);
+  }
+
+  /*
+  // Now reset fluid state out of thermal equilibrium via tgas
+  pmb->par_for(
+      "thermalization::tgas", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int k, const int j, const int i) {
+        v(0, gas::prim::density(), k, j, i) = rho;
+        v(0, gas::prim::velocity(0), k, j, i) = vx;
+        v(0, gas::prim::velocity(1), k, j, i) = 0.0;
+        v(0, gas::prim::velocity(2), k, j, i) = 0.0;
+        v(0, gas::prim::sie(), k, j, i) =
+            eos.InternalEnergyFromDensityTemperature(rho, tgas);
+
+        if (do_moment) {
+          v(0, rad::prim::energy(), k, j, i) = ar * SQR(SQR(trad));
+          v(0, rad::prim::flux(0), k, j, i) = 0.0;
+          v(0, rad::prim::flux(1), k, j, i) = 0.0;
+          v(0, rad::prim::flux(2), k, j, i) = 0.0;
+        }
+      });
+  */
+}
+
+} // namespace crooked_pipe
+#endif // PGEN_CROOKED_PIPE_HPP_
+

--- a/src/pgen/crooked_pipe.hpp
+++ b/src/pgen/crooked_pipe.hpp
@@ -44,9 +44,10 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const bool do_radiation = artemis_pkg->Param<bool>("do_radiation");
   const bool do_imc = artemis_pkg->Param<bool>("do_imc");
   const bool do_moment = artemis_pkg->Param<bool>("do_moment");
+  const bool update_fluxes = artemis_pkg->Param<bool>("update_fluxes");
   PARTHENON_REQUIRE(do_gas, "Crooked pipe problem requires gas!");
   PARTHENON_REQUIRE(!(do_dust), "Crooked pipe problem does not permit dust!");
-  //PARTHENON_REQUIRE(!(do_gas), "Crooked pipe problem does not permit gas!");
+  PARTHENON_REQUIRE(!(update_fluxes), "Crooked pipe problem requires update fluxes to be off!");
   auto gas_pkg = pmb->packages.Get("gas");
   const auto eos = gas_pkg->Param<EOS>("eos_d");
   Real ar = Null<Real>();
@@ -59,7 +60,7 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const Real rho_thin = pin->GetOrAddReal("problem", "rho_thin", 1.0);
   const Real rho_thick = pin->GetOrAddReal("problem", "rho_thick", 1000.0);
   const Real t_source = pin->GetOrAddReal("problem", "t_source", 0.3); // put in K?
-  const Real t_init = pin->GetOrAddReal("problem", "t_init", 0.01); // put in K?
+  const Real t_init = pin->GetOrAddReal("problem", "t_init", 0.01);    // put in K?
 
   // Allocate sparse
   auto &md = pmb->meshblock_data.Get();
@@ -77,15 +78,16 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
-  std::array<std::array<double, 4>, 7> thick_regions = {{{3.0,4.0, -1.0,1.0},
-                                                      {-2.0,2.5, -2.0, -0.5}, // extended xl to -2 for thick region above source
-                                                      {-2.0, 2.5, 0.5, 2.0}, // extended xl to -2 for thick region above source
-                                                      {4.5, 7.0, -2.0, -0.5},
-                                                      {4.5, 7.0, 0.5, 2.0},
-                                                      {2.5, 4.5, -2.0, -1.5},
-                                                      {2.5, 4.5, 1.5, 2.5}}};
+  std::array<std::array<double, 4>, 7> thick_regions = {
+      {{3.0, 4.0, -1.0, 1.0},
+       {-2.0, 2.5, -2.0, -0.5}, // extended xl to -2 for thick region above source
+       {-2.0, 2.5, 0.5, 2.0},   // extended xl to -2 for thick region above source
+       {4.5, 7.0, -2.0, -0.5},
+       {4.5, 7.0, 0.5, 2.0},
+       {2.5, 4.5, -2.0, -1.5},
+       {2.5, 4.5, 1.5, 2.5}}};
 
-  std::array<std::array<double, 4>, 1> thin_source_regions= {{{-2.0,0.0,-0.5,0.5}}};
+  std::array<std::array<double, 4>, 1> thin_source_regions = {{{-2.0, 0.0, -0.5, 0.5}}};
 
   const auto &cpars =
       pmb->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
@@ -102,36 +104,37 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   // * initial material and radiation temperature of all cell using t_init
   if (do_imc) {
     pmb->par_for(
-      "crooked_pipe::trad", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-      KOKKOS_LAMBDA(const int k, const int j, const int i) {
+        "crooked_pipe::trad", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int k, const int j, const int i) {
+          geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
+          const auto &xv = coords.GetCellCenter(vg, 0, k, j, i);
 
-      geometry::Coords<GEOM> coords(cpars, pco, k, j, i);
-      const auto &xv = coords.GetCellCenter(vg, 0, k, j, i);
+          const Real xl = xv[0];
+          const Real xu = xv[0];
+          const Real yl = xv[1];
+          const Real yu = xv[1];
 
-      const Real xl = xv[0];
-      const Real xu = xv[0];
-      const Real yl = xv[1];
-      const Real yu = xv[1];
-
-      // default thin cell
-      v(0, gas::prim::density(), k, j, i) = rho_thin;
-      v(0, gas::prim::sie(), k, j, i) =
-          eos.InternalEnergyFromDensityTemperature(rho_thin, t_init);
-
-      for( const auto &iregion : thick_regions) {
-        if (xl >= iregion[0] && xu <= iregion[1] && yl >= iregion[2] && yu <= iregion[3]) {
-          v(0, gas::prim::density(), k, j, i) = rho_thick;
+          // default thin cell
+          v(0, gas::prim::density(), k, j, i) = rho_thin;
           v(0, gas::prim::sie(), k, j, i) =
-              eos.InternalEnergyFromDensityTemperature(rho_thick, t_init);
-        }
-      }
-      for( const auto &iregion : thin_source_regions) {
-        if (xl >= iregion[0] && xu <= iregion[1] && yl >= iregion[2] && yu <= iregion[3]) {
-          v(0, gas::prim::sie(), k, j, i) =
-              eos.InternalEnergyFromDensityTemperature(rho_thin, t_source);
-        }
-      }
-    });
+              eos.InternalEnergyFromDensityTemperature(rho_thin, t_init);
+
+          for (const auto &iregion : thick_regions) {
+            if (xl >= iregion[0] && xu <= iregion[1] && yl >= iregion[2] &&
+                yu <= iregion[3]) {
+              v(0, gas::prim::density(), k, j, i) = rho_thick;
+              v(0, gas::prim::sie(), k, j, i) =
+                  eos.InternalEnergyFromDensityTemperature(rho_thick, t_init);
+            }
+          }
+          for (const auto &iregion : thin_source_regions) {
+            if (xl >= iregion[0] && xu <= iregion[1] && yl >= iregion[2] &&
+                yu <= iregion[3]) {
+              v(0, gas::prim::sie(), k, j, i) =
+                  eos.InternalEnergyFromDensityTemperature(rho_thin, t_source);
+            }
+          }
+        });
     jaybenne::InitializeRadiation(md.get(), true);
   }
 
@@ -159,4 +162,3 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
 } // namespace crooked_pipe
 #endif // PGEN_CROOKED_PIPE_HPP_
-

--- a/src/pgen/crooked_pipe.hpp
+++ b/src/pgen/crooked_pipe.hpp
@@ -77,15 +77,15 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
-  std::vector<std::array<double, 4>> thick_regions = {{3.0,4.0, -1.0,1.0},
+  std::array<std::array<double, 4>, 7> thick_regions = {{{3.0,4.0, -1.0,1.0},
                                                       {-2.0,2.5, -2.0, -0.5}, // extended xl to -2 for thick region above source
                                                       {-2.0, 2.5, 0.5, 2.0}, // extended xl to -2 for thick region above source
                                                       {4.5, 7.0, -2.0, -0.5},
                                                       {4.5, 7.0, 0.5, 2.0},
                                                       {2.5, 4.5, -2.0, -1.5},
-                                                      {2.5, 4.5, 1.5, 2.5}};
+                                                      {2.5, 4.5, 1.5, 2.5}}};
 
-  std::vector<std::array<double, 4>> thin_source_regions= {{-2.0,0.0,-0.5,0.5}};
+  std::array<std::array<double, 4>, 1> thin_source_regions= {{{-2.0,0.0,-0.5,0.5}}};
 
   const auto &cpars =
       pmb->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");

--- a/src/pgen/params.yaml
+++ b/src/pgen/params.yaml
@@ -296,3 +296,22 @@ problem(thermalization):
     _type: Real
     _default: 1.0
     _description: "Background radiation temperature."
+
+problem(crooked_pipe):
+  _description: "<problem> block parameters when artemis/problem=crooked_pipe"
+  rho_thick:
+    _type: Real
+    _default: 100.0
+    _description: "Thick material density."
+  rho_thin:
+    _type: Real
+    _default: 1.0
+    _description: "Thin material density."
+  t_source:
+    _type: Real
+    _default: 100.0
+    _description: "Source region temperature."
+  t_init:
+    _type: Real
+    _default: 1.0
+    _description: "Non-source initial temperature."

--- a/src/pgen/pgen.hpp
+++ b/src/pgen/pgen.hpp
@@ -34,6 +34,7 @@
 #include "shock.hpp"
 #include "strat.hpp"
 #include "thermalization.hpp"
+#include "crooked_pipe.hpp"
 
 using namespace parthenon::package::prelude;
 
@@ -75,6 +76,8 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
     strat::ProblemGenerator<T>(pmb, pin);
   } else if (name == "thermalization") {
     thermalization::ProblemGenerator<T>(pmb, pin);
+  } else if (name == "crooked_pipe") {
+    crooked_pipe::ProblemGenerator<T>(pmb, pin);
   } else {
     PARTHENON_FAIL("Invalid problem name!");
   }

--- a/src/pgen/pgen.hpp
+++ b/src/pgen/pgen.hpp
@@ -24,6 +24,7 @@
 #include "coag.hpp"
 #include "conduction.hpp"
 #include "constant.hpp"
+#include "crooked_pipe.hpp"
 #include "disk.hpp"
 #include "gaussian_bump.hpp"
 #include "geometry/geometry.hpp"
@@ -34,7 +35,6 @@
 #include "shock.hpp"
 #include "strat.hpp"
 #include "thermalization.hpp"
-#include "crooked_pipe.hpp"
 
 using namespace parthenon::package::prelude;
 

--- a/src/utils/artemis_utils.cpp
+++ b/src/utils/artemis_utils.cpp
@@ -38,6 +38,7 @@ void PrintArtemisConfiguration(Packages_t &packages) {
     std::string hfill(21, ' ');
     std::string msg = "";
     if (params.Get<bool>("do_gas")) msg += "Gas\n";
+    if (!params.Get<bool>("update_fluxes")) msg += "(without flux updates)\n";
     if (params.Get<bool>("do_dust")) msg += hfill + "Dust\n";
     if (params.Get<bool>("do_gravity")) msg += hfill + "Gravity\n";
     if (params.Get<bool>("do_rotating_frame")) msg += hfill + "Rotating frame\n";

--- a/tst/scripts/coagulation/coagulation.py
+++ b/tst/scripts/coagulation/coagulation.py
@@ -20,7 +20,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 
 _nranks = 1

--- a/tst/scripts/collisions/collisions.py
+++ b/tst/scripts/collisions/collisions.py
@@ -22,7 +22,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
 import matplotlib

--- a/tst/scripts/coords/blast.py
+++ b/tst/scripts/coords/blast.py
@@ -20,7 +20,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)

--- a/tst/scripts/diffusion/alpha_disk.py
+++ b/tst/scripts/diffusion/alpha_disk.py
@@ -20,7 +20,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)

--- a/tst/scripts/diffusion/thermal_diffusion.py
+++ b/tst/scripts/diffusion/thermal_diffusion.py
@@ -20,7 +20,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)

--- a/tst/scripts/disk/disk.py
+++ b/tst/scripts/disk/disk.py
@@ -21,7 +21,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)

--- a/tst/scripts/disk_nbody/disk_nbody.py
+++ b/tst/scripts/disk_nbody/disk_nbody.py
@@ -21,7 +21,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)

--- a/tst/scripts/drag/drag.py
+++ b/tst/scripts/drag/drag.py
@@ -20,7 +20,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)

--- a/tst/scripts/nbody/nbody.py
+++ b/tst/scripts/nbody/nbody.py
@@ -25,7 +25,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)

--- a/tst/scripts/ssheet/ssheet.py
+++ b/tst/scripts/ssheet/ssheet.py
@@ -22,7 +22,6 @@ import os
 import scripts.utils.artemis as artemis
 from scipy.interpolate import interp1d
 
-
 logger = logging.getLogger("artemis" + __name__[7:])  # set logger name
 logging.getLogger("h5py").setLevel(logging.WARNING)
 logging.getLogger("matplotlib").setLevel(logging.WARNING)


### PR DESCRIPTION
## Background

* We'd like to compare the moment method and IMC on a common radiation test problem

## Description of Changes

* Add pgen input for crooked pipe with geometric density and temperature specifications
* Modify pgen.hpp to include crooked pipe case
* Modify params.yaml to include crooked pipe defaults

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
