### PR TITLE
reconstruction options

### DIFF
--- a/doc/src/physics.rst
+++ b/doc/src/physics.rst
@@ -56,7 +56,7 @@ An example input block for a gas could read
   <gas>
   cfl = 0.3
   riemann = hllc     # llf, hlle, hllc Riemann solvers
-  reconstruct = plm  # pcm, plm, ppm reconstructions
+  reconstruct = plm  # pcm, plm, ppm, wenoz, wenomz reconstructions
   
   <gas/eos/ideal>
   gamma = 1.4
@@ -303,7 +303,7 @@ An example dust input block reads:
    cfl = 0.3
    nspecies = 3
    riemann = hlle       # llf, hlle
-   reconstruct = plm    # pcm, plm, ppm
+   reconstruct = plm    # pcm, plm, ppm, wenoz, wenomz
    grain_density = 1.7  # g/cc
    sizes = 1e-4, 1e-2, 1e-1  # cm
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,8 @@ set (SRC_LIST
   utils/fluxes/reconstruction/pcm.hpp
   utils/fluxes/reconstruction/plm.hpp
   utils/fluxes/reconstruction/ppm.hpp
+  utils/fluxes/reconstruction/wenoz.hpp
+  utils/fluxes/reconstruction/wenomz.hpp
   utils/fluxes/riemann/hllc.hpp
   utils/fluxes/riemann/hlle.hpp
   utils/fluxes/riemann/llf.hpp

--- a/src/artemis.hpp
+++ b/src/artemis.hpp
@@ -171,7 +171,7 @@ enum class RSolver { hllc_general, hlle, llf, hllc_gamma, null };
 // ... Upwinding (left vs right state)
 enum class Upwind { l, r, null };
 // ...Reconstruction algorithms
-enum class ReconstructionMethod { pcm, plm, ppm, null };
+enum class ReconstructionMethod { pcm, plm, ppm, wenoz, wenomz, null };
 // ...Fluid types
 enum class Fluid { gas, dust, radiation, null };
 // ...Closure types

--- a/src/dust/params.yaml
+++ b/src/dust/params.yaml
@@ -72,6 +72,12 @@ dust:
     ppm:
       _type: opt
       _description: "Piecewise Parabolic"
+    wenoz:
+      _type: opt
+      _description: "Weighted Essentially Non Oscillatory (Z)"
+    wenomz:
+      _type: opt
+      _description: "Weighted Essentially Non Oscillatory (MZ)"
 
   riemann:
     _type: string

--- a/src/gas/params.yaml
+++ b/src/gas/params.yaml
@@ -60,6 +60,12 @@ gas:
     ppm:
       _type: opt
       _description: "Piecewise Parabolic"
+    wenoz:
+      _type: opt
+      _description: "Weighted Essentially Non Oscillatory (Z)"
+    wenomz:
+      _type: opt
+      _description: "Weighted Essentially Non Oscillatory (MZ)"
   riemann:
     _type: string
     _default: hllc-general

--- a/src/radiation/params.yaml
+++ b/src/radiation/params.yaml
@@ -25,6 +25,12 @@ radiation:
       ppm:
         _type: opt
         _description: "Piecewise Parabolic"
+      wenoz:
+        _type: opt
+        _description: "Weighted Essentially Non Oscillatory (Z)"
+      wenomz:
+        _type: opt
+        _description: "Weighted Essentially Non Oscillatory (MZ)"
     riemann:
       _type: string
       _description: "Riemann solver"

--- a/src/rotating_frame/advection_driver.cpp
+++ b/src/rotating_frame/advection_driver.cpp
@@ -128,6 +128,10 @@ TaskStatus LagrangeRemap(MeshData<Real> *u0, const Real scdt) {
     return LagrangeRemapImpl<ReconstructionMethod::plm>(u0, v0, vg, dwdt);
   } else if (recon == ReconstructionMethod::ppm) {
     return LagrangeRemapImpl<ReconstructionMethod::ppm>(u0, v0, vg, dwdt);
+  } else if (recon == ReconstructionMethod::wenoz) {
+    return LagrangeRemapImpl<ReconstructionMethod::wenoz>(u0, v0, vg, dwdt);
+  } else if (recon == ReconstructionMethod::wenomz) {
+    return LagrangeRemapImpl<ReconstructionMethod::wenomz>(u0, v0, vg, dwdt);
   } else {
     PARTHENON_FAIL("Unsupported reconstruction method in rotating_frame");
   }

--- a/src/rotating_frame/params.yaml
+++ b/src/rotating_frame/params.yaml
@@ -23,6 +23,12 @@ rotating_frame:
     ppm:
       _type: opt
       _description: "Piecewise Parabolic"
+    wenoz:
+      _type: opt
+      _description: "Weighted Essentially Non Oscillatory (Z)"
+    wenomz:
+      _type: opt
+      _description: "Weighted Essentially Non Oscillatory (MZ)"
     cfl:
       _type: Real
       _default: 0.8

--- a/src/utils/artemis_utils.cpp
+++ b/src/utils/artemis_utils.cpp
@@ -269,6 +269,14 @@ ReconstructionMethod ChooseReconMethod(std::string recon) {
     PARTHENON_REQUIRE(parthenon::Globals::nghost >= 3,
                       "PPM requires at least 3 ghost cells.");
     return ReconstructionMethod::ppm;
+  } else if (recon.compare("wenoz") == 0) {
+    PARTHENON_REQUIRE(parthenon::Globals::nghost >= 3,
+                      "WENO-Z requires at least 3 ghost cells.");
+    return ReconstructionMethod::wenoz;
+  } else if (recon.compare("wenomz") == 0) {
+    PARTHENON_REQUIRE(parthenon::Globals::nghost >= 3,
+                      "WENO-MZ requires at least 3 ghost cells.");
+    return ReconstructionMethod::wenomz;
   }
   PARTHENON_FAIL("Reconstruction method not recognized.");
   return ReconstructionMethod::pcm;

--- a/src/utils/fluxes/fluid_fluxes.hpp
+++ b/src/utils/fluxes/fluid_fluxes.hpp
@@ -429,6 +429,10 @@ TaskStatus CalculateFluxesReconSelect(MeshData<Real> *md, PKG &pkg, PRIM vp, FLU
     return CalculateFluxesImpl<G, F, C, R, S::plm>(md, pkg, vp, vflx, vface, vg);
   } else if (recon_method == S::ppm) {
     return CalculateFluxesImpl<G, F, C, R, S::ppm>(md, pkg, vp, vflx, vface, vg);
+  } else if (recon_method == S::wenoz) {
+    return CalculateFluxesImpl<G, F, C, R, S::wenoz>(md, pkg, vp, vflx, vface, vg);
+  } else if (recon_method == S::wenomz) {
+    return CalculateFluxesImpl<G, F, C, R, S::wenomz>(md, pkg, vp, vflx, vface, vg);
   } else {
     PARTHENON_FAIL("Reconstruction method not recognized!");
   }

--- a/src/utils/fluxes/reconstruction/reconstruction.hpp
+++ b/src/utils/fluxes/reconstruction/reconstruction.hpp
@@ -116,5 +116,7 @@ post_recon(const EOS &eos, const Real dfloor, const Real siefloor,
 #include "pcm.hpp"
 #include "plm.hpp"
 #include "ppm.hpp"
+#include "wenoz.hpp"
+#include "wenomz.hpp"
 
 #endif // ARTEMIS_UTILS_FLUXES_RECONSTRUCTION_RECONSTRUCTION_HPP_

--- a/src/utils/fluxes/reconstruction/reconstruction.hpp
+++ b/src/utils/fluxes/reconstruction/reconstruction.hpp
@@ -116,7 +116,7 @@ post_recon(const EOS &eos, const Real dfloor, const Real siefloor,
 #include "pcm.hpp"
 #include "plm.hpp"
 #include "ppm.hpp"
-#include "wenoz.hpp"
 #include "wenomz.hpp"
+#include "wenoz.hpp"
 
 #endif // ARTEMIS_UTILS_FLUXES_RECONSTRUCTION_RECONSTRUCTION_HPP_

--- a/src/utils/fluxes/reconstruction/wenomz.hpp
+++ b/src/utils/fluxes/reconstruction/wenomz.hpp
@@ -47,11 +47,11 @@ void WENOMZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &
             weno_beta_coeff_1 * SQR(3 * q_i - 4 * q_ip1 + q_ip2), 
             weno_beta_coeff_4 * SQR(q_im1 - 2 * q_i + q_ip1)};
 
-  Real tau_5 = fabs(beta[0] - beta[2]);
-  Real r = (fabs(beta[2] - beta[1]) + Fuzz<Real>()) / (fabs(beta[0] - beta[1]) + Fuzz<Real>());
+  Real tau_5 = std::abs(beta[0] - beta[2]);
+  Real r = (std::abs(beta[2] - beta[1]) + Fuzz<Real>()) / (std::abs(beta[0] - beta[1]) + Fuzz<Real>());
   Real t0 = 1.0 + r;
   Real t2 = 1.0 + 1.0 / r;
-  Real eta = tau_5 * SQR(SQR(tau_5 / (fmax(beta[0], beta[2]) + Fuzz<Real>()) ));
+  Real eta = tau_5 * SQR(SQR(tau_5 / (std::max(beta[0], beta[2]) + Fuzz<Real>()) ));
 
 
   const std::array<Real,3> indicator{

--- a/src/utils/fluxes/reconstruction/wenomz.hpp
+++ b/src/utils/fluxes/reconstruction/wenomz.hpp
@@ -89,7 +89,7 @@ void WENOMZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &
 }
 //----------------------------------------------------------------------------------------
 //! \class ArtemisUtils::Reconstruction<RSolver::wenomz, X1DIR, ...>
-//! \brief The piecewise parabolic reconstruction method in the X1 direction
+//! \brief The WENO-MZ method in the X1 direction
 template <Coordinates GEOM>
 struct Reconstruction<ReconstructionMethod::wenomz, X1DIR, GEOM> {
   template <typename V1, typename V2>

--- a/src/utils/fluxes/reconstruction/wenomz.hpp
+++ b/src/utils/fluxes/reconstruction/wenomz.hpp
@@ -1,0 +1,183 @@
+//========================================================================================
+// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#ifndef UTILS_FLUXES_RECONSTRUCTION_WENOMZ_HPP_
+#define UTILS_FLUXES_RECONSTRUCTION_WENOMZ_HPP_
+
+// Artemis includes
+#include "artemis.hpp"
+
+namespace ArtemisUtils {
+//----------------------------------------------------------------------------------------
+//! WENO-MZ reconstruction
+//!
+//! REFERENCES:
+//! Wang Y., Zhao K., Yuan L., "A modified fifth-order WENO-Z scheme based on the
+//! weights of the reformulated adaptive order WENO scheme"
+//! Int J Numer Meth Fluids. 2024;96:1631–1652
+//!
+//! \fn ArtemisUtils::WENOMZ5()
+//! interpolated values at L/R edges of cell i, that is ql(i+1) and qr(i). Works for
+//! reconstruction in any dimension by passing in the appropriate q_im2,...,q _ip2.
+KOKKOS_INLINE_FUNCTION
+void WENOMZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &q_ip1,
+            const Real &q_ip2, Real &ql_ip1, Real &qr_i) {
+
+  // Smooth WENO weights: See Jiang & Shu 1996
+
+  constexpr Real weno_beta_coeff_0 = 13. / 12.;
+  constexpr Real weno_beta_coeff_1  = 0.25;
+  constexpr Real weno_beta_coeff_4  = 1. / 12.;
+
+  const std::array<Real,4> beta{
+            weno_beta_coeff_0 * SQR(q_im2 - 2 * q_im1 + q_i) +
+            weno_beta_coeff_1 * SQR(q_im2 - 4 * q_im1 + 3 * q_i),
+            weno_beta_coeff_0 * SQR(q_im1 - 2 * q_i + q_ip1) +
+            weno_beta_coeff_1 * SQR(q_im1 + q_ip1),
+            weno_beta_coeff_0 * SQR(q_i - 2 * q_ip1 + q_ip2) +
+            weno_beta_coeff_1 * SQR(3 * q_i - 4 * q_ip1 + q_ip2), 
+            weno_beta_coeff_4 * SQR(q_im1 - 2 * q_i + q_ip1)};
+
+  Real tau_5 = fabs(beta[0] - beta[2]);
+  Real r = (fabs(beta[2] - beta[1]) + Fuzz<Real>()) / (fabs(beta[0] - beta[1]) + Fuzz<Real>());
+  Real t0 = 1.0 + r;
+  Real t2 = 1.0 + 1.0 / r;
+  Real eta = tau_5 * SQR(SQR(tau_5 / (fmax(beta[0], beta[2]) + Fuzz<Real>()) ));
+
+
+  const std::array<Real,3> indicator{
+                         eta/(beta[0] + Fuzz<Real>()) + (tau_5 - eta)/(t0 * beta[3] + Fuzz<Real>()),
+                         eta/(beta[1] + Fuzz<Real>()) + (tau_5 - eta)/(2. * beta[3] + Fuzz<Real>()),
+                         eta/(beta[2] + Fuzz<Real>()) + (tau_5 - eta)/(t2 * beta[3] + Fuzz<Real>())};
+
+  // compute qL_ip1
+  std::array<Real,3> f{2.0 * q_im2 - 7.0 * q_im1 + 11.0 * q_i,
+                                  -1.0 * q_im1 + 5.0 * q_i + 2.0 * q_ip1,
+                                   2.0 * q_i + 5.0 * q_ip1 - q_ip2};
+
+  std::array<Real,3> alpha{
+   0.1 * (1.0 + indicator[0]),
+   0.6 * (1.0 + indicator[1]),
+   0.3 * (1.0 + indicator[2])};
+  Real alpha_sum = 6.0 * (alpha[0] + alpha[1] + alpha[2]);
+
+  ql_ip1 = (f[0] * alpha[0] + f[1] * alpha[1] + f[2] * alpha[2]) / alpha_sum;
+
+  // compute qR_i
+  // Factor of 1/6 in coefficients of f[] array applied to alpha_sum to reduce divisions
+  f[0] = 2.0 * q_ip2 - 7.0 * q_ip1 + 11.0 * q_i;
+  f[1] = -1.0 * q_ip1 + 5.0 * q_i   + 2.0 * q_im1;
+  f[2] = 2.0 * q_i   + 5.0 * q_im1 -      q_im2;
+
+  alpha[0] = 0.1 + 0.1*indicator[2];
+  alpha[2] = 0.3 + 0.3*indicator[0];
+
+  alpha_sum = 6.0 * (alpha[0] + alpha[1] + alpha[2]);
+
+  qr_i = (f[0] * alpha[0] + f[1] * alpha[1] + f[2] * alpha[2]) / alpha_sum;
+
+  return;
+}
+//----------------------------------------------------------------------------------------
+//! \class ArtemisUtils::Reconstruction<RSolver::wenomz, X1DIR, ...>
+//! \brief The piecewise parabolic reconstruction method in the X1 direction
+template <Coordinates GEOM>
+struct Reconstruction<ReconstructionMethod::wenomz, X1DIR, GEOM> {
+  template <typename V1, typename V2>
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V1 &q, const V2 &vg, parthenon::ScratchPad2D<Real> &ql,
+             parthenon::ScratchPad2D<Real> &qr) const {
+    for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
+      parthenon::par_for_inner(
+          DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
+            WENOMZ5(q(b, n, k, j, i - 2), q(b, n, k, j, i - 1), q(b, n, k, j, i),
+                 q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), ql(n, i + 1), qr(n, i));
+          });
+    }
+  }
+};
+
+//----------------------------------------------------------------------------------------
+//! \class ArtemisUtils::Reconstruction<RSolver::wenomz, X2DIR, ...>
+//! \brief The piecewise parabolic reconstruction method in the X2 direction
+template <Coordinates GEOM>
+struct Reconstruction<ReconstructionMethod::wenomz, X2DIR, GEOM> {
+  template <typename V1, typename V2>
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V1 &q, const V2 &vg, parthenon::ScratchPad2D<Real> &ql_jp1,
+             parthenon::ScratchPad2D<Real> &qr_j) const {
+    for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
+      parthenon::par_for_inner(
+          DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
+            WENOMZ5(q(b, n, k, j - 2, i), q(b, n, k, j - 1, i), q(b, n, k, j, i),
+                 q(b, n, k, j + 1, i), q(b, n, k, j + 2, i), ql_jp1(n, i), qr_j(n, i));
+          });
+    }
+  }
+};
+
+//----------------------------------------------------------------------------------------
+//! \class ArtemisUtils::Reconstruction<RSolver::wenomz, X3DIR, ...>
+//! \brief The piecewise parabolic reconstruction method in the X3 direction
+template <Coordinates GEOM>
+struct Reconstruction<ReconstructionMethod::wenomz, X3DIR, GEOM> {
+  template <typename V1, typename V2>
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V1 &q, const V2 &vg, parthenon::ScratchPad2D<Real> &ql_kp1,
+             parthenon::ScratchPad2D<Real> &qr_k) const {
+    for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
+      parthenon::par_for_inner(
+          DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
+            WENOMZ5(q(b, n, k - 2, j, i), q(b, n, k - 1, j, i), q(b, n, k, j, i),
+                 q(b, n, k + 1, j, i), q(b, n, k + 2, j, i), ql_kp1(n, i), qr_k(n, i));
+          });
+    }
+  }
+};
+
+template <Coordinates GEOM>
+struct ReconGradient<GEOM, ReconstructionMethod::wenomz> {
+  template <typename V>
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3>
+  operator()(const geometry::CoordParams &cpars, const V &q,
+             const std::array<Real, 3> &dx, const int multi_d, const int three_d,
+             const int b, const int n, const int k, const int j, const int i) const {
+    std::array<Real, 3> dqdx{0.0, 0.0, 0.0};
+    Real wl = Null<Real>(), wr = Null<Real>();
+
+    WENOMZ5(q(b, n, k, j, i - 2), q(b, n, k, j, i - 1), q(b, n, k, j, i),
+         q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), wl, wr);
+    dqdx[0] = (wr - wl) / (2.0 * dx[0]);
+
+    wl = Null<Real>(), wr = Null<Real>();
+    WENOMZ5(q(b, n, k, j - 2 * multi_d, i), q(b, n, k, j - multi_d, i), q(b, n, k, j, i),
+         q(b, n, k, j + multi_d, i), q(b, n, k, j + 2 * multi_d, i), wl, wr);
+    dqdx[1] = (wr - wl) / (2.0 * dx[1]);
+
+    wl = Null<Real>(), wr = Null<Real>();
+    WENOMZ5(q(b, n, k - three_d, j, i), q(b, n, k - 2 * three_d, j, i), q(b, n, k, j, i),
+         q(b, n, k + three_d, j, i), q(b, n, k + 2 * three_d, j, i), wl, wr);
+    dqdx[2] = (wr - wl) / (2.0 * dx[2]);
+
+    return dqdx;
+  }
+};
+
+} // namespace ArtemisUtils
+
+#endif // UTILS_FLUXES_RECONSTRUCTION_WENOMZ_HPP_

--- a/src/utils/fluxes/reconstruction/wenomz.hpp
+++ b/src/utils/fluxes/reconstruction/wenomz.hpp
@@ -30,44 +30,41 @@ namespace ArtemisUtils {
 //! reconstruction in any dimension by passing in the appropriate q_im2,...,q _ip2.
 KOKKOS_INLINE_FUNCTION
 void WENOMZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &q_ip1,
-            const Real &q_ip2, Real &ql_ip1, Real &qr_i) {
+             const Real &q_ip2, Real &ql_ip1, Real &qr_i) {
 
   // Smooth WENO weights: See Jiang & Shu 1996
 
   constexpr Real weno_beta_coeff_0 = 13. / 12.;
-  constexpr Real weno_beta_coeff_1  = 0.25;
-  constexpr Real weno_beta_coeff_4  = 1. / 12.;
+  constexpr Real weno_beta_coeff_1 = 0.25;
+  constexpr Real weno_beta_coeff_4 = 1. / 12.;
 
-  const std::array<Real,4> beta{
-            weno_beta_coeff_0 * SQR(q_im2 - 2 * q_im1 + q_i) +
-            weno_beta_coeff_1 * SQR(q_im2 - 4 * q_im1 + 3 * q_i),
-            weno_beta_coeff_0 * SQR(q_im1 - 2 * q_i + q_ip1) +
-            weno_beta_coeff_1 * SQR(q_im1 + q_ip1),
-            weno_beta_coeff_0 * SQR(q_i - 2 * q_ip1 + q_ip2) +
-            weno_beta_coeff_1 * SQR(3 * q_i - 4 * q_ip1 + q_ip2), 
-            weno_beta_coeff_4 * SQR(q_im1 - 2 * q_i + q_ip1)};
+  const std::array<Real, 4> beta{weno_beta_coeff_0 * SQR(q_im2 - 2 * q_im1 + q_i) +
+                                     weno_beta_coeff_1 * SQR(q_im2 - 4 * q_im1 + 3 * q_i),
+                                 weno_beta_coeff_0 * SQR(q_im1 - 2 * q_i + q_ip1) +
+                                     weno_beta_coeff_1 * SQR(q_im1 + q_ip1),
+                                 weno_beta_coeff_0 * SQR(q_i - 2 * q_ip1 + q_ip2) +
+                                     weno_beta_coeff_1 * SQR(3 * q_i - 4 * q_ip1 + q_ip2),
+                                 weno_beta_coeff_4 * SQR(q_im1 - 2 * q_i + q_ip1)};
 
   Real tau_5 = std::abs(beta[0] - beta[2]);
-  Real r = (std::abs(beta[2] - beta[1]) + Fuzz<Real>()) / (std::abs(beta[0] - beta[1]) + Fuzz<Real>());
+  Real r = (std::abs(beta[2] - beta[1]) + Fuzz<Real>()) /
+           (std::abs(beta[0] - beta[1]) + Fuzz<Real>());
   Real t0 = 1.0 + r;
   Real t2 = 1.0 + 1.0 / r;
-  Real eta = tau_5 * SQR(SQR(tau_5 / (std::max(beta[0], beta[2]) + Fuzz<Real>()) ));
+  Real eta = tau_5 * SQR(SQR(tau_5 / (std::max(beta[0], beta[2]) + Fuzz<Real>())));
 
-
-  const std::array<Real,3> indicator{
-                         eta/(beta[0] + Fuzz<Real>()) + (tau_5 - eta)/(t0 * beta[3] + Fuzz<Real>()),
-                         eta/(beta[1] + Fuzz<Real>()) + (tau_5 - eta)/(2. * beta[3] + Fuzz<Real>()),
-                         eta/(beta[2] + Fuzz<Real>()) + (tau_5 - eta)/(t2 * beta[3] + Fuzz<Real>())};
+  const std::array<Real, 3> indicator{
+      eta / (beta[0] + Fuzz<Real>()) + (tau_5 - eta) / (t0 * beta[3] + Fuzz<Real>()),
+      eta / (beta[1] + Fuzz<Real>()) + (tau_5 - eta) / (2. * beta[3] + Fuzz<Real>()),
+      eta / (beta[2] + Fuzz<Real>()) + (tau_5 - eta) / (t2 * beta[3] + Fuzz<Real>())};
 
   // compute qL_ip1
-  std::array<Real,3> f{2.0 * q_im2 - 7.0 * q_im1 + 11.0 * q_i,
-                                  -1.0 * q_im1 + 5.0 * q_i + 2.0 * q_ip1,
-                                   2.0 * q_i + 5.0 * q_ip1 - q_ip2};
+  std::array<Real, 3> f{2.0 * q_im2 - 7.0 * q_im1 + 11.0 * q_i,
+                        -1.0 * q_im1 + 5.0 * q_i + 2.0 * q_ip1,
+                        2.0 * q_i + 5.0 * q_ip1 - q_ip2};
 
-  std::array<Real,3> alpha{
-   0.1 * (1.0 + indicator[0]),
-   0.6 * (1.0 + indicator[1]),
-   0.3 * (1.0 + indicator[2])};
+  std::array<Real, 3> alpha{0.1 * (1.0 + indicator[0]), 0.6 * (1.0 + indicator[1]),
+                            0.3 * (1.0 + indicator[2])};
   Real alpha_sum = 6.0 * (alpha[0] + alpha[1] + alpha[2]);
 
   ql_ip1 = (f[0] * alpha[0] + f[1] * alpha[1] + f[2] * alpha[2]) / alpha_sum;
@@ -75,11 +72,11 @@ void WENOMZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &
   // compute qR_i
   // Factor of 1/6 in coefficients of f[] array applied to alpha_sum to reduce divisions
   f[0] = 2.0 * q_ip2 - 7.0 * q_ip1 + 11.0 * q_i;
-  f[1] = -1.0 * q_ip1 + 5.0 * q_i   + 2.0 * q_im1;
-  f[2] = 2.0 * q_i   + 5.0 * q_im1 -      q_im2;
+  f[1] = -1.0 * q_ip1 + 5.0 * q_i + 2.0 * q_im1;
+  f[2] = 2.0 * q_i + 5.0 * q_im1 - q_im2;
 
-  alpha[0] = 0.1 + 0.1*indicator[2];
-  alpha[2] = 0.3 + 0.3*indicator[0];
+  alpha[0] = 0.1 + 0.1 * indicator[2];
+  alpha[2] = 0.3 + 0.3 * indicator[0];
 
   alpha_sum = 6.0 * (alpha[0] + alpha[1] + alpha[2]);
 
@@ -102,7 +99,7 @@ struct Reconstruction<ReconstructionMethod::wenomz, X1DIR, GEOM> {
       parthenon::par_for_inner(
           DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
             WENOMZ5(q(b, n, k, j, i - 2), q(b, n, k, j, i - 1), q(b, n, k, j, i),
-                 q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), ql(n, i + 1), qr(n, i));
+                    q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), ql(n, i + 1), qr(n, i));
           });
     }
   }
@@ -123,7 +120,7 @@ struct Reconstruction<ReconstructionMethod::wenomz, X2DIR, GEOM> {
       parthenon::par_for_inner(
           DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
             WENOMZ5(q(b, n, k, j - 2, i), q(b, n, k, j - 1, i), q(b, n, k, j, i),
-                 q(b, n, k, j + 1, i), q(b, n, k, j + 2, i), ql_jp1(n, i), qr_j(n, i));
+                    q(b, n, k, j + 1, i), q(b, n, k, j + 2, i), ql_jp1(n, i), qr_j(n, i));
           });
     }
   }
@@ -144,7 +141,7 @@ struct Reconstruction<ReconstructionMethod::wenomz, X3DIR, GEOM> {
       parthenon::par_for_inner(
           DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
             WENOMZ5(q(b, n, k - 2, j, i), q(b, n, k - 1, j, i), q(b, n, k, j, i),
-                 q(b, n, k + 1, j, i), q(b, n, k + 2, j, i), ql_kp1(n, i), qr_k(n, i));
+                    q(b, n, k + 1, j, i), q(b, n, k + 2, j, i), ql_kp1(n, i), qr_k(n, i));
           });
     }
   }
@@ -161,17 +158,17 @@ struct ReconGradient<GEOM, ReconstructionMethod::wenomz> {
     Real wl = Null<Real>(), wr = Null<Real>();
 
     WENOMZ5(q(b, n, k, j, i - 2), q(b, n, k, j, i - 1), q(b, n, k, j, i),
-         q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), wl, wr);
+            q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), wl, wr);
     dqdx[0] = (wr - wl) / (2.0 * dx[0]);
 
     wl = Null<Real>(), wr = Null<Real>();
     WENOMZ5(q(b, n, k, j - 2 * multi_d, i), q(b, n, k, j - multi_d, i), q(b, n, k, j, i),
-         q(b, n, k, j + multi_d, i), q(b, n, k, j + 2 * multi_d, i), wl, wr);
+            q(b, n, k, j + multi_d, i), q(b, n, k, j + 2 * multi_d, i), wl, wr);
     dqdx[1] = (wr - wl) / (2.0 * dx[1]);
 
     wl = Null<Real>(), wr = Null<Real>();
     WENOMZ5(q(b, n, k - three_d, j, i), q(b, n, k - 2 * three_d, j, i), q(b, n, k, j, i),
-         q(b, n, k + three_d, j, i), q(b, n, k + 2 * three_d, j, i), wl, wr);
+            q(b, n, k + three_d, j, i), q(b, n, k + 2 * three_d, j, i), wl, wr);
     dqdx[2] = (wr - wl) / (2.0 * dx[2]);
 
     return dqdx;

--- a/src/utils/fluxes/reconstruction/wenoz.hpp
+++ b/src/utils/fluxes/reconstruction/wenoz.hpp
@@ -46,7 +46,7 @@ void WENOZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &q
             weno_beta_coeff_0 * SQR(q_i - 2 * q_ip1 + q_ip2) +
             weno_beta_coeff_1 * SQR(3 * q_i - 4 * q_ip1 + q_ip2)};
 
-  Real tau5 = fabs(beta[0] - beta[2]);
+  Real tau5 = std::abs(beta[0] - beta[2]);
 
   const std::array<Real,3> indicator{
                          SQR(tau5 / (beta[0] + Fuzz<Real>())),

--- a/src/utils/fluxes/reconstruction/wenoz.hpp
+++ b/src/utils/fluxes/reconstruction/wenoz.hpp
@@ -1,0 +1,177 @@
+//========================================================================================
+// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#ifndef UTILS_FLUXES_RECONSTRUCTION_WENOZ_HPP_
+#define UTILS_FLUXES_RECONSTRUCTION_WENOZ_HPP_
+
+// Artemis includes
+#include "artemis.hpp"
+
+namespace ArtemisUtils {
+//----------------------------------------------------------------------------------------
+//! WENO-Z reconstruction
+//!
+//! REFERENCES:
+//! Borges R., Carmona M., Costa B., Don W.S. , "An improved weighted essentially
+//! non-oscillatory scheme for hyperbolic conservation laws" , JCP, 227, 3191 (2008)
+//!
+//! Castro M., Costa B., Don W.W. , "High order weighted essentially non-oscillatory
+//! WENO-Z schemes for hyperbolic conservation laws" , JCP, 230, 1766 (2011)
+//!
+//! \fn ArtemisUtils::WENOZ5()
+//! interpolated values at L/R edges of cell i, that is ql(i+1) and qr(i). Works for
+//! reconstruction in any dimension by passing in the appropriate q_im2,...,q _ip2.
+KOKKOS_INLINE_FUNCTION
+void WENOZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &q_ip1,
+            const Real &q_ip2, Real &ql_ip1, Real &qr_i) {
+
+  // Smooth WENO weights: See Jiang & Shu 1996
+
+  constexpr Real weno_beta_coeff_0 = 13. / 12.;
+  constexpr Real weno_beta_coeff_1  = 0.25;
+  const std::array<Real,3> beta{
+            weno_beta_coeff_0 * SQR(q_im2 - 2 * q_im1 + q_i) +
+            weno_beta_coeff_1 * SQR(q_im2 - 4 * q_im1 + 3 * q_i),
+            weno_beta_coeff_0 * SQR(q_im1 - 2 * q_i + q_ip1) +
+            weno_beta_coeff_1 * SQR(q_im1 + q_ip1),
+            weno_beta_coeff_0 * SQR(q_i - 2 * q_ip1 + q_ip2) +
+            weno_beta_coeff_1 * SQR(3 * q_i - 4 * q_ip1 + q_ip2)};
+
+  Real tau5 = fabs(beta[0] - beta[2]);
+
+  const std::array<Real,3> indicator{
+                         SQR(tau5 / (beta[0] + Fuzz<Real>())),
+                         SQR(tau5 / (beta[1] + Fuzz<Real>())),
+                         SQR(tau5 / (beta[2] + Fuzz<Real>()))};
+
+  // compute qL_ip1
+  std::array<Real,3> f{2.0 * q_im2 - 7.0 * q_im1 + 11.0 * q_i,
+                                  -1.0 * q_im1 + 5.0 * q_i + 2.0 * q_ip1,
+                                   2.0 * q_i + 5.0 * q_ip1 - q_ip2};
+
+  std::array<Real,3> alpha{
+   0.1 * (1.0 + indicator[0]),
+   0.6 * (1.0 + indicator[1]),
+   0.3 * (1.0 + indicator[2])};
+  Real alpha_sum = 6.0 * (alpha[0] + alpha[1] + alpha[2]);
+
+  ql_ip1 = (f[0] * alpha[0] + f[1] * alpha[1] + f[2] * alpha[2]) / alpha_sum;
+
+  // compute qR_i
+  // Factor of 1/6 in coefficients of f[] array applied to alpha_sum to reduce divisions
+  f[0] = 2.0 * q_ip2 - 7.0 * q_ip1 + 11.0 * q_i;
+  f[1] = -1.0 * q_ip1 + 5.0 * q_i   + 2.0 * q_im1;
+  f[2] = 2.0 * q_i   + 5.0 * q_im1 -      q_im2;
+
+  alpha[0] = 0.1 + 0.1*indicator[2];
+  alpha[2] = 0.3 + 0.3*indicator[0];
+
+  alpha_sum = 6.0 * (alpha[0] + alpha[1] + alpha[2]);
+
+  qr_i = (f[0] * alpha[0] + f[1] * alpha[1] + f[2] * alpha[2]) / alpha_sum;
+
+  return;
+}
+//----------------------------------------------------------------------------------------
+//! \class ArtemisUtils::Reconstruction<RSolver::wenoz, X1DIR, ...>
+//! \brief The piecewise parabolic reconstruction method in the X1 direction
+template <Coordinates GEOM>
+struct Reconstruction<ReconstructionMethod::wenoz, X1DIR, GEOM> {
+  template <typename V1, typename V2>
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V1 &q, const V2 &vg, parthenon::ScratchPad2D<Real> &ql,
+             parthenon::ScratchPad2D<Real> &qr) const {
+    for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
+      parthenon::par_for_inner(
+          DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
+            WENOZ5(q(b, n, k, j, i - 2), q(b, n, k, j, i - 1), q(b, n, k, j, i),
+                 q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), ql(n, i + 1), qr(n, i));
+          });
+    }
+  }
+};
+
+//----------------------------------------------------------------------------------------
+//! \class ArtemisUtils::Reconstruction<RSolver::wenoz, X2DIR, ...>
+//! \brief The piecewise parabolic reconstruction method in the X2 direction
+template <Coordinates GEOM>
+struct Reconstruction<ReconstructionMethod::wenoz, X2DIR, GEOM> {
+  template <typename V1, typename V2>
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V1 &q, const V2 &vg, parthenon::ScratchPad2D<Real> &ql_jp1,
+             parthenon::ScratchPad2D<Real> &qr_j) const {
+    for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
+      parthenon::par_for_inner(
+          DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
+            WENOZ5(q(b, n, k, j - 2, i), q(b, n, k, j - 1, i), q(b, n, k, j, i),
+                 q(b, n, k, j + 1, i), q(b, n, k, j + 2, i), ql_jp1(n, i), qr_j(n, i));
+          });
+    }
+  }
+};
+
+//----------------------------------------------------------------------------------------
+//! \class ArtemisUtils::Reconstruction<RSolver::wenoz, X3DIR, ...>
+//! \brief The piecewise parabolic reconstruction method in the X3 direction
+template <Coordinates GEOM>
+struct Reconstruction<ReconstructionMethod::wenoz, X3DIR, GEOM> {
+  template <typename V1, typename V2>
+  KOKKOS_INLINE_FUNCTION void
+  operator()(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
+             const int b, const int k, const int j, const int il, const int iu,
+             const V1 &q, const V2 &vg, parthenon::ScratchPad2D<Real> &ql_kp1,
+             parthenon::ScratchPad2D<Real> &qr_k) const {
+    for (int n = q.GetLowerBound(b); n <= q.GetUpperBound(b); ++n) {
+      parthenon::par_for_inner(
+          DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
+            WENOZ5(q(b, n, k - 2, j, i), q(b, n, k - 1, j, i), q(b, n, k, j, i),
+                 q(b, n, k + 1, j, i), q(b, n, k + 2, j, i), ql_kp1(n, i), qr_k(n, i));
+          });
+    }
+  }
+};
+
+template <Coordinates GEOM>
+struct ReconGradient<GEOM, ReconstructionMethod::wenoz> {
+  template <typename V>
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3>
+  operator()(const geometry::CoordParams &cpars, const V &q,
+             const std::array<Real, 3> &dx, const int multi_d, const int three_d,
+             const int b, const int n, const int k, const int j, const int i) const {
+    std::array<Real, 3> dqdx{0.0, 0.0, 0.0};
+    Real wl = Null<Real>(), wr = Null<Real>();
+
+    WENOZ5(q(b, n, k, j, i - 2), q(b, n, k, j, i - 1), q(b, n, k, j, i),
+         q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), wl, wr);
+    dqdx[0] = (wr - wl) / (2.0 * dx[0]);
+
+    wl = Null<Real>(), wr = Null<Real>();
+    WENOZ5(q(b, n, k, j - 2 * multi_d, i), q(b, n, k, j - multi_d, i), q(b, n, k, j, i),
+         q(b, n, k, j + multi_d, i), q(b, n, k, j + 2 * multi_d, i), wl, wr);
+    dqdx[1] = (wr - wl) / (2.0 * dx[1]);
+
+    wl = Null<Real>(), wr = Null<Real>();
+    WENOZ5(q(b, n, k - three_d, j, i), q(b, n, k - 2 * three_d, j, i), q(b, n, k, j, i),
+         q(b, n, k + three_d, j, i), q(b, n, k + 2 * three_d, j, i), wl, wr);
+    dqdx[2] = (wr - wl) / (2.0 * dx[2]);
+
+    return dqdx;
+  }
+};
+
+} // namespace ArtemisUtils
+
+#endif // UTILS_FLUXES_RECONSTRUCTION_WENOZ_HPP_

--- a/src/utils/fluxes/reconstruction/wenoz.hpp
+++ b/src/utils/fluxes/reconstruction/wenoz.hpp
@@ -37,31 +37,28 @@ void WENOZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &q
   // Smooth WENO weights: See Jiang & Shu 1996
 
   constexpr Real weno_beta_coeff_0 = 13. / 12.;
-  constexpr Real weno_beta_coeff_1  = 0.25;
-  const std::array<Real,3> beta{
-            weno_beta_coeff_0 * SQR(q_im2 - 2 * q_im1 + q_i) +
-            weno_beta_coeff_1 * SQR(q_im2 - 4 * q_im1 + 3 * q_i),
-            weno_beta_coeff_0 * SQR(q_im1 - 2 * q_i + q_ip1) +
-            weno_beta_coeff_1 * SQR(q_im1 + q_ip1),
-            weno_beta_coeff_0 * SQR(q_i - 2 * q_ip1 + q_ip2) +
-            weno_beta_coeff_1 * SQR(3 * q_i - 4 * q_ip1 + q_ip2)};
+  constexpr Real weno_beta_coeff_1 = 0.25;
+  const std::array<Real, 3> beta{weno_beta_coeff_0 * SQR(q_im2 - 2 * q_im1 + q_i) +
+                                     weno_beta_coeff_1 * SQR(q_im2 - 4 * q_im1 + 3 * q_i),
+                                 weno_beta_coeff_0 * SQR(q_im1 - 2 * q_i + q_ip1) +
+                                     weno_beta_coeff_1 * SQR(q_im1 + q_ip1),
+                                 weno_beta_coeff_0 * SQR(q_i - 2 * q_ip1 + q_ip2) +
+                                     weno_beta_coeff_1 *
+                                         SQR(3 * q_i - 4 * q_ip1 + q_ip2)};
 
   Real tau5 = std::abs(beta[0] - beta[2]);
 
-  const std::array<Real,3> indicator{
-                         SQR(tau5 / (beta[0] + Fuzz<Real>())),
-                         SQR(tau5 / (beta[1] + Fuzz<Real>())),
-                         SQR(tau5 / (beta[2] + Fuzz<Real>()))};
+  const std::array<Real, 3> indicator{SQR(tau5 / (beta[0] + Fuzz<Real>())),
+                                      SQR(tau5 / (beta[1] + Fuzz<Real>())),
+                                      SQR(tau5 / (beta[2] + Fuzz<Real>()))};
 
   // compute qL_ip1
-  std::array<Real,3> f{2.0 * q_im2 - 7.0 * q_im1 + 11.0 * q_i,
-                                  -1.0 * q_im1 + 5.0 * q_i + 2.0 * q_ip1,
-                                   2.0 * q_i + 5.0 * q_ip1 - q_ip2};
+  std::array<Real, 3> f{2.0 * q_im2 - 7.0 * q_im1 + 11.0 * q_i,
+                        -1.0 * q_im1 + 5.0 * q_i + 2.0 * q_ip1,
+                        2.0 * q_i + 5.0 * q_ip1 - q_ip2};
 
-  std::array<Real,3> alpha{
-   0.1 * (1.0 + indicator[0]),
-   0.6 * (1.0 + indicator[1]),
-   0.3 * (1.0 + indicator[2])};
+  std::array<Real, 3> alpha{0.1 * (1.0 + indicator[0]), 0.6 * (1.0 + indicator[1]),
+                            0.3 * (1.0 + indicator[2])};
   Real alpha_sum = 6.0 * (alpha[0] + alpha[1] + alpha[2]);
 
   ql_ip1 = (f[0] * alpha[0] + f[1] * alpha[1] + f[2] * alpha[2]) / alpha_sum;
@@ -69,11 +66,11 @@ void WENOZ5(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &q
   // compute qR_i
   // Factor of 1/6 in coefficients of f[] array applied to alpha_sum to reduce divisions
   f[0] = 2.0 * q_ip2 - 7.0 * q_ip1 + 11.0 * q_i;
-  f[1] = -1.0 * q_ip1 + 5.0 * q_i   + 2.0 * q_im1;
-  f[2] = 2.0 * q_i   + 5.0 * q_im1 -      q_im2;
+  f[1] = -1.0 * q_ip1 + 5.0 * q_i + 2.0 * q_im1;
+  f[2] = 2.0 * q_i + 5.0 * q_im1 - q_im2;
 
-  alpha[0] = 0.1 + 0.1*indicator[2];
-  alpha[2] = 0.3 + 0.3*indicator[0];
+  alpha[0] = 0.1 + 0.1 * indicator[2];
+  alpha[2] = 0.3 + 0.3 * indicator[0];
 
   alpha_sum = 6.0 * (alpha[0] + alpha[1] + alpha[2]);
 
@@ -96,7 +93,7 @@ struct Reconstruction<ReconstructionMethod::wenoz, X1DIR, GEOM> {
       parthenon::par_for_inner(
           DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
             WENOZ5(q(b, n, k, j, i - 2), q(b, n, k, j, i - 1), q(b, n, k, j, i),
-                 q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), ql(n, i + 1), qr(n, i));
+                   q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), ql(n, i + 1), qr(n, i));
           });
     }
   }
@@ -117,7 +114,7 @@ struct Reconstruction<ReconstructionMethod::wenoz, X2DIR, GEOM> {
       parthenon::par_for_inner(
           DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
             WENOZ5(q(b, n, k, j - 2, i), q(b, n, k, j - 1, i), q(b, n, k, j, i),
-                 q(b, n, k, j + 1, i), q(b, n, k, j + 2, i), ql_jp1(n, i), qr_j(n, i));
+                   q(b, n, k, j + 1, i), q(b, n, k, j + 2, i), ql_jp1(n, i), qr_j(n, i));
           });
     }
   }
@@ -138,7 +135,7 @@ struct Reconstruction<ReconstructionMethod::wenoz, X3DIR, GEOM> {
       parthenon::par_for_inner(
           DEFAULT_INNER_LOOP_PATTERN, member, il, iu, [&](const int i) {
             WENOZ5(q(b, n, k - 2, j, i), q(b, n, k - 1, j, i), q(b, n, k, j, i),
-                 q(b, n, k + 1, j, i), q(b, n, k + 2, j, i), ql_kp1(n, i), qr_k(n, i));
+                   q(b, n, k + 1, j, i), q(b, n, k + 2, j, i), ql_kp1(n, i), qr_k(n, i));
           });
     }
   }
@@ -155,17 +152,17 @@ struct ReconGradient<GEOM, ReconstructionMethod::wenoz> {
     Real wl = Null<Real>(), wr = Null<Real>();
 
     WENOZ5(q(b, n, k, j, i - 2), q(b, n, k, j, i - 1), q(b, n, k, j, i),
-         q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), wl, wr);
+           q(b, n, k, j, i + 1), q(b, n, k, j, i + 2), wl, wr);
     dqdx[0] = (wr - wl) / (2.0 * dx[0]);
 
     wl = Null<Real>(), wr = Null<Real>();
     WENOZ5(q(b, n, k, j - 2 * multi_d, i), q(b, n, k, j - multi_d, i), q(b, n, k, j, i),
-         q(b, n, k, j + multi_d, i), q(b, n, k, j + 2 * multi_d, i), wl, wr);
+           q(b, n, k, j + multi_d, i), q(b, n, k, j + 2 * multi_d, i), wl, wr);
     dqdx[1] = (wr - wl) / (2.0 * dx[1]);
 
     wl = Null<Real>(), wr = Null<Real>();
     WENOZ5(q(b, n, k - three_d, j, i), q(b, n, k - 2 * three_d, j, i), q(b, n, k, j, i),
-         q(b, n, k + three_d, j, i), q(b, n, k + 2 * three_d, j, i), wl, wr);
+           q(b, n, k + three_d, j, i), q(b, n, k + 2 * three_d, j, i), wl, wr);
     dqdx[2] = (wr - wl) / (2.0 * dx[2]);
 
     return dqdx;


### PR DESCRIPTION
I have attempted to add two variations of WENO-Z reconstruction. The first follows [Borges et al. 2008](https://doi.org/10.1016/j.jcp.2007.11.038) and the improvements suggested in [Castro et al. 2011](http://dx.doi.org/10.1016/j.jcp.2010.11.028) and is called WENO-Z. I have also implemented [WENO-MZ](https://onlinelibrary.wiley.com/doi/10.1002/fld.5314) as a reconstruction option, which should have better resolution of smooth features, even in the presence of shocks.  

Here are a couple examples of the accuracy for a quick linear wave test, and a demonstration that they are stable for simple shock tube. 
<img width="1253" height="905" alt="lin_err" src="https://github.com/user-attachments/assets/6feae3ae-f88e-4e35-bf2c-c8573ab125a7" />
<img width="1200" height="905" alt="sod" src="https://github.com/user-attachments/assets/9f6d7dc5-a5fe-426a-9903-77becdb5c1aa" />

