### PR TITLE
Turn on/off radiation

### DIFF
--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -238,7 +238,7 @@ TaskCollection ArtemisDriver<GEOM>::StepTasks() {
     const Real bdt = integrator->beta[stage - 1] * integrator->dt;
 
     // Compute gravitational potential
-    if (do_self_gravity) SelfGravity::SolvePoisson(tc, pmesh);
+    if (do_self_gravity) SelfGravity::SolvePoisson(tc, pmesh, time, stage);
 
     TaskRegion &tr = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
@@ -330,8 +330,8 @@ TaskCollection ArtemisDriver<GEOM>::StepTasks() {
       // NOTE(@pdmullen): RK integrated, operator split cooling (RHS computed from U)
       TaskID cooling_src = drag_src;
       if (do_cooling) {
-        cooling_src =
-            tl.AddTask(drag_src, Gas::Cooling::CoolingSource<GEOM>, u0.get(), time, bdt);
+        cooling_src = tl.AddTask(drag_src, Gas::Cooling::CoolingSource<GEOM>, u0.get(),
+                                 time, bdt, stage);
       }
 
       // Set auxillary fields

--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -128,7 +128,7 @@ TaskListStatus ArtemisDriver<GEOM>::Step() {
   TaskListStatus status = TaskListStatus::complete;
   // Execute explicit, unsplit physics
   if (do_raytrace) {
-    status = RT::RaytraceDriver(pmesh);
+    status = RT::RaytraceDriver(pmesh, tm.time);
     if (status != TaskListStatus::complete) return status;
   }
 
@@ -147,7 +147,7 @@ TaskListStatus ArtemisDriver<GEOM>::Step() {
     if (status != TaskListStatus::complete) return status;
   }
 
-  // Operator split, moments subcyling (M1 or P1)
+  // Operator split, moments subcycling (M1 or P1)
   if (do_moment) {
     status = Moments::MomentsDriver<GEOM>(pmesh, tm, rad_integrator.get());
     if (status != TaskListStatus::complete) return status;

--- a/src/gas/cooling/cooling.cpp
+++ b/src/gas/cooling/cooling.cpp
@@ -15,6 +15,7 @@
 #include "gas/cooling/cooling.hpp"
 #include "artemis.hpp"
 #include "geometry/geometry.hpp"
+#include "utils/artemis_utils.hpp"
 
 using namespace parthenon::package::prelude;
 
@@ -82,6 +83,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("ttype", ttype);
   params.Add("tpars", tpars);
 
+  // Enroll in tstart/tstop machinery
+  ArtemisUtils::AddPackageTimeParams(params, "cooling", pin);
+
   return cooling;
 }
 
@@ -89,10 +93,26 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 //! \fn  TaskStatus Cooling::CoolingSource
 //! \brief Wrapper function for external cooling options
 template <Coordinates GEOM>
-TaskStatus CoolingSource(MeshData<Real> *md, const Real time, const Real dt) {
+TaskStatus CoolingSource(MeshData<Real> *md, const Real time, const Real dt,
+                         const int stage) {
   PARTHENON_INSTRUMENT
   auto pm = md->GetParentPointer();
   auto &pkg = pm->packages.Get("cooling");
+
+  const auto active = ArtemisUtils::CheckPackageStatus(pkg, time);
+  if (active == ArtemisUtils::PackageControl::inactive) {
+    return TaskStatus::complete;
+  } else if (active == ArtemisUtils::PackageControl::shutdown) {
+    if ((Globals::my_rank == 0) && (stage == 1)) {
+      printf("Turning off cooling at t=%.8e...\n", time);
+    }
+    return TaskStatus::complete;
+  } else if (active == ArtemisUtils::PackageControl::initial) {
+    if ((Globals::my_rank == 0) && (stage == 1)) {
+      printf("Turning on cooling at t=%.8e...\n", time);
+    }
+  }
+
   CoolingType ctype = pkg->template Param<CoolingType>("type");
   TempRefType ttype = pkg->template Param<TempRefType>("ttype");
   if (ctype == CoolingType::beta) {
@@ -109,12 +129,18 @@ TaskStatus CoolingSource(MeshData<Real> *md, const Real time, const Real dt) {
 //! template instantiations
 typedef Coordinates G;
 typedef MeshData<Real> MD;
-template TaskStatus CoolingSource<G::cartesian>(MD *md, const Real t, const Real d);
-template TaskStatus CoolingSource<G::cylindrical>(MD *md, const Real t, const Real d);
-template TaskStatus CoolingSource<G::spherical3D>(MD *md, const Real t, const Real d);
-template TaskStatus CoolingSource<G::spherical1D>(MD *md, const Real t, const Real d);
-template TaskStatus CoolingSource<G::spherical2D>(MD *md, const Real t, const Real d);
-template TaskStatus CoolingSource<G::axisymmetric>(MD *md, const Real t, const Real d);
+template TaskStatus CoolingSource<G::cartesian>(MD *md, const Real t, const Real d,
+                                                const int s);
+template TaskStatus CoolingSource<G::cylindrical>(MD *md, const Real t, const Real d,
+                                                  const int s);
+template TaskStatus CoolingSource<G::spherical3D>(MD *md, const Real t, const Real d,
+                                                  const int s);
+template TaskStatus CoolingSource<G::spherical1D>(MD *md, const Real t, const Real d,
+                                                  const int s);
+template TaskStatus CoolingSource<G::spherical2D>(MD *md, const Real t, const Real d,
+                                                  const int s);
+template TaskStatus CoolingSource<G::axisymmetric>(MD *md, const Real t, const Real d,
+                                                   const int s);
 
 } // namespace Cooling
 } // namespace Gas

--- a/src/gas/cooling/cooling.hpp
+++ b/src/gas/cooling/cooling.hpp
@@ -62,7 +62,8 @@ template <Coordinates GEOM, TempRefType T>
 TaskStatus BetaCooling(MeshData<Real> *md, const Real time, const Real dt);
 
 template <Coordinates GEOM>
-TaskStatus CoolingSource(MeshData<Real> *md, const Real time, const Real dt);
+TaskStatus CoolingSource(MeshData<Real> *md, const Real time, const Real dt,
+                         const int stage);
 
 } // namespace Cooling
 } // namespace Gas

--- a/src/gas/params.yaml
+++ b/src/gas/params.yaml
@@ -367,6 +367,11 @@ cooling:
     _type: Real
     _default: "0.0"
     _description: "Power law index for spherical power law"
-
-
-
+  tstart:
+    _type: Real
+    _description: "Turn on cooling at this time"
+    _default: "0.0"
+  tstop:
+    _type: Real
+    _description: "Turn off cooling at this time"
+    _default: "1e99"

--- a/src/radiation/imc/imc_driver.cpp
+++ b/src/radiation/imc/imc_driver.cpp
@@ -37,16 +37,16 @@ TaskListStatus JaybenneIMC(Mesh *pmesh, const SimTime &tm, const Real dt) {
     return TaskListStatus::complete;
   } else if (active == ArtemisUtils::PackageControl::shutdown) {
     if (Globals::my_rank == 0) {
-      printf("Turning off iMC radiation at t=%.8e...\n", tm.time);
+      printf("Turning off IMC radiation at t=%.8e...\n", tm.time);
     }
     return TaskListStatus::complete;
   } else if (active == ArtemisUtils::PackageControl::initial) {
     if (Globals::my_rank == 0) {
       printf("Turning on IMC radiation at t=%.8e...\n", tm.time);
     }
-    // What to call here to set the field?
-    // Need a pmesh version of this
-    // jaybenne::InitializeRadiation(md.get(), true)
+    for (auto &mbd : pmesh->mesh_data.Get()->GetAllBlockData()) {
+      jaybenne::InitializeRadiation(mbd.get(), true);
+    }
   }
   auto status = Radiation::UpdateRadiationFields(pmesh).Execute();
   if (status != TaskListStatus::complete) return status;

--- a/src/radiation/imc/imc_driver.cpp
+++ b/src/radiation/imc/imc_driver.cpp
@@ -16,6 +16,7 @@
 #include "derived/fill_derived.hpp"
 #include "radiation/imc/imc.hpp"
 #include "radiation/radiation.hpp"
+#include "utils/artemis_utils.hpp"
 
 // Jaybenne includes
 #include "jaybenne.hpp"
@@ -30,6 +31,23 @@ namespace IMC {
 template <Coordinates GEOM>
 TaskListStatus JaybenneIMC(Mesh *pmesh, const SimTime &tm, const Real dt) {
   PARTHENON_INSTRUMENT
+  auto &pkg = pmesh->packages.Get("radiation");
+  const auto active = ArtemisUtils::CheckPackageStatus(pkg, tm.time);
+  if (active == ArtemisUtils::PackageControl::inactive) {
+    return TaskListStatus::complete;
+  } else if (active == ArtemisUtils::PackageControl::shutdown) {
+    if (Globals::my_rank == 0) {
+      printf("Turning off iMC radiation at t=%.8e...\n", tm.time);
+    }
+    return TaskListStatus::complete;
+  } else if (active == ArtemisUtils::PackageControl::initial) {
+    if (Globals::my_rank == 0) {
+      printf("Turning on IMC radiation at t=%.8e...\n", tm.time);
+    }
+    // What to call here to set the field?
+    // Need a pmesh version of this
+    // jaybenne::InitializeRadiation(md.get(), true)
+  }
   auto status = Radiation::UpdateRadiationFields(pmesh).Execute();
   if (status != TaskListStatus::complete) return status;
   status = jaybenne::RadiationStep(pmesh, tm, dt).Execute();

--- a/src/radiation/moments/moments.cpp
+++ b/src/radiation/moments/moments.cpp
@@ -87,10 +87,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
              pin->GetOrAddBoolean("radiation/moment", "fatal_if_unconverged", true));
 
   // how to handle the matter coupling:
-  // full_coupling = false only does a loop over energy couopling
+  // full_coupling = false only does a loop over energy coupling
   // full_coupling = true also does an outer loop over momentum coupling
   params.Add("full_coupling",
              pin->GetOrAddBoolean("radiation/moment", "full_coupling", true));
+
+  ArtemisUtils::AddPackageTimeParams(params, "radiation/moment", pin);
 
   // Radiation constants (including chat for Moments)
   // NOTE(@pdmullen): These are also stored in top level radiation package...
@@ -376,6 +378,52 @@ TaskStatus MatterCoupling(MeshData<Real> *u0, const Real dt) {
     }
   }
   return TaskStatus::complete;
+}
+
+void InitMesh(parthenon::Mesh *pmesh) {
+  PARTHENON_INSTRUMENT
+  auto &moments_pkg = pmesh->packages.Get("moments");
+  auto &gas_pkg = pmesh->packages.Get("gas");
+
+  const Real arad = moments_pkg->Param<Real>("arad");
+  const auto &eos_d = gas_pkg->Param<EOS>("eos_d");
+
+  for (int partition = 0; partition < pmesh->DefaultNumPartitions(); partition++) {
+    auto md = pmesh->mesh_data.GetOrAdd("u0c", partition).get();
+
+    // Packing and Indexing
+    static auto desc =
+        MakePackDescriptor<gas::prim::density, gas::prim::sie, rad::cons::energy,
+                           rad::prim::energy, rad::cons::flux, rad::prim::flux>(
+            (pmesh->resolved_packages).get());
+    auto vmesh = desc.GetPack(md);
+
+    IndexRange ib = md->GetBoundsI(IndexDomain::interior);
+    IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
+    IndexRange kb = md->GetBoundsK(IndexDomain::interior);
+    const auto ndim = pmesh->ndim;
+    const auto &cpars =
+        pmesh->packages.Get("artemis")->template Param<geometry::CoordParams>(
+            "coord_params");
+
+    // Compute minimum dx
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "Moments::InitMesh", DevExecSpace(), 0, md->NumBlocks() - 1,
+        kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+          // Extract coordinates
+          const Real &rho = vmesh(b, gas::prim::density(0), k, j, i);
+          const Real &sie = vmesh(b, gas::prim::sie(0), k, j, i);
+          const Real T = eos_d.TemperatureFromDensityInternalEnergy(rho, sie);
+          const Real Erad = arad * SQR(SQR(T));
+          vmesh(b, rad::cons::energy(0), k, j, i) = Erad;
+          vmesh(b, rad::prim::energy(0), k, j, i) = Erad;
+          for (int d = 0; d < 3; d++) {
+            vmesh(b, rad::cons::flux(d), k, j, i) = 0.0;
+            vmesh(b, rad::prim::flux(d), k, j, i) = 0.0;
+          }
+        });
+  }
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/radiation/moments/moments.cpp
+++ b/src/radiation/moments/moments.cpp
@@ -401,9 +401,9 @@ void InitMesh(parthenon::Mesh *pmesh) {
             (pmesh->resolved_packages).get());
     auto vmesh = desc.GetPack(md);
 
-    IndexRange ib = md->GetBoundsI(IndexDomain::interior);
-    IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
-    IndexRange kb = md->GetBoundsK(IndexDomain::interior);
+    IndexRange ib = md->GetBoundsI(IndexDomain::entire);
+    IndexRange jb = md->GetBoundsJ(IndexDomain::entire);
+    IndexRange kb = md->GetBoundsK(IndexDomain::entire);
     const auto ndim = pmesh->ndim;
     const auto &cpars =
         pmesh->packages.Get("artemis")->template Param<geometry::CoordParams>(

--- a/src/radiation/moments/moments.cpp
+++ b/src/radiation/moments/moments.cpp
@@ -92,8 +92,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   params.Add("full_coupling",
              pin->GetOrAddBoolean("radiation/moment", "full_coupling", true));
 
-  ArtemisUtils::AddPackageTimeParams(params, "radiation/moment", pin);
-
   // Radiation constants (including chat for Moments)
   // NOTE(@pdmullen): These are also stored in top level radiation package...
   const Real light = constants.GetCCode();

--- a/src/radiation/moments/moments.cpp
+++ b/src/radiation/moments/moments.cpp
@@ -108,6 +108,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   const Real tfloor = pin->GetOrAddReal("radiation/moment", "tfloor_cgs", 10.); // K
   params.Add("tfloor", tfloor * units.GetTemperaturePhysicalToCode());
 
+  params.Add("use_opac",
+             pin->GetOrAddBoolean("radiation/moments", "init_with_opac", true));
+
   // Number of radiation species
   const int nspecies = pin->GetOrAddInteger("radiation/moment", "nspecies", 1);
   params.Add("nspecies", nspecies);
@@ -378,12 +381,14 @@ TaskStatus MatterCoupling(MeshData<Real> *u0, const Real dt) {
   return TaskStatus::complete;
 }
 
+template <Coordinates GEOM>
 void InitMesh(parthenon::Mesh *pmesh) {
   PARTHENON_INSTRUMENT
   auto &moments_pkg = pmesh->packages.Get("moments");
   auto &gas_pkg = pmesh->packages.Get("gas");
 
   const Real arad = moments_pkg->Param<Real>("arad");
+  const bool use_opac = moments_pkg->Param<bool>("use_opac");
   const auto &eos_d = gas_pkg->Param<EOS>("eos_d");
 
   for (int partition = 0; partition < pmesh->DefaultNumPartitions(); partition++) {
@@ -404,23 +409,49 @@ void InitMesh(parthenon::Mesh *pmesh) {
         pmesh->packages.Get("artemis")->template Param<geometry::CoordParams>(
             "coord_params");
 
-    // Compute minimum dx
-    parthenon::par_for(
-        DEFAULT_LOOP_PATTERN, "Moments::InitMesh", DevExecSpace(), 0, md->NumBlocks() - 1,
-        kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-          // Extract coordinates
-          const Real &rho = vmesh(b, gas::prim::density(0), k, j, i);
-          const Real &sie = vmesh(b, gas::prim::sie(0), k, j, i);
-          const Real T = eos_d.TemperatureFromDensityInternalEnergy(rho, sie);
-          const Real Erad = arad * SQR(SQR(T));
-          vmesh(b, rad::cons::energy(0), k, j, i) = Erad;
-          vmesh(b, rad::prim::energy(0), k, j, i) = Erad;
-          for (int d = 0; d < 3; d++) {
-            vmesh(b, rad::cons::flux(d), k, j, i) = 0.0;
-            vmesh(b, rad::prim::flux(d), k, j, i) = 0.0;
-          }
-        });
+    if (use_opac) {
+      const auto &opac_d = gas_pkg->Param<MeanOpacity>("opacity_d");
+      const bool multi_d = pmesh->ndim >= 2;
+      const bool three_d = pmesh->ndim == 3;
+      parthenon::par_for(
+          DEFAULT_LOOP_PATTERN, "Moments::InitMesh", DevExecSpace(), 0,
+          md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+          KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+            geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
+            const auto &dx = coords.GetCellWidths();
+            const Real &rho = vmesh(b, gas::prim::density(0), k, j, i);
+            const Real &sie = vmesh(b, gas::prim::sie(0), k, j, i);
+            const Real T = eos_d.TemperatureFromDensityInternalEnergy(rho, sie);
+            Real dx_min = dx[0];
+            if (multi_d) dx_min = std::min(dx_min, dx[1]);
+            if (three_d) dx_min = std::min(dx_min, dx[2]);
+            const Real tau =
+                std::min(1.0, dx_min * opac_d.RosselandMeanAbsorptionCoefficient(rho, T));
+            const Real Erad = tau * arad * SQR(SQR(T));
+            vmesh(b, rad::cons::energy(0), k, j, i) = Erad;
+            vmesh(b, rad::prim::energy(0), k, j, i) = Erad;
+            for (int d = 0; d < 3; d++) {
+              vmesh(b, rad::cons::flux(d), k, j, i) = 0.0;
+              vmesh(b, rad::prim::flux(d), k, j, i) = 0.0;
+            }
+          });
+    } else {
+      parthenon::par_for(
+          DEFAULT_LOOP_PATTERN, "Moments::InitMesh", DevExecSpace(), 0,
+          md->NumBlocks() - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+          KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+            const Real &rho = vmesh(b, gas::prim::density(0), k, j, i);
+            const Real &sie = vmesh(b, gas::prim::sie(0), k, j, i);
+            const Real T = eos_d.TemperatureFromDensityInternalEnergy(rho, sie);
+            const Real Erad = arad * SQR(SQR(T));
+            vmesh(b, rad::cons::energy(0), k, j, i) = Erad;
+            vmesh(b, rad::prim::energy(0), k, j, i) = Erad;
+            for (int d = 0; d < 3; d++) {
+              vmesh(b, rad::cons::flux(d), k, j, i) = 0.0;
+              vmesh(b, rad::prim::flux(d), k, j, i) = 0.0;
+            }
+          });
+    }
   }
 }
 
@@ -434,5 +465,12 @@ template TaskStatus MatterCoupling<G::axisymmetric>(MD *u0, const Real dt);
 template TaskStatus MatterCoupling<G::spherical1D>(MD *u0, const Real dt);
 template TaskStatus MatterCoupling<G::spherical2D>(MD *u0, const Real dt);
 template TaskStatus MatterCoupling<G::spherical3D>(MD *u0, const Real dt);
+
+template void InitMesh<G::cartesian>(parthenon::Mesh *pmesh);
+template void InitMesh<G::cylindrical>(parthenon::Mesh *pmesh);
+template void InitMesh<G::axisymmetric>(parthenon::Mesh *pmesh);
+template void InitMesh<G::spherical1D>(parthenon::Mesh *pmesh);
+template void InitMesh<G::spherical2D>(parthenon::Mesh *pmesh);
+template void InitMesh<G::spherical3D>(parthenon::Mesh *pmesh);
 
 } // namespace Moments

--- a/src/radiation/moments/moments.hpp
+++ b/src/radiation/moments/moments.hpp
@@ -40,6 +40,7 @@ template <Coordinates GEOM>
 TaskCollection MomentsTasks(Mesh *pmesh, const SimTime &tm,
                             parthenon::LowStorageIntegrator *integrator);
 
+void InitMesh(parthenon::Mesh *pmesh);
 //----------------------------------------------------------------------------------------
 //! \fn Real Moments::EstimateTimeStep
 //! \brief Not enrolled in parthenon's determination for global dt

--- a/src/radiation/moments/moments.hpp
+++ b/src/radiation/moments/moments.hpp
@@ -40,6 +40,7 @@ template <Coordinates GEOM>
 TaskCollection MomentsTasks(Mesh *pmesh, const SimTime &tm,
                             parthenon::LowStorageIntegrator *integrator);
 
+template <Coordinates GEOM>
 void InitMesh(parthenon::Mesh *pmesh);
 //----------------------------------------------------------------------------------------
 //! \fn Real Moments::EstimateTimeStep

--- a/src/radiation/moments/moments_driver.cpp
+++ b/src/radiation/moments/moments_driver.cpp
@@ -28,7 +28,7 @@ TaskListStatus MomentsDriver(Mesh *pmesh, const SimTime &tm,
                              parthenon::LowStorageIntegrator *integrator) {
   PARTHENON_INSTRUMENT
   // Craft a series of **equal** substeps that sum to the unsplit step
-  auto &pkg = pmesh->packages.Get("moments");
+  auto &pkg = pmesh->packages.Get("radiation");
   const auto active = ArtemisUtils::CheckPackageStatus(pkg, tm.time);
   if (active == ArtemisUtils::PackageControl::inactive) {
     return TaskListStatus::complete;

--- a/src/radiation/moments/moments_driver.cpp
+++ b/src/radiation/moments/moments_driver.cpp
@@ -28,6 +28,21 @@ TaskListStatus MomentsDriver(Mesh *pmesh, const SimTime &tm,
                              parthenon::LowStorageIntegrator *integrator) {
   PARTHENON_INSTRUMENT
   // Craft a series of **equal** substeps that sum to the unsplit step
+  auto &pkg = pmesh->packages.Get("moments");
+  const auto active = ArtemisUtils::CheckPackageStatus(pkg, tm.time);
+  if (active == ArtemisUtils::PackageControl::inactive) {
+    return TaskListStatus::complete;
+  } else if (active == ArtemisUtils::PackageControl::shutdown) {
+    if (Globals::my_rank == 0) {
+      printf("Turning off radiation moments at t=%.8e...\n", tm.time);
+    }
+    return TaskListStatus::complete;
+  } else if (active == ArtemisUtils::PackageControl::initial) {
+    if (Globals::my_rank == 0) {
+      printf("Turning on radiation moments at t=%.8e...\n", tm.time);
+    }
+    Moments::InitMesh(pmesh);
+  }
   const Real dtlimit = Moments::EstimateTimeStep<GEOM>(pmesh);
   const int nsteps = static_cast<int>(std::ceil(integrator->dt / dtlimit));
   integrator->dt = integrator->dt / nsteps;

--- a/src/radiation/moments/moments_driver.cpp
+++ b/src/radiation/moments/moments_driver.cpp
@@ -41,7 +41,7 @@ TaskListStatus MomentsDriver(Mesh *pmesh, const SimTime &tm,
     if (Globals::my_rank == 0) {
       printf("Turning on radiation moments at t=%.8e...\n", tm.time);
     }
-    Moments::InitMesh(pmesh);
+    Moments::InitMesh<GEOM>(pmesh);
   }
   const Real dtlimit = Moments::EstimateTimeStep<GEOM>(pmesh);
   const int nsteps = static_cast<int>(std::ceil(integrator->dt / dtlimit));

--- a/src/radiation/params.yaml
+++ b/src/radiation/params.yaml
@@ -98,6 +98,14 @@ radiation:
       _type: bool
       _description: "Crash the code if the matter-coupling step does not converge."
       _default: true
+    tstart:
+      _type: Real
+      _description: "Turn on moments at this time"
+      _default: "0.0"
+    tstop:
+      _type: Real
+      _description: "Turn off moments at this time"
+      _default: "1e99"
   imc:
     _description: "IMC radiation model from the Jaybenne library"
     _type: node
@@ -179,4 +187,12 @@ radiation:
         _type: Real
         _description: "Radiation enrgy density floor"
         _default: 1e-10
+      tstart:
+        _type: Real
+        _description: "Turn on raytrace at this time"
+        _default: "0.0"
+      tstop:
+        _type: Real
+        _description: "Turn off raytrace at this time"
+        _default: "1e99"
       

--- a/src/radiation/params.yaml
+++ b/src/radiation/params.yaml
@@ -172,11 +172,11 @@ radiation:
       _default: true
     tstart:
       _type: Real
-      _description: "Turn on moments at this time"
+      _description: "Turn on IMC at this time"
       _default: "0.0"
     tstop:
       _type: Real
-      _description: "Turn off moments at this time"
+      _description: "Turn off IMC at this time"
       _default: "1e99"
   raytrace:
       _description: "Raytraced radiation model. This is currently designed for raytracing the stellar light from the center of a spherical grid."

--- a/src/radiation/params.yaml
+++ b/src/radiation/params.yaml
@@ -106,6 +106,10 @@ radiation:
       _type: Real
       _description: "Turn off moments at this time"
       _default: "1e99"
+    init_with_opac:
+      _type: bool
+      _description: "When dynamically initializing the radiation field, scale a T^4 by min(1, tau), where tau is the optical depth of the cell"
+      _default: "true"
   imc:
     _description: "IMC radiation model from the Jaybenne library"
     _type: node
@@ -166,6 +170,14 @@ radiation:
       _type: bool
       _description: "Radiation affects host fluid fields."
       _default: true
+    tstart:
+      _type: Real
+      _description: "Turn on moments at this time"
+      _default: "0.0"
+    tstop:
+      _type: Real
+      _description: "Turn off moments at this time"
+      _default: "1e99"
   raytrace:
       _description: "Raytraced radiation model. This is currently designed for raytracing the stellar light from the center of a spherical grid."
       _type: node

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -74,6 +74,9 @@ Initialize(ParameterInput *pin, ArtemisUtils::Constants &constants, const bool d
     radiation->AddField<rad::opac::scattering>(m);
   }
 
+  // Enroll in tstart/tstop machinery
+  ArtemisUtils::AddPackageTimeParams(
+      params, (do_imc) ? "radiation/imc" : "radiation/moment", pin);
   return radiation;
 }
 

--- a/src/radiation/raytrace/raytrace.cpp
+++ b/src/radiation/raytrace/raytrace.cpp
@@ -20,6 +20,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
   auto rt = std::make_shared<StateDescriptor>("raytrace");
   Params &params = rt->AllParams();
 
+  ArtemisUtils::AddPackageTimeParams(params, "radiation/raytrace", pin);
+
   // Opacity models
   const Real time = units.GetTimeCodeToPhysical();
   const Real mass = units.GetMassCodeToPhysical();
@@ -350,13 +352,26 @@ TaskCollection RaytraceDriverTasks(Mesh *pmesh, const ParticleWeights &pwght) {
 //----------------------------------------------------------------------------------------
 //! \fn  StateDescriptor RT::RaytraceDriver
 //! \brief Pepare to call the TaskCollection for raytracing
-TaskListStatus RaytraceDriver(Mesh *pmesh) {
+TaskListStatus RaytraceDriver(Mesh *pmesh, const Real time) {
   PARTHENON_INSTRUMENT
+  auto &rt_pkg = pmesh->packages.Get("raytrace");
+  const auto active = ArtemisUtils::CheckPackageStatus(rt_pkg, time);
+  if (active == ArtemisUtils::PackageControl::inactive) {
+    return TaskListStatus::complete;
+  } else if (active == ArtemisUtils::PackageControl::shutdown) {
+    if (Globals::my_rank == 0) {
+      printf("Turning off raytrace at t=%.8e...\n", time);
+    }
+    return TaskListStatus::complete;
+  } else if (active == ArtemisUtils::PackageControl::initial) {
+    if (Globals::my_rank == 0) {
+      printf("Turning on raytrace at t=%.8e...\n", time);
+    }
+  }
+
   auto &artemis_pkg = pmesh->packages.Get("artemis");
   auto geom = artemis_pkg->Param<Coordinates>("coords");
   // What is the minimum dtheta, dphi
-  auto &rt_pkg = pmesh->packages.Get("raytrace");
-
   const auto x2min = rt_pkg->Param<Real>("x2min");
   const auto x2max = rt_pkg->Param<Real>("x2max");
   const auto nx2 = rt_pkg->Param<int>("nx2");

--- a/src/radiation/raytrace/raytrace.hpp
+++ b/src/radiation/raytrace/raytrace.hpp
@@ -24,7 +24,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
                                             ArtemisUtils::Units &units,
                                             ArtemisUtils::Constants &constants);
 
-TaskListStatus RaytraceDriver(Mesh *pmesh);
+TaskListStatus RaytraceDriver(Mesh *pmesh, const Real time);
 
 struct ParticleWeights {
   Real dx2 = 1.0;

--- a/src/self_gravity/params.yaml
+++ b/src/self_gravity/params.yaml
@@ -24,3 +24,11 @@ self_gravity:
     _type: Real
     _description: "Residual tolerance for Poisson solver"
     _default: 1.0e-12
+  tstart:
+    _type: Real
+    _description: "Turn on self-gravity at this time"
+    _default: "0.0"
+  tstop:
+    _type: Real
+    _description: "Turn off self-gravity at this time"
+    _default: "1e99"

--- a/src/self_gravity/poisson_driver.cpp
+++ b/src/self_gravity/poisson_driver.cpp
@@ -33,6 +33,7 @@
 // Artemis includes
 #include "self_gravity/poisson_equation.hpp"
 #include "self_gravity/self_gravity.hpp"
+#include "utils/artemis_utils.hpp"
 
 using namespace parthenon::driver::prelude;
 
@@ -41,11 +42,26 @@ namespace SelfGravity {
 //----------------------------------------------------------------------------------------
 //! \fn TaskListStatus SelfGravity::PoissonDriver
 //! \brief
-void SolvePoisson(TaskCollection &tc, Mesh *pmesh) {
+void SolvePoisson(TaskCollection &tc, Mesh *pmesh, const Real time, const int stage) {
   using namespace parthenon;
   TaskID none(0);
 
   auto pkg = pmesh->packages.Get("self_gravity");
+
+  // Check if this package is active
+  const auto active = ArtemisUtils::CheckPackageStatus(pkg, time);
+  if (active == ArtemisUtils::PackageControl::inactive) {
+    return;
+  } else if (active == ArtemisUtils::PackageControl::shutdown) {
+    if ((Globals::my_rank == 0) && (stage == 1)) {
+      printf("Turning off self-gravity at t=%.8e...\n", time);
+    }
+    return;
+  } else if (active == ArtemisUtils::PackageControl::initial) {
+    if ((Globals::my_rank == 0) && (stage == 1)) {
+      printf("Turning on self-gravity at t=%.8e...\n", time);
+    }
+  }
   auto psolver =
       pkg->Param<std::shared_ptr<parthenon::solvers::SolverBase>>("solver_pointer");
 

--- a/src/self_gravity/self_gravity.cpp
+++ b/src/self_gravity/self_gravity.cpp
@@ -179,6 +179,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin,
 
   params.Add("solver_pointer", psolver);
 
+  // Enroll in tstart/tstop machinery
+  ArtemisUtils::AddPackageTimeParams(params, block_name, pin);
+
   return self_gravity;
 }
 

--- a/src/self_gravity/self_gravity.hpp
+++ b/src/self_gravity/self_gravity.hpp
@@ -32,7 +32,7 @@ void FillPoissonRHS(MeshData<Real> *md);
 template <Coordinates GEOM>
 TaskStatus SelfGravity(MeshData<Real> *md, const Real time, const Real dt);
 
-void SolvePoisson(TaskCollection &tc, Mesh *pmesh);
+void SolvePoisson(TaskCollection &tc, Mesh *pmesh, const Real time, const int stage);
 
 } // namespace SelfGravity
 

--- a/src/utils/artemis_utils.hpp
+++ b/src/utils/artemis_utils.hpp
@@ -251,6 +251,44 @@ Real CutCell2D(const std::array<Real, 4> &x, const std::array<Real, 4> &y,
   return vol_inside / vol;
 }
 
+enum class PackageControl { inactive = -1, shutdown = 0, active = 1, initial = 2 };
+
+template <class PKG>
+inline PackageControl CheckPackageStatus(PKG &pkg, const Real time) {
+  // if t >= tstart, turn the package on
+  // if t >= tstop, turn the package off
+
+  auto *active = pkg->template MutableParam<bool>("active");
+  if (*active) {
+    if (time >= pkg->template Param<Real>("tstop")) {
+      *active = false;
+      return PackageControl::shutdown; // turn off
+    }
+    return PackageControl::active; // keep going
+  } else {
+    if ((time >= pkg->template Param<Real>("tstart")) &&
+        (time < pkg->template Param<Real>("tstop"))) {
+      *active = true;
+      return PackageControl::initial; // first time active
+    }
+  }
+  return PackageControl::inactive; // already off
+}
+
+template <class PARS>
+inline void AddPackageTimeParams(PARS &params, const std::string block_name,
+                                 ParameterInput *pin) {
+  // if t >= tstart, turn the package on
+  // if t >= tstop, turn the package off
+
+  const Real tstart = pin->GetOrAddReal(block_name, "tstart", 0.0);
+  params.Add("tstart", tstart);
+  params.Add("tstop", pin->GetOrAddReal(block_name, "tstop", 1e99));
+  params.Add("active", pin->GetOrAddBoolean(block_name, "active", tstart == 0.0),
+             Params::Mutability::Restart);
+  return;
+}
+
 } // namespace ArtemisUtils
 
 #endif // UTILS_ARTEMIS_UTILS_HPP_


### PR DESCRIPTION
## Background

This adds the machinery to turn on/off and initialize/shutdown a package during a simulation. To start, I have enrolled moments and raytrace into this. 

When moments comes on, it will set all variables to LTE values.

We should do the same for IMC and pretty much all of the packages.

I have tested this locally, and it works correctly, even through restarts.

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
- [ ] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was created in part or in whole by generative AI`