### PR TITLE
Fargo

### DIFF
--- a/inputs/disk/binary_cyl.in
+++ b/inputs/disk/binary_cyl.in
@@ -68,6 +68,7 @@ drag = true
 # cooling = true
 viscosity = true
 rotating_frame = true
+orbital_advection = true
 
 <gas>
 cfl = 0.3
@@ -84,6 +85,7 @@ gamma = 1.00001
 
 <rotating_frame>
 omega = 1.0
+gm = 1.0
 
 <gas/viscosity>
 type = alpha
@@ -120,3 +122,4 @@ rho0 = 1.0
 dslope = -0.5
 tslope = -1.0
 h0 = 0.05
+

--- a/inputs/disk/binary_nbody_cyl.in
+++ b/inputs/disk/binary_nbody_cyl.in
@@ -14,6 +14,7 @@
 <artemis>
 problem = disk             # name of the pgen
 coordinates = cylindrical  # coordinate system
+radial_spacing = logarithmic
 
 <parthenon/job>
 problem_id = disk  # problem ID: basename of output filenames
@@ -40,13 +41,13 @@ nghost = 2
 # refinement = adaptive
 # numlevel = 4
 
-nx1    = 128                # Number of zones in X1-direction
-x1min  = 0.3                # minimum value of X1
-x1max  = 3.0                # maximum value of X1
+nx1    = 256                 # Number of zones in X1-direction
+x1min  = -1.2039728043259361 # minimum value of X1 ( = 0.3)
+x1max  = 1.0986122886681098  # maximum value of X1 ( = 3.0)
 ix1_bc = ic                 # Inner-X1 boundary condition flag
 ox1_bc = ic                 # Outer-X1 boundary condition flag
 
-nx2    = 256                # Number of zones in X2-direction
+nx2    = 512                # Number of zones in X2-direction
 x2min  = 0.0                # minimum value of X2
 x2max  = 6.283185307179586  # maximum value of X2
 ix2_bc = periodic           # Inner-X2 boundary condition flag
@@ -72,6 +73,7 @@ drag = true
 # cooling = true
 viscosity = true
 rotating_frame = true
+orbital_advection = true
 
 <gas>
 cfl = 0.3
@@ -89,6 +91,7 @@ gamma = 1.00001
 
 <rotating_frame>
 omega = 1.0
+gm = 1.0
 
 <gas/viscosity>
 type = alpha
@@ -116,11 +119,11 @@ couple = 1
 
 <nbody/particle2/soft>
 radius = 0.03
-type = spline
+type = plummer
 
-<nbody/particle2/sink>
-radius = 0.03
-gamma = 1.0
+#<nbody/particle2/sink>
+#radius = 0.03
+#gamma = 1.0
 # beta = 10.0
 
 # initialize the particles as a binary

--- a/inputs/ssheet/ssheet.in
+++ b/inputs/ssheet/ssheet.in
@@ -63,6 +63,7 @@ nx3 = 1   # Number of cells in each MeshBlock, X3-dir
 gas = true
 gravity = true
 rotating_frame = true
+orbital_advection = true
 
 <gas>
 cfl = 0.3

--- a/src/artemis.cpp
+++ b/src/artemis.cpp
@@ -102,12 +102,12 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   const bool do_radiation = pin->GetOrAddBoolean("physics", "radiation", false);
   const bool do_coagulation = pin->GetOrAddBoolean("physics", "coagulation", false);
   const bool do_raytrace = pin->GetOrAddBoolean("physics", "raytrace", false);
+  const bool do_orbital_advection =
+      pin->GetOrAddBoolean("physics", "orbital_advection", false);
 
   // Determine input file specified algorithms
   const bool do_imc = do_radiation && pin->DoesBlockExist("radiation/imc");
   const bool do_moment = do_radiation && pin->DoesBlockExist("radiation/moment");
-  const bool do_shear =
-      do_rotating_frame ? (pin->GetOrAddReal("rotating_frame", "qshear", 0) > 0) : false;
   const bool update_fluxes = pin->GetOrAddBoolean("gas", "update_fluxes", true);
 
   // Check configuration selection compatibility
@@ -142,7 +142,7 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   artemis->AddParam("do_coagulation", do_coagulation);
   artemis->AddParam("do_imc", do_imc);
   artemis->AddParam("do_moment", do_moment);
-  artemis->AddParam("do_shear", do_shear);
+  artemis->AddParam("do_orbital_advection", do_orbital_advection);
   artemis->AddParam("do_raytrace", do_raytrace);
   artemis->AddParam("update_fluxes", update_fluxes);
 
@@ -169,7 +169,8 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
     packages.Add(SelfGravity::Initialize(pin.get(), constants, packages));
   if (do_gas) packages.Add(Gas::Initialize(pin.get(), units, constants, packages));
   if (do_dust) packages.Add(Dust::Initialize(pin.get(), units));
-  if (do_rotating_frame) packages.Add(RotatingFrame::Initialize(pin.get()));
+  if (do_rotating_frame || do_orbital_advection)
+    packages.Add(RotatingFrame::Initialize(pin.get()));
   if (do_cooling) packages.Add(Gas::Cooling::Initialize(pin.get()));
   if (do_drag) packages.Add(Drag::Initialize(pin.get()));
 

--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -319,7 +319,7 @@ TaskCollection ArtemisDriver<GEOM>::StepTasks() {
 
       // Apply rotating frame source term
       TaskID rframe_src = rt_src;
-      if (do_rotating_frame) {
+      if (do_rotating_frame || do_orbital_advection) {
         rframe_src =
             tl.AddTask(rt_src, RotatingFrame::RotatingFrameForce, u0.get(), time, bdt);
       }

--- a/src/artemis_driver.cpp
+++ b/src/artemis_driver.cpp
@@ -64,7 +64,7 @@ ArtemisDriver<GEOM>::ArtemisDriver(ParameterInput *pin, ApplicationInput *app_in
   do_gravity = artemis_pkg->template Param<bool>("do_gravity");
   do_self_gravity = artemis_pkg->template Param<bool>("do_self_gravity");
   do_rotating_frame = artemis_pkg->template Param<bool>("do_rotating_frame");
-  do_shear = artemis_pkg->template Param<bool>("do_shear");
+  do_orbital_advection = artemis_pkg->template Param<bool>("do_orbital_advection");
   do_cooling = artemis_pkg->template Param<bool>("do_cooling");
   do_drag = artemis_pkg->template Param<bool>("do_drag");
   do_viscosity = artemis_pkg->template Param<bool>("do_viscosity");
@@ -79,6 +79,8 @@ ArtemisDriver<GEOM>::ArtemisDriver(ParameterInput *pin, ApplicationInput *app_in
   // Update fluxes option--gas fields are needed for radiation temperature updates but for
   // rad-only test problems turn off advection
   update_fluxes = artemis_pkg->template Param<bool>("update_fluxes");
+
+  ndim = pm->ndim;
 
   // Moments integrator
   if (do_moment) {
@@ -135,10 +137,13 @@ TaskListStatus ArtemisDriver<GEOM>::Step() {
   status = StepTasks().Execute();
   if (status != TaskListStatus::complete) return status;
 
-  // Operator split, background linear advection (for shearing box)
-  if (do_shear) {
-    status = RotatingFrame::Advect(pmesh, tm);
-    if (status != TaskListStatus::complete) return status;
+  // Operator split, background linear advection
+  if (do_orbital_advection && (ndim > 1)) {
+    // only if the advection direction is included
+    if constexpr (!geometry::is_axisymmetric<GEOM>()) {
+      status = RotatingFrame::Advect<GEOM>(pmesh, tm);
+      if (status != TaskListStatus::complete) return status;
+    }
   }
 
   // Operator split, IMC/DDMC radiation with Jaybenne

--- a/src/artemis_driver.hpp
+++ b/src/artemis_driver.hpp
@@ -52,8 +52,10 @@ class ArtemisDriver : public EvolutionDriver {
  protected:
   IntegratorPtr_t integrator, nbody_integrator, rad_integrator;
   StateDescriptor *artemis_pkg;
+  int ndim;
   bool do_gas, do_dust, do_moment, do_imc;
-  bool do_gravity, do_self_gravity, do_nbody, do_rotating_frame, do_shear;
+  bool do_gravity, do_self_gravity, do_nbody, do_rotating_frame;
+  bool do_orbital_advection;
   bool do_cooling, do_drag, do_viscosity, do_conduction, do_diffusion;
   bool do_coagulation, do_raytrace;
   bool update_fluxes;

--- a/src/artemis_params.yaml
+++ b/src/artemis_params.yaml
@@ -86,6 +86,10 @@ physics:
     _type: "bool"
     _default: "false"
     _description: "Turn on the rotating frame"
+  orbital_advection:
+    _type: "bool"
+    _default: "false"
+    _description: "Turn on orbital advection"
   cooling:
     _type: "bool"
     _default: "false"

--- a/src/gravity/nbody_gravity.hpp
+++ b/src/gravity/nbody_gravity.hpp
@@ -29,7 +29,7 @@ NBodyGravityImpl(V1 &vmesh, V2 &vg, const geometry::Coords<GEOM> &coords,
                  const NBody::Particle &pl, ArtemisUtils::array_type<Real, 7> &lforce,
                  const int b, const int k, const int j, const int i, const bool do_gas,
                  const bool do_dust, const Real qshear, const Real omb, const Real omf,
-                 const Real time, const Real dt) {
+                 const Real gm_bg, const Real time, const Real dt) {
   // Extract coordinates
 
   const auto &x = coords.GetCellCenter(vg, b, k, j, i);
@@ -52,7 +52,7 @@ NBodyGravityImpl(V1 &vmesh, V2 &vg, const geometry::Coords<GEOM> &coords,
     // TODO(AMD): The background velocity should have the frame velocity in it. Only
     // important for non-shearing box
     const auto &vrot = RotatingFrame::RotationVelocity<GEOM>(x, omf);
-    const auto &vback = RotatingFrame::BackgroundVelocity<GEOM>(qshear, omb, x[0]);
+    const auto &vback = RotatingFrame::BackgroundVelocity<GEOM>(qshear, omb, gm_bg, x);
     vf[0] = ex1[0] * (vback[0] + vrot[0]) + ex2[0] * (vback[1] + vrot[1]) +
             ex3[0] * (vback[2] + vrot[2]);
     vf[1] = ex1[1] * (vback[0] + vrot[0]) + ex2[1] * (vback[1] + vrot[1]) +
@@ -173,22 +173,21 @@ TaskStatus NBodyGravity(MeshData<Real> *md, const Real time, const Real dt) {
   const bool do_gas = artemis_pkg->template Param<bool>("do_gas");
   const bool do_dust = artemis_pkg->template Param<bool>("do_dust");
   bool do_rf = artemis_pkg->template Param<bool>("do_rotating_frame");
+  bool do_oa = artemis_pkg->template Param<bool>("do_orbital_advection");
 
   Real omf = 0.0;
   Real omb = 0.0;
   Real qshear = 0.0;
-  if (do_rf) {
+  Real gm_bg = 0.0;
+  if (do_rf || do_oa) {
     auto &rf_pkg = pm->packages.Get("rotating_frame");
     const bool global_frame = nbody_pkg->template Param<bool>("frame_correction");
-    if (global_frame) {
+    if (do_rf && global_frame) {
       omf = rf_pkg->template Param<Real>("omega");
-      omb = omf;
-      qshear = rf_pkg->template Param<Real>("qshear");
-    } else {
-      // still need the background flow if shearing box local
-      omb = rf_pkg->template Param<Real>("omega");
-      qshear = rf_pkg->template Param<Real>("qshear");
     }
+    omb = rf_pkg->template Param<Real>("omega");
+    qshear = rf_pkg->template Param<Real>("qshear");
+    gm_bg = rf_pkg->template Param<Real>("gm");
   }
   const auto &cpars = artemis_pkg->template Param<geometry::CoordParams>("coord_params");
 
@@ -223,7 +222,7 @@ TaskStatus NBodyGravity(MeshData<Real> *md, const Real time, const Real dt) {
           if (particles(n).couple) {
             const geometry::Coords<GEOM> coords(cpars, vmesh.GetCoordinates(b), k, j, i);
             NBodyGravityImpl<GEOM>(vmesh, vg, coords, particles(n), lsum, b, k, j, i,
-                                   do_gas, do_dust, qshear, omb, omf, time, dt);
+                                   do_gas, do_dust, qshear, omb, omf, gm_bg, time, dt);
           }
         },
         ArtemisUtils::SumMyArray<Real, Kokkos::HostSpace, 7>(lforce));

--- a/src/pgen/disk.hpp
+++ b/src/pgen/disk.hpp
@@ -37,6 +37,7 @@
 #include "geometry/geometry.hpp"
 #include "gravity/nbody_gravity.hpp"
 #include "nbody/nbody.hpp"
+#include "rotating_frame/rotating_frame.hpp"
 #include "utils/artemis_utils.hpp"
 #include "utils/eos/eos.hpp"
 #include "utils/units.hpp"
@@ -68,6 +69,7 @@ struct DiskParams {
   bool do_gas, do_dust, do_moment, do_imc;
   bool nbody_temp;
   bool quiet_start;
+  bool do_oa;
   bool log;
   bool multi_d, three_d;
 };
@@ -203,13 +205,21 @@ KOKKOS_INLINE_FUNCTION State ComputeDiskProfile(
   const Real nu = ViscosityProfile(pgen, eos_d, rt, xcyl[2]);
   const Real vr = pgen.quiet_start ? 0.0 : -1.5 * nu / xcyl[0];
 
-  // Construct the total cylindrical velocity
+  // Construct the cylindrical velocity in the rotating frame.
   const Real vcyl[3] = {vr, vp - pgen.omf * xcyl[0], 0.0};
 
-  // and convert it to the problem geometry
+  // Convert to coordinate basis
   res.gvel1 = ArtemisUtils::VDot(vcyl, ex1);
   res.gvel2 = ArtemisUtils::VDot(vcyl, ex2);
   res.gvel3 = ArtemisUtils::VDot(vcyl, ex3);
+
+  // Subtract the background velocity
+  if (pgen.do_oa) {
+    const auto vbg = RotatingFrame::BackgroundVelocity<GEOM>(0.0, pgen.omf, pgen.gm, xv);
+    res.gvel1 -= vbg[0];
+    res.gvel2 -= vbg[1];
+    res.gvel3 -= vbg[2];
+  }
 
   if (!(do_dust)) return res;
 
@@ -219,6 +229,14 @@ KOKKOS_INLINE_FUNCTION State ComputeDiskProfile(
   res.dvel1 = ArtemisUtils::VDot(vkep, ex1);
   res.dvel2 = ArtemisUtils::VDot(vkep, ex2);
   res.dvel3 = ArtemisUtils::VDot(vkep, ex3);
+
+  // Subtract the background velocity for dust too
+  if (pgen.do_oa) {
+    const auto vbg = RotatingFrame::BackgroundVelocity<GEOM>(0.0, pgen.omf, pgen.gm, xv);
+    res.dvel1 -= vbg[0];
+    res.dvel2 -= vbg[1];
+    res.dvel3 -= vbg[2];
+  }
 
   return res;
 }
@@ -305,6 +323,7 @@ inline void InitDiskParams(MeshBlock *pmb, ParameterInput *pin) {
     } else {
       disk_params.omf = 0.0;
     }
+    disk_params.do_oa = params.Get<bool>("do_orbital_advection");
     if (params.Get<bool>("do_viscosity")) {
       const auto vtype = pin->GetString("gas/viscosity", "type");
       if (vtype == "alpha") {
@@ -518,6 +537,30 @@ void DiskBoundaryVisc(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) {
         const auto &[xcylm1, scr1m1, scr2m1, scr3m1] = cm1.ConvertToCylWithVec(xvm1);
         const Real epm1[3] = {scr1m1[1], scr2m1[1], scr3m1[1]};
 
+        // background velocity
+        Real vbg_a = 0.0, vbg_p1 = 0.0, vbg_m1 = 0.0, vbg_g = 0.0;
+        if (dp.do_oa) {
+          const auto ba =
+              RotatingFrame::BackgroundVelocity<GEOM>(0.0, dp.omf, dp.gm, xva);
+          const Real ba3[3] = {ba[0], ba[1], ba[2]};
+          vbg_a = ArtemisUtils::VDot(ba3, epa);
+
+          const auto bp =
+              RotatingFrame::BackgroundVelocity<GEOM>(0.0, dp.omf, dp.gm, xvp1);
+          const Real bp3[3] = {bp[0], bp[1], bp[2]};
+          vbg_p1 = ArtemisUtils::VDot(bp3, epp1);
+
+          const auto bm =
+              RotatingFrame::BackgroundVelocity<GEOM>(0.0, dp.omf, dp.gm, xvm1);
+          const Real bm3[3] = {bm[0], bm[1], bm[2]};
+          vbg_m1 = ArtemisUtils::VDot(bm3, epm1);
+
+          const auto bg = RotatingFrame::BackgroundVelocity<GEOM>(0.0, dp.omf, dp.gm, xv);
+          const Real bg3[3] = {bg[0], bg[1], bg[2]};
+          const Real ep_g[3] = {ex1[1], ex2[1], ex3[1]};
+          vbg_g = ArtemisUtils::VDot(bg3, ep_g);
+        }
+
         // Compute cell separations (using logarithmics if necessary)
         const Real xma = std::log(xv[ix1] / xva[ix1]);
         const Real dx = std::log(xvp1[ix1] / xvm1[ix1]);
@@ -545,10 +588,12 @@ void DiskBoundaryVisc(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) {
             Real gvm1[3] = {v(0, gas::prim::velocity(VI(n, 0)), im1[0], im1[1], im1[2]),
                             v(0, gas::prim::velocity(VI(n, 1)), im1[0], im1[1], im1[2]),
                             v(0, gas::prim::velocity(VI(n, 2)), im1[0], im1[1], im1[2])};
-            const Real gvp = ArtemisUtils::VDot(gva, epa) + dp.omf * xcyla[0];
+            const Real gvp = ArtemisUtils::VDot(gva, epa) + dp.omf * xcyla[0] + vbg_a;
             const Real gvz = ArtemisUtils::VDot(gva, eza);
-            const Real gvp1p = ArtemisUtils::VDot(gvp1, epp1) + dp.omf * xcylp1[0];
-            const Real gvm1p = ArtemisUtils::VDot(gvm1, epm1) + dp.omf * xcylm1[0];
+            const Real gvp1p =
+                ArtemisUtils::VDot(gvp1, epp1) + dp.omf * xcylp1[0] + vbg_p1;
+            const Real gvm1p =
+                ArtemisUtils::VDot(gvm1, epm1) + dp.omf * xcylm1[0] + vbg_m1;
             const Real dgvp = std::log(gvp1p / gvm1p);
             const Real vpg = gvp * std::exp(dgvp * xmadx);
             Real rhog, gvR;
@@ -564,7 +609,7 @@ void DiskBoundaryVisc(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) {
               gvR = -dp.mdot / (2 * M_PI * xcyl[0] * rhog);
             }
 
-            const Real gvcyl[3] = {gvR, vpg - dp.omf * xcyl[0], gvz};
+            const Real gvcyl[3] = {gvR, vpg - dp.omf * xcyl[0] - vbg_g, gvz};
             const Real gvel[3] = {ArtemisUtils::VDot(gvcyl, ex1),
                                   ArtemisUtils::VDot(gvcyl, ex2),
                                   ArtemisUtils::VDot(gvcyl, ex3)};
@@ -595,14 +640,16 @@ void DiskBoundaryVisc(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) {
             Real dvm1[3] = {v(0, dust::prim::velocity(VI(n, 0)), im1[0], im1[1], im1[2]),
                             v(0, dust::prim::velocity(VI(n, 1)), im1[0], im1[1], im1[2]),
                             v(0, dust::prim::velocity(VI(n, 2)), im1[0], im1[1], im1[2])};
-            const Real dvp = ArtemisUtils::VDot(dva, epa) + dp.omf * xcyla[0];
+            const Real dvp = ArtemisUtils::VDot(dva, epa) + dp.omf * xcyla[0] + vbg_a;
             const Real dvR = ArtemisUtils::VDot(dva, eRa);
             const Real dvz = ArtemisUtils::VDot(dva, eza);
-            const Real dvp1p = ArtemisUtils::VDot(dvp1, epp1) + dp.omf * xcylp1[0];
-            const Real dvm1p = ArtemisUtils::VDot(dvm1, epm1) + dp.omf * xcylm1[0];
+            const Real dvp1p =
+                ArtemisUtils::VDot(dvp1, epp1) + dp.omf * xcylp1[0] + vbg_p1;
+            const Real dvm1p =
+                ArtemisUtils::VDot(dvm1, epm1) + dp.omf * xcylm1[0] + vbg_m1;
             const Real ddvp = std::log(dvp1p / dvm1p);
-            const Real dvcyl[3] = {dvR, dvp * std::exp(ddvp * xmadx) - dp.omf * xcyl[0],
-                                   dvz};
+            const Real dvcyl[3] = {
+                dvR, dvp * std::exp(ddvp * xmadx) - dp.omf * xcyl[0] - vbg_g, dvz};
             const Real dvel[3] = {ArtemisUtils::VDot(dvcyl, ex1),
                                   ArtemisUtils::VDot(dvcyl, ex2),
                                   ArtemisUtils::VDot(dvcyl, ex3)};
@@ -779,6 +826,32 @@ void DiskBoundaryExtrap(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) 
 
         const auto &[xcylm1, scr1m1, scr2m1, scr3m1] = coords.ConvertToCylWithVec(xvm1);
         const Real epm1[3] = {scr1m1[1], scr2m1[1], scr3m1[1]};
+
+        // background velocity
+        Real vbg_a = 0.0, vbg_p1 = 0.0, vbg_m1 = 0.0, vbg_g = 0.0;
+        if (dp.do_oa) {
+          const auto ba =
+              RotatingFrame::BackgroundVelocity<GEOM>(0.0, dp.omf, dp.gm, xva);
+          const Real ba3[3] = {ba[0], ba[1], ba[2]};
+          vbg_a = ArtemisUtils::VDot(ba3, epa);
+
+          const auto bp =
+              RotatingFrame::BackgroundVelocity<GEOM>(0.0, dp.omf, dp.gm, xvp1);
+          const Real bp3[3] = {bp[0], bp[1], bp[2]};
+          vbg_p1 = ArtemisUtils::VDot(bp3, epp1);
+
+          const auto bm =
+              RotatingFrame::BackgroundVelocity<GEOM>(0.0, dp.omf, dp.gm, xvm1);
+          const Real bm3[3] = {bm[0], bm[1], bm[2]};
+          vbg_m1 = ArtemisUtils::VDot(bm3, epm1);
+
+          const auto bgg =
+              RotatingFrame::BackgroundVelocity<GEOM>(0.0, dp.omf, dp.gm, xv);
+          const Real bg3[3] = {bgg[0], bgg[1], bgg[2]};
+          const Real ep_g[3] = {ex1[1], ex2[1], ex3[1]};
+          vbg_g = ArtemisUtils::VDot(bg3, ep_g);
+        }
+
         // Compute cell separations (using logarithmics if necessary)
         const Real xma = (lnx) ? std::log(xv[ix1] / xva[ix1]) : xv[ix1] - xva[ix1];
         const Real dx = (lnx) ? std::log(xvp1[ix1] / xvm1[ix1]) : xvp1[ix1] - xvm1[ix1];
@@ -806,14 +879,16 @@ void DiskBoundaryExtrap(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) 
             Real gvm1[3] = {v(0, gas::prim::velocity(VI(n, 0)), im1[0], im1[1], im1[2]),
                             v(0, gas::prim::velocity(VI(n, 1)), im1[0], im1[1], im1[2]),
                             v(0, gas::prim::velocity(VI(n, 2)), im1[0], im1[1], im1[2])};
-            const Real gvp = ArtemisUtils::VDot(gva, epa) + dp.omf * xcyla[0];
+            const Real gvp = ArtemisUtils::VDot(gva, epa) + dp.omf * xcyla[0] + vbg_a;
             const Real gvR = ArtemisUtils::VDot(gva, eRa);
             const Real gvz = ArtemisUtils::VDot(gva, eza);
-            const Real gvp1p = ArtemisUtils::VDot(gvp1, epp1) + dp.omf * xcylp1[0];
-            const Real gvm1p = ArtemisUtils::VDot(gvm1, epm1) + dp.omf * xcylm1[0];
+            const Real gvp1p =
+                ArtemisUtils::VDot(gvp1, epp1) + dp.omf * xcylp1[0] + vbg_p1;
+            const Real gvm1p =
+                ArtemisUtils::VDot(gvm1, epm1) + dp.omf * xcylm1[0] + vbg_m1;
             const Real dgvp = std::log(gvp1p / gvm1p);
-            const Real gvcyl[3] = {gvR, gvp * std::exp(dgvp * xmadx) - dp.omf * xcyl[0],
-                                   gvz};
+            const Real gvcyl[3] = {
+                gvR, gvp * std::exp(dgvp * xmadx) - dp.omf * xcyl[0] - vbg_g, gvz};
             const Real gvel[3] = {ArtemisUtils::VDot(gvcyl, ex1),
                                   ArtemisUtils::VDot(gvcyl, ex2),
                                   ArtemisUtils::VDot(gvcyl, ex3)};
@@ -846,14 +921,16 @@ void DiskBoundaryExtrap(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse) 
             Real dvm1[3] = {v(0, dust::prim::velocity(VI(n, 0)), im1[0], im1[1], im1[2]),
                             v(0, dust::prim::velocity(VI(n, 1)), im1[0], im1[1], im1[2]),
                             v(0, dust::prim::velocity(VI(n, 2)), im1[0], im1[1], im1[2])};
-            const Real dvp = ArtemisUtils::VDot(dva, epa) + dp.omf * xcyla[0];
+            const Real dvp = ArtemisUtils::VDot(dva, epa) + dp.omf * xcyla[0] + vbg_a;
             const Real dvR = ArtemisUtils::VDot(dva, eRa);
             const Real dvz = ArtemisUtils::VDot(dva, eza);
-            const Real dvp1p = ArtemisUtils::VDot(dvp1, epp1) + dp.omf * xcylp1[0];
-            const Real dvm1p = ArtemisUtils::VDot(dvm1, epm1) + dp.omf * xcylm1[0];
+            const Real dvp1p =
+                ArtemisUtils::VDot(dvp1, epp1) + dp.omf * xcylp1[0] + vbg_p1;
+            const Real dvm1p =
+                ArtemisUtils::VDot(dvm1, epm1) + dp.omf * xcylm1[0] + vbg_m1;
             const Real ddvp = std::log(dvp1p / dvm1p);
-            const Real dvcyl[3] = {dvR, dvp * std::exp(ddvp * xmadx) - dp.omf * xcyl[0],
-                                   dvz};
+            const Real dvcyl[3] = {
+                dvR, dvp * std::exp(ddvp * xmadx) - dp.omf * xcyl[0] - vbg_g, dvz};
             const Real dvel[3] = {ArtemisUtils::VDot(dvcyl, ex1),
                                   ArtemisUtils::VDot(dvcyl, ex2),
                                   ArtemisUtils::VDot(dvcyl, ex3)};

--- a/src/pgen/strat.hpp
+++ b/src/pgen/strat.hpp
@@ -56,7 +56,8 @@ struct StratParams {
   Real kbmu;
   bool three_d;
   Real ar;
-  bool do_dust, do_moment, do_imc;
+  Real dvdx;
+  bool do_oa, do_dust, do_moment, do_imc;
   int npoints;
 };
 
@@ -74,6 +75,8 @@ inline void InitStratParams(MeshBlock *pmb, ParameterInput *pin) {
     strat_params.three_d = pin->GetInteger("parthenon/mesh", "nx3") > 1;
     strat_params.q = pmb->packages.Get("rotating_frame")->Param<Real>("qshear");
     strat_params.Om0 = pmb->packages.Get("rotating_frame")->Param<Real>("omega");
+    strat_params.do_oa =
+        pmb->packages.Get("rotating_frame")->Param<bool>("do_orbital_advection");
     strat_params.h = pin->GetOrAddReal("problem", "h", 1.0);
     strat_params.rho0 = pin->GetOrAddReal("problem", "rho0", 1.0);
     strat_params.r0 = pin->GetOrAddReal("problem", "r0", 1.0);
@@ -96,6 +99,7 @@ inline void InitStratParams(MeshBlock *pmb, ParameterInput *pin) {
     strat_params.do_imc = params.Get<bool>("do_imc");
     strat_params.do_moment = params.Get<bool>("do_moment");
     strat_params.ar = constants.GetARCode();
+    strat_params.dvdx = strat_params.do_oa ? 0.0 : -pars.q * pars.Om0;
     params.Add("strat_params", strat_params);
   }
 }
@@ -181,8 +185,7 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         const Real z = coords.x3v();
 
         const Real vx1 = 0.0;
-        // const Real vx2 = -pars.q * pars.Om0 * x;
-        const Real dvx2 = 0.0; // residual eq evolution
+        const Real vx2 = pars.dvdx * x;
         const Real vx3 = 0.0;
         const Real temp = pars.temp0;
         const Real dens =
@@ -192,7 +195,7 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
         v(0, gas::prim::density(0), k, j, i) = dens;
         v(0, gas::prim::velocity(0), k, j, i) = vx1;
-        v(0, gas::prim::velocity(1), k, j, i) = dvx2;
+        v(0, gas::prim::velocity(1), k, j, i) = vx2;
         v(0, gas::prim::velocity(2), k, j, i) = vx3;
         v(0, gas::prim::sie(0), k, j, i) = sie;
         if (pars.do_dust) {
@@ -200,7 +203,7 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
           for (int n = 0; n < v.GetSize(0, dust::prim::density()); ++n) {
             v(0, dust::prim::density(n), k, j, i) = ddens;
             v(0, dust::prim::velocity(VI(n, 0)), k, j, i) = vx1;
-            v(0, dust::prim::velocity(VI(n, 1)), k, j, i) = dvx2;
+            v(0, dust::prim::velocity(VI(n, 1)), k, j, i) = vx2;
             v(0, dust::prim::velocity(VI(n, 2)), k, j, i) = vx3;
           }
         }
@@ -463,8 +466,7 @@ inline void ShearInnerX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
         const Real x = coords.x1v();
         const Real xf = coords.bnds.x1[0];
 
-        // const Real vy0 = -pars.q * pars.Om0 * x;
-        const Real dvy0 = 0.0; // residual eq evolution
+        const Real vy0 = pars.dvdx * x;
         const bool outflow = (xf >= 0.0);
 
         Real gdsum = 0.0;
@@ -473,7 +475,7 @@ inline void ShearInnerX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
           const Real gv2 = v(0, gas::prim::velocity(VI(n, 1)), k, js, i);
           const Real gv3 = v(0, gas::prim::velocity(VI(n, 2)), k, js, i);
           const Real vx1g = outflow ? gv1 : 0.0;
-          const Real vx2g = outflow ? ((gv2 > 0.) ? 0.0 : gv2) : dvy0;
+          const Real vx2g = outflow ? ((gv2 > 0.) ? 0.0 : gv2) : vy0;
           const Real vx3g = outflow ? gv3 : 0.0;
           const Real densg =
               outflow ? v(0, gas::prim::density(n), k, js, i) : InitialDensity(pars, z);
@@ -495,7 +497,7 @@ inline void ShearInnerX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
             const Real dv2 = v(0, dust::prim::velocity(VI(n, 1)), k, js, i);
             const Real dv3 = v(0, dust::prim::velocity(VI(n, 2)), k, js, i);
             const Real vx1d = dv1;
-            const Real vx2d = outflow ? ((dv2 > 0.) ? 0.0 : dv2) : dvy0;
+            const Real vx2d = outflow ? ((dv2 > 0.) ? 0.0 : dv2) : vy0;
             const Real vx3d = dv3;
             const Real densd =
                 outflow ? v(0, dust::prim::density(n), k, js, i) : gdsum * pars.d2g;
@@ -585,8 +587,7 @@ inline void ShearOuterX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
         const Real x = coords.x1v();
         const Real xf = coords.bnds.x1[0];
 
-        // const Real vy0 = -pars.q * pars.Om0 * x;
-        const Real dvy0 = 0.0; // residual eq evolution
+        const Real vy0 = pars.dvdx * x;
         const bool outflow = (xf < 0.0);
 
         Real gdsum = 0.0;
@@ -595,7 +596,7 @@ inline void ShearOuterX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
           const Real gv2 = v(0, gas::prim::velocity(VI(n, 1)), k, je, i);
           const Real gv3 = v(0, gas::prim::velocity(VI(n, 2)), k, je, i);
           const Real vx1g = outflow ? gv1 : 0.0;
-          const Real vx2g = outflow ? ((gv2 < 0.0) ? 0.0 : gv2) : dvy0;
+          const Real vx2g = outflow ? ((gv2 < 0.0) ? 0.0 : gv2) : vy0;
           const Real vx3g = outflow ? gv3 : 0.0;
           const Real densg =
               outflow ? v(0, gas::prim::density(n), k, je, i) : InitialDensity(pars, z);
@@ -617,7 +618,7 @@ inline void ShearOuterX2(std::shared_ptr<MeshBlockData<Real>> &mbd, bool coarse)
             const Real dv2 = v(0, dust::prim::velocity(VI(n, 1)), k, je, i);
             const Real dv3 = v(0, dust::prim::velocity(VI(n, 2)), k, je, i);
             const Real vx1d = dv1;
-            const Real vx2d = outflow ? ((dv2 < 0.0) ? 0.0 : dv2) : dvy0;
+            const Real vx2d = outflow ? ((dv2 < 0.0) ? 0.0 : dv2) : vy0;
             const Real vx3d = dv3;
             const Real densd =
                 outflow ? v(0, dust::prim::density(n), k, je, i) : gdsum * pars.d2g;

--- a/src/pgen/strat.hpp
+++ b/src/pgen/strat.hpp
@@ -99,7 +99,7 @@ inline void InitStratParams(MeshBlock *pmb, ParameterInput *pin) {
     strat_params.do_imc = params.Get<bool>("do_imc");
     strat_params.do_moment = params.Get<bool>("do_moment");
     strat_params.ar = constants.GetARCode();
-    strat_params.dvdx = strat_params.do_oa ? 0.0 : -pars.q * pars.Om0;
+    strat_params.dvdx = strat_params.do_oa ? 0.0 : -strat_params.q * strat_params.Om0;
     params.Add("strat_params", strat_params);
   }
 }

--- a/src/radiation/moments/matter_coupling.hpp
+++ b/src/radiation/moments/matter_coupling.hpp
@@ -68,10 +68,13 @@ TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
   // Extract rotating frame quantities
   Real om0 = 0.0;
   Real qshear = 0.0;
-  if (pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame")) {
+  Real gm_bg = 0.0;
+  if (pm->packages.Get("artemis")->template Param<bool>("do_orbital_advection") ||
+      pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame")) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
     qshear = rframe_pkg->template Param<Real>("qshear");
     om0 = rframe_pkg->template Param<Real>("omega");
+    gm_bg = rframe_pkg->template Param<Real>("gm");
   }
   const bool do_raytrace =
       pm->packages.Get("artemis")->template Param<bool>("do_raytrace");
@@ -103,7 +106,7 @@ TaskStatus MatterCouplingSimpleImpl(MeshData<Real> *u0, const Real dt) {
         if (do_raytrace) Q = dt * v0(b, gas::src::energy(), k, j, i);
         Real e0 = v0(b, gas::cons::internal_energy(), k, j, i);
         const auto vb = RotatingFrame::BackgroundVelocity<GEOM>(
-            qshear, om0, coords.GetCellCenter(vg, b, k, j, i)[0]);
+            qshear, om0, gm_bg, coords.GetCellCenter(vg, b, k, j, i));
         std::array<Real, 3> v{
             vb[0] + v0(b, gas::cons::momentum(0), k, j, i) / (hx[0] * dens),
             vb[1] + v0(b, gas::cons::momentum(1), k, j, i) / (hx[1] * dens),
@@ -229,10 +232,13 @@ TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
   // Extract rotating frame quantities
   Real om0 = 0.0;
   Real qshear = 0.0;
-  if (pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame")) {
+  Real gm_bg = 0.0;
+  if (pm->packages.Get("artemis")->template Param<bool>("do_orbital_advection") ||
+      pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame")) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
     qshear = rframe_pkg->template Param<Real>("qshear");
     om0 = rframe_pkg->template Param<Real>("omega");
+    gm_bg = rframe_pkg->template Param<Real>("gm");
   }
   const auto &cpars =
       pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
@@ -282,7 +288,7 @@ TaskStatus MatterCouplingFullSingleImpl(MeshData<Real> *u0, const Real dt) {
         Real B = arad * SQR(SQR(T));
 
         const auto vb = RotatingFrame::BackgroundVelocity<GEOM>(
-            qshear, om0, coords.GetCellCenter(vg, b, k, j, i)[0]);
+            qshear, om0, gm_bg, coords.GetCellCenter(vg, b, k, j, i));
         const std::array<Real, 3> p0{
             vb[0] * dens + v0(b, gas::cons::momentum(0), k, j, i) / hx[0],
             vb[1] * dens + v0(b, gas::cons::momentum(1), k, j, i) / hx[1],

--- a/src/rotating_frame/advection_driver.cpp
+++ b/src/rotating_frame/advection_driver.cpp
@@ -31,10 +31,11 @@ namespace RotatingFrame {
 //----------------------------------------------------------------------------------------
 //! \fn TaskListStatus RotatingFrame::Advect
 //! \brief Executes linear advection term for orbital advection
+template <Coordinates GEOM>
 TaskListStatus Advect(Mesh *pmesh, const SimTime &tm) {
   PARTHENON_INSTRUMENT
-  // Craft a series of **equal** subsetps that sum to the unsplit step
-  const Real dtlimit = EstimateTimestep(pmesh, 1.0);
+  // Craft a series of **equal** substeps that sum to the unsplit step
+  const Real dtlimit = EstimateTimestep<GEOM>(pmesh, 1.0);
   const int nsteps = static_cast<int>(std::ceil(tm.dt / dtlimit));
   const Real scdt = tm.dt / nsteps;
 
@@ -49,7 +50,7 @@ TaskListStatus Advect(Mesh *pmesh, const SimTime &tm) {
 
   // Execute LinearAdvectionStep over substeps
   for (int step = 1; step <= nsteps; step++) {
-    auto status = LinearAdvectionStep(pmesh, tm, scdt).Execute();
+    auto status = LinearAdvectionStep<GEOM>(pmesh, tm, scdt).Execute();
     if (status != TaskListStatus::complete) return status;
   }
 
@@ -58,6 +59,7 @@ TaskListStatus Advect(Mesh *pmesh, const SimTime &tm) {
 
 //----------------------------------------------------------------------------------------
 //! \fn  TaskCollection LinearAdvectionStep
+template <Coordinates GEOM>
 TaskCollection LinearAdvectionStep(Mesh *pmesh, const SimTime &tm, const Real scdt) {
   PARTHENON_INSTRUMENT
   TaskCollection tc;
@@ -76,9 +78,8 @@ TaskCollection LinearAdvectionStep(Mesh *pmesh, const SimTime &tm, const Real sc
     auto &u0 = pmesh->mesh_data.GetOrAdd("u0", i);
 
     auto start_recv = tl.AddTask(none, parthenon::StartReceiveBoundBufs<any>, u0);
-    auto update = tl.AddTask(start_recv, LagrangeRemap, u0.get(), scdt);
-    auto set_aux = tl.AddTask(
-        update, ArtemisDerived::SetAuxillaryFields<Coordinates::cartesian>, u0.get());
+    auto update = tl.AddTask(start_recv, LagrangeRemap<GEOM>, u0.get(), scdt);
+    auto set_aux = tl.AddTask(update, ArtemisDerived::SetAuxillaryFields<GEOM>, u0.get());
     auto c2p = tl.AddTask(set_aux, PreCommFillDerived<MeshData<Real>>, u0.get());
     auto bcs = parthenon::AddBoundaryExchangeTasks(c2p, tl, u0, pmesh->multilevel);
     auto p2c = tl.AddTask(bcs, FillDerived<MeshData<Real>>, u0.get());
@@ -90,6 +91,7 @@ TaskCollection LinearAdvectionStep(Mesh *pmesh, const SimTime &tm, const Real sc
 //----------------------------------------------------------------------------------------
 //! \fn  TaskStatus RotatingFrame::LagrangeRemap
 //! \brief
+template <Coordinates GEOM>
 TaskStatus LagrangeRemap(MeshData<Real> *u0, const Real scdt) {
   PARTHENON_INSTRUMENT
   using parthenon::MakePackDescriptor;
@@ -105,10 +107,11 @@ TaskStatus LagrangeRemap(MeshData<Real> *u0, const Real scdt) {
   auto &rframe_pkg = pm->packages.Get("rotating_frame");
   const Real qshear = rframe_pkg->template Param<Real>("qshear");
   const Real om0 = rframe_pkg->template Param<Real>("omega");
+  const Real gm = rframe_pkg->template Param<Real>("gm");
   const auto recon = rframe_pkg->template Param<ReconstructionMethod>("recon");
 
-  // Extract integrator weights
-  const Real dwdt = -qshear * om0 * scdt;
+  // Shearing box displacement (Cartesian) or zero for curvilinear
+  const Real dwdt = (GEOM == Coordinates::cartesian) ? (-qshear * om0 * scdt) : 0.0;
 
   // Packing and indexing
   static auto desc =
@@ -123,20 +126,42 @@ TaskStatus LagrangeRemap(MeshData<Real> *u0, const Real scdt) {
 
   // Call upwind advection routines with requested recon
   if (recon == ReconstructionMethod::pcm) {
-    return LagrangeRemapImpl<ReconstructionMethod::pcm>(u0, v0, vg, dwdt);
+    return LagrangeRemapImpl<GEOM, ReconstructionMethod::pcm>(u0, v0, vg, dwdt, gm, om0,
+                                                              scdt);
   } else if (recon == ReconstructionMethod::plm) {
-    return LagrangeRemapImpl<ReconstructionMethod::plm>(u0, v0, vg, dwdt);
+    return LagrangeRemapImpl<GEOM, ReconstructionMethod::plm>(u0, v0, vg, dwdt, gm, om0,
+                                                              scdt);
   } else if (recon == ReconstructionMethod::ppm) {
-    return LagrangeRemapImpl<ReconstructionMethod::ppm>(u0, v0, vg, dwdt);
+    return LagrangeRemapImpl<GEOM, ReconstructionMethod::ppm>(u0, v0, vg, dwdt, gm, om0,
+                                                              scdt);
   } else if (recon == ReconstructionMethod::wenoz) {
-    return LagrangeRemapImpl<ReconstructionMethod::wenoz>(u0, v0, vg, dwdt);
+    return LagrangeRemapImpl<GEOM, ReconstructionMethod::wenoz>(u0, v0, vg, dwdt, gm, om0,
+                                                                scdt);
   } else if (recon == ReconstructionMethod::wenomz) {
-    return LagrangeRemapImpl<ReconstructionMethod::wenomz>(u0, v0, vg, dwdt);
+    return LagrangeRemapImpl<GEOM, ReconstructionMethod::wenomz>(u0, v0, vg, dwdt, gm,
+                                                                 om0, scdt);
   } else {
     PARTHENON_FAIL("Unsupported reconstruction method in rotating_frame");
   }
 
   return TaskStatus::complete;
 }
+
+//----------------------------------------------------------------------------------------
+//! template instantiations
+template TaskListStatus Advect<Coordinates::cartesian>(Mesh *, const SimTime &);
+template TaskListStatus Advect<Coordinates::cylindrical>(Mesh *, const SimTime &);
+template TaskListStatus Advect<Coordinates::spherical3D>(Mesh *, const SimTime &);
+
+template TaskCollection
+LinearAdvectionStep<Coordinates::cartesian>(Mesh *, const SimTime &, const Real);
+template TaskCollection
+LinearAdvectionStep<Coordinates::cylindrical>(Mesh *, const SimTime &, const Real);
+template TaskCollection
+LinearAdvectionStep<Coordinates::spherical3D>(Mesh *, const SimTime &, const Real);
+
+template TaskStatus LagrangeRemap<Coordinates::cartesian>(MeshData<Real> *, const Real);
+template TaskStatus LagrangeRemap<Coordinates::cylindrical>(MeshData<Real> *, const Real);
+template TaskStatus LagrangeRemap<Coordinates::spherical3D>(MeshData<Real> *, const Real);
 
 } // namespace RotatingFrame

--- a/src/rotating_frame/advection_driver.cpp
+++ b/src/rotating_frame/advection_driver.cpp
@@ -78,7 +78,13 @@ TaskCollection LinearAdvectionStep(Mesh *pmesh, const SimTime &tm, const Real sc
     auto &u0 = pmesh->mesh_data.GetOrAdd("u0", i);
 
     auto start_recv = tl.AddTask(none, parthenon::StartReceiveBoundBufs<any>, u0);
-    auto update = tl.AddTask(start_recv, LagrangeRemap<GEOM>, u0.get(), scdt);
+    auto start_flx_recv = tl.AddTask(none, parthenon::StartReceiveFluxCorrections, u0);
+    auto remap = tl.AddTask(start_recv, LagrangeRemap<GEOM>, u0.get(), scdt);
+    auto send_flx = tl.AddTask(remap, parthenon::LoadAndSendFluxCorrections, u0);
+    auto recv_flx = tl.AddTask(start_flx_recv, parthenon::ReceiveFluxCorrections, u0);
+    auto set_flx = tl.AddTask(recv_flx, parthenon::SetFluxCorrections, u0);
+    auto update = tl.AddTask(remap | set_flx, ArtemisUtils::ApplyUpdate<GEOM>, u0.get(),
+                             u0.get(), 1.0, 0.0, scdt);
     auto set_aux = tl.AddTask(update, ArtemisDerived::SetAuxillaryFields<GEOM>, u0.get());
     auto c2p = tl.AddTask(set_aux, PreCommFillDerived<MeshData<Real>>, u0.get());
     auto bcs = parthenon::AddBoundaryExchangeTasks(c2p, tl, u0, pmesh->multilevel);
@@ -117,7 +123,8 @@ TaskStatus LagrangeRemap(MeshData<Real> *u0, const Real scdt) {
   static auto desc =
       MakePackDescriptor<gas::cons::density, gas::cons::momentum, gas::cons::total_energy,
                          gas::cons::internal_energy, dust::cons::density,
-                         dust::cons::momentum>(resolved_pkgs.get());
+                         dust::cons::momentum>(resolved_pkgs.get(), {},
+                                               {parthenon::PDOpt::WithFluxes});
   auto v0 = desc.GetPack(u0);
   static auto desc_g =
       MakePackDescriptor<geom::vol, geom::x1v, geom::x2v, geom::x3v, geom::dx1, geom::dx2,

--- a/src/rotating_frame/params.yaml
+++ b/src/rotating_frame/params.yaml
@@ -13,7 +13,7 @@ rotating_frame:
   gm:
     _type: Real
     _default: 0.0
-    _description: "GM of central point mass for orbital advection. If zero, attempts to source from gravity package."
+    _description: "GM of central point mass for orbital advection. Used to compute the Keplerian rotation rate."
   reconstruct:
     _type: string
     _default: plm

--- a/src/rotating_frame/params.yaml
+++ b/src/rotating_frame/params.yaml
@@ -10,6 +10,10 @@ rotating_frame:
     _type: Real
     _default: 0.0
     _description: "Shear rate of the shearing box. Set to -1.5 for Keplerian shear."
+  gm:
+    _type: Real
+    _default: 0.0
+    _description: "GM of central point mass for orbital advection. If zero, attempts to source from gravity package."
   reconstruct:
     _type: string
     _default: plm

--- a/src/rotating_frame/rotating_frame.cpp
+++ b/src/rotating_frame/rotating_frame.cpp
@@ -129,7 +129,7 @@ TaskStatus RotatingFrameForce(MeshData<Real> *md, const Real time, const Real dt
 
   // Switch for the different implementations based on coordinate system
   if (coords == Coordinates::cartesian) {
-    return ShearingBoxImpl(md, om0, qshear, do_gas, do_dust, dt);
+    return ShearingBoxImpl(md, om0, qshear, do_oa, do_gas, do_dust, dt);
   } else if (coords == Coordinates::axisymmetric) {
     return RotatingFrameImpl<Coordinates::axisymmetric>(md, om0, do_oa, gm, do_gas,
                                                         do_dust, dt);

--- a/src/rotating_frame/rotating_frame.cpp
+++ b/src/rotating_frame/rotating_frame.cpp
@@ -120,23 +120,31 @@ TaskStatus RotatingFrameForce(MeshData<Real> *md, const Real time, const Real dt
   const bool do_dust = artemis_pkg->Param<bool>("do_dust");
   const auto coords = artemis_pkg->Param<Coordinates>("coords");
 
+  const bool do_rotating_frame = artemis_pkg->Param<bool>("do_rotating_frame");
   auto &rframe_pkg = pm->packages.Get("rotating_frame");
-  const Real om0 = rframe_pkg->Param<Real>("omega");
+  const Real om0 = do_rotating_frame ? rframe_pkg->Param<Real>("omega") : 0.0;
   const Real qshear = rframe_pkg->Param<Real>("qshear");
+  const bool do_oa = rframe_pkg->Param<bool>("do_orbital_advection");
+  const Real gm = rframe_pkg->Param<Real>("gm");
 
   // Switch for the different implementations based on coordinate system
   if (coords == Coordinates::cartesian) {
     return ShearingBoxImpl(md, om0, qshear, do_gas, do_dust, dt);
   } else if (coords == Coordinates::axisymmetric) {
-    return RotatingFrameImpl<Coordinates::axisymmetric>(md, om0, do_gas, do_dust, dt);
+    return RotatingFrameImpl<Coordinates::axisymmetric>(md, om0, do_oa, gm, do_gas,
+                                                        do_dust, dt);
   } else if (coords == Coordinates::spherical1D) {
-    return RotatingFrameImpl<Coordinates::spherical1D>(md, om0, do_gas, do_dust, dt);
+    return RotatingFrameImpl<Coordinates::spherical1D>(md, om0, do_oa, gm, do_gas,
+                                                       do_dust, dt);
   } else if (coords == Coordinates::spherical2D) {
-    return RotatingFrameImpl<Coordinates::spherical2D>(md, om0, do_gas, do_dust, dt);
+    return RotatingFrameImpl<Coordinates::spherical2D>(md, om0, do_oa, gm, do_gas,
+                                                       do_dust, dt);
   } else if (coords == Coordinates::spherical3D) {
-    return RotatingFrameImpl<Coordinates::spherical3D>(md, om0, do_gas, do_dust, dt);
+    return RotatingFrameImpl<Coordinates::spherical3D>(md, om0, do_oa, gm, do_gas,
+                                                       do_dust, dt);
   } else if (coords == Coordinates::cylindrical) {
-    return RotatingFrameImpl<Coordinates::cylindrical>(md, om0, do_gas, do_dust, dt);
+    return RotatingFrameImpl<Coordinates::cylindrical>(md, om0, do_oa, gm, do_gas,
+                                                       do_dust, dt);
   } else {
     PARTHENON_FAIL("Rotating frame is not consistent with this coordinate system");
   }

--- a/src/rotating_frame/rotating_frame.cpp
+++ b/src/rotating_frame/rotating_frame.cpp
@@ -184,9 +184,8 @@ Real EstimateTimestep(parthenon::Mesh *pmesh, const Real dt_ratio) {
       min_dt = std::min(min_dt, dx2 / std::max(std::abs(wp[1]), std::abs(wm[1])));
     } else if constexpr (GEOM == Coordinates::cylindrical) {
       const Real Rmin = reg.xmin_[0];
-      const Real zmin = reg.xmin_[2];
       const Real dphi = (reg.xmax_[1] - reg.xmin_[1]) / reg.nx_[1];
-      const Real omega_max = OmegaKep(gm, Rmin, zmin) - om0;
+      const Real omega_max = OmegaKep(gm, Rmin) - om0;
       min_dt = std::min(min_dt, dphi / std::abs(omega_max));
     } else if constexpr (GEOM == Coordinates::spherical3D) {
       const Real rmin = reg.xmin_[0];

--- a/src/rotating_frame/rotating_frame.cpp
+++ b/src/rotating_frame/rotating_frame.cpp
@@ -182,6 +182,9 @@ Real EstimateTimestep(parthenon::Mesh *pmesh, const Real dt_ratio) {
   const Real &cfl = rframe_pkg->template Param<Real>("cfl");
 
   // Compute linear advection timestep to sub-cycle
+  const bool log_coords = pmesh->packages.Get("artemis")
+                              ->template Param<geometry::CoordParams>("coord_params")
+                              .log;
   Real min_dt = Big<Real>();
   for (auto const &pmb : pmesh->block_list) {
     [[maybe_unused]] const auto &reg = pmb->block_size;
@@ -191,12 +194,14 @@ Real EstimateTimestep(parthenon::Mesh *pmesh, const Real dt_ratio) {
       const Real dx2 = (reg.xmax_[1] - reg.xmin_[1]) / reg.nx_[1];
       min_dt = std::min(min_dt, dx2 / std::max(std::abs(wp[1]), std::abs(wm[1])));
     } else if constexpr (GEOM == Coordinates::cylindrical) {
-      const Real Rmin = reg.xmin_[0];
+      // For log-R coordinates reg.xmin_[0] stores log(Rmin), not Rmin
+      const Real Rmin = log_coords ? std::exp(reg.xmin_[0]) : reg.xmin_[0];
       const Real dphi = (reg.xmax_[1] - reg.xmin_[1]) / reg.nx_[1];
       const Real omega_max = OmegaKep(gm, Rmin) - om0;
       min_dt = std::min(min_dt, dphi / std::abs(omega_max));
     } else if constexpr (GEOM == Coordinates::spherical3D) {
-      const Real rmin = reg.xmin_[0];
+      // For log-r coordinates reg.xmin_[0] stores log(rmin), not rmin
+      const Real rmin = log_coords ? std::exp(reg.xmin_[0]) : reg.xmin_[0];
       const Real dphi = (reg.xmax_[2] - reg.xmin_[2]) / reg.nx_[2];
       const Real omega_max = OmegaKep(gm, rmin) - om0;
       min_dt = std::min(min_dt, dphi / std::abs(omega_max));

--- a/src/rotating_frame/rotating_frame.cpp
+++ b/src/rotating_frame/rotating_frame.cpp
@@ -26,20 +26,51 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   auto rframe_pkg = std::make_shared<StateDescriptor>("rotating_frame");
   Params &params = rframe_pkg->AllParams();
 
-  const Real omega = pin->GetReal("rotating_frame", "omega");
+  const Real omega = pin->GetOrAddReal("rotating_frame", "omega", 0.0);
   const Real qshear = pin->GetOrAddReal("rotating_frame", "qshear", 0.0);
-  PARTHENON_REQUIRE(omega != 0.0, "rotating_frame/omega cannot be zero! To disable, set "
-                                  "physics/rotating_frame = false");
+  const bool do_rotating_frame = pin->GetOrAddBoolean("physics", "rotating_frame", false);
+  if (do_rotating_frame) {
+    PARTHENON_REQUIRE(omega != 0.0,
+                      "rotating_frame/omega cannot be zero! To disable, set "
+                      "physics/rotating_frame = false");
+  }
+
+  // Coordinates
+  const int ndim = ProblemDimension(pin);
+  std::string sys = pin->GetOrAddString("artemis", "coordinates", "cartesian");
+  Coordinates coords = geometry::CoordSelect(sys, ndim);
+
+  // qshear is only valid for cartesian (shearing box)
   if (qshear != 0) {
-    const std::string sys = pin->GetString("artemis", "coordinates");
     PARTHENON_REQUIRE(
         sys == "cartesian",
         "rotating_frame/qshear must be zero for non-Cartesian coordinate systems!");
     PARTHENON_REQUIRE(parthenon::Globals::nghost >= 2,
                       "Rotating frame advection step requires at least 2 ghost cells.");
   }
+
+  // GM for orbital advection in curvilinear coordinates
+  Real gm = pin->GetOrAddReal("rotating_frame", "gm", 0.0);
+  const bool do_orbital_advection =
+      pin->GetOrAddBoolean("physics", "orbital_advection", false);
+  if (do_orbital_advection) {
+    if (geometry::is_cartesian(coords)) {
+      PARTHENON_REQUIRE(qshear > 0.0, "Cartesian orbital advection requires qshear > 0!");
+      PARTHENON_REQUIRE(do_rotating_frame,
+                        "Cartesian orbital advection requires rotating_frame = true!");
+    } else {
+      PARTHENON_REQUIRE(
+          coords != Coordinates::spherical1D,
+          "Orbital advection cannot be used with 1D spherical coordinates!");
+      PARTHENON_REQUIRE(gm > 0.0,
+                        "Orbital advection in curvilinear coordinates requires gm > 0!");
+    }
+  }
+
   params.Add("omega", omega);
   params.Add("qshear", qshear);
+  params.Add("gm", gm);
+  params.Add("do_orbital_advection", do_orbital_advection);
 
   // Linear advection timestep controls
   const Real cfl = pin->GetOrAddReal("rotating_frame", "cfl", 0.9);
@@ -53,13 +84,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   recon_method = ArtemisUtils::ChooseReconMethod(recon);
   params.Add("recon", recon_method);
 
-  // Coordinates
-  const int ndim = ProblemDimension(pin);
-  std::string sys = pin->GetOrAddString("artemis", "coordinates", "cartesian");
-  Coordinates coords = geometry::CoordSelect(sys, ndim);
   params.Add("coords", coords);
 
-  // Rotating frame timestep (if do_shear)
+  // Rotating frame / orbital advection timestep
   if (coords == Coordinates::cartesian) {
     rframe_pkg->EstimateTimestepMesh = EstimateTimestepMesh<Coordinates::cartesian>;
   } else if (coords == Coordinates::spherical1D) {
@@ -119,38 +146,54 @@ TaskStatus RotatingFrameForce(MeshData<Real> *md, const Real time, const Real dt
 
 //----------------------------------------------------------------------------------------
 //! \fn Real RotatingFrame::EstimateTimestep
-//! \brief Compute multiple of linear advection timestep (if do_shear)
+//! \brief Compute multiple of linear advection timestep (if do_orbital_advection)
 template <Coordinates GEOM>
 Real EstimateTimestepMesh(MeshData<Real> *md) {
   PARTHENON_INSTRUMENT
   auto pmesh = md->GetParentPointer();
-  const bool do_shear = pmesh->packages.Get("artemis")->template Param<bool>("do_shear");
-  if (!(do_shear)) return Big<Real>();
+  const bool do_oa =
+      pmesh->packages.Get("artemis")->template Param<bool>("do_orbital_advection");
+  if (!do_oa) return Big<Real>();
 
   auto &rframe_pkg = pmesh->packages.Get("rotating_frame");
   const Real &dt_ratio = rframe_pkg->template Param<Real>("dt_ratio");
-  return EstimateTimestep(pmesh, dt_ratio);
+  return EstimateTimestep<GEOM>(pmesh, dt_ratio);
 }
 
 //----------------------------------------------------------------------------------------
 //! \fn Real RotatingFrame::EstimateTimeStep
 //! \brief Not enrolled in parthenon's determination for global dt
+template <Coordinates GEOM>
 Real EstimateTimestep(parthenon::Mesh *pmesh, const Real dt_ratio) {
   PARTHENON_INSTRUMENT
   // Extract rotating frame params
   auto &rframe_pkg = pmesh->packages.Get("rotating_frame");
   const Real &om0 = rframe_pkg->Param<Real>("omega");
   const Real &qshear = rframe_pkg->Param<Real>("qshear");
+  const Real &gm = rframe_pkg->Param<Real>("gm");
   const Real &cfl = rframe_pkg->template Param<Real>("cfl");
 
   // Compute linear advection timestep to sub-cycle
   Real min_dt = Big<Real>();
   for (auto const &pmb : pmesh->block_list) {
-    const auto &reg = pmb->block_size;
-    const auto wp = BackgroundVelocity<Coordinates::cartesian>(qshear, om0, reg.xmax_[0]);
-    const auto wm = BackgroundVelocity<Coordinates::cartesian>(qshear, om0, reg.xmin_[0]);
-    const Real dx2 = (reg.xmax_[1] - reg.xmin_[1]) / reg.nx_[1];
-    min_dt = std::min(min_dt, dx2 / std::max(std::abs(wp[1]), std::abs(wm[1])));
+    [[maybe_unused]] const auto &reg = pmb->block_size;
+    if constexpr (GEOM == Coordinates::cartesian) {
+      const auto wp = BackgroundVelocity<GEOM>(qshear, om0, gm, {reg.xmax_[0], 0.0, 0.0});
+      const auto wm = BackgroundVelocity<GEOM>(qshear, om0, gm, {reg.xmin_[0], 0.0, 0.0});
+      const Real dx2 = (reg.xmax_[1] - reg.xmin_[1]) / reg.nx_[1];
+      min_dt = std::min(min_dt, dx2 / std::max(std::abs(wp[1]), std::abs(wm[1])));
+    } else if constexpr (GEOM == Coordinates::cylindrical) {
+      const Real Rmin = reg.xmin_[0];
+      const Real zmin = reg.xmin_[2];
+      const Real dphi = (reg.xmax_[1] - reg.xmin_[1]) / reg.nx_[1];
+      const Real omega_max = OmegaKep(gm, Rmin, zmin) - om0;
+      min_dt = std::min(min_dt, dphi / std::abs(omega_max));
+    } else if constexpr (GEOM == Coordinates::spherical3D) {
+      const Real rmin = reg.xmin_[0];
+      const Real dphi = (reg.xmax_[2] - reg.xmin_[2]) / reg.nx_[2];
+      const Real omega_max = OmegaKep(gm, rmin) - om0;
+      min_dt = std::min(min_dt, dphi / std::abs(omega_max));
+    }
   }
 #ifdef MPI_PARALLEL
   PARTHENON_MPI_CHECK(MPI_Allreduce(MPI_IN_PLACE, &min_dt, 1, MPI_PARTHENON_REAL, MPI_MIN,
@@ -168,5 +211,12 @@ template Real EstimateTimestepMesh<Coordinates::spherical1D>(MD *md);
 template Real EstimateTimestepMesh<Coordinates::spherical2D>(MD *md);
 template Real EstimateTimestepMesh<Coordinates::spherical3D>(MD *md);
 template Real EstimateTimestepMesh<Coordinates::axisymmetric>(MD *md);
+
+template Real EstimateTimestep<Coordinates::cartesian>(parthenon::Mesh *, const Real);
+template Real EstimateTimestep<Coordinates::cylindrical>(parthenon::Mesh *, const Real);
+template Real EstimateTimestep<Coordinates::spherical1D>(parthenon::Mesh *, const Real);
+template Real EstimateTimestep<Coordinates::spherical2D>(parthenon::Mesh *, const Real);
+template Real EstimateTimestep<Coordinates::spherical3D>(parthenon::Mesh *, const Real);
+template Real EstimateTimestep<Coordinates::axisymmetric>(parthenon::Mesh *, const Real);
 
 } // namespace RotatingFrame

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -187,9 +187,9 @@ KOKKOS_INLINE_FUNCTION std::array<Real, 3> RotationVelocity(const std::array<Rea
 template <Coordinates GEOM>
 struct OrbitalAdvection {
   Real gm, omega_f, qshear, scdt, dwdt;
-  static constexpr bool phi_is_x2 =
-      (GEOM == Coordinates::cartesian || GEOM == Coordinates::cylindrical);
-  static constexpr int phi_idx = phi_is_x2 ? 1 : 2;
+
+  static constexpr int phi_idx =
+      ((GEOM == Coordinates::cartesian) || (GEOM == Coordinates::cylindrical)) ? 1 : 2;
 
   KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real R) const {
     return std::sqrt(gm / (R * R * R));
@@ -329,15 +329,15 @@ struct OrbitalAdvection {
 };
 
 //----------------------------------------------------------------------------------------
-//! \fn  RemapUpdate
+//! \fn  RemapUpdateX2
 //! \brief Conservative intersection-remap update using OrbitalAdvection struct.
 //! Only interior cells (js <= j/jp <= je in the sweep direction) are updated.
 template <Coordinates GEOM, typename V1>
 KOKKOS_INLINE_FUNCTION void
-RemapUpdate(const OrbitalAdvection<GEOM> &oa, const V1 &v0, const ReconInfo &rp,
-            const ReconInfo &r, const Real vb, const int three_d, const int b,
-            const int n, const int k, const int j, const int jp, const int i,
-            const int js, const int je) {
+RemapUpdateX2(const OrbitalAdvection<GEOM> &oa, const V1 &v0, const ReconInfo &rp,
+              const ReconInfo &r, const Real vb, const int three_d, const int b,
+              const int n, const int k, const int j, const int jp, const int i,
+              const int js, const int je) {
   const Real flip = (vb < 0.0) ? -1.0 : 1.0;
   const Real I0 = oa.ComputeI0(r, flip);
   const auto I1 = oa.ComputeI1(r, flip, vb, I0, three_d);
@@ -348,15 +348,32 @@ RemapUpdate(const OrbitalAdvection<GEOM> &oa, const V1 &v0, const ReconInfo &rp,
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn  RemapCons
+//! \fn  RemapUpdateX3
+//! \brief Conservative intersection-remap update using OrbitalAdvection struct.
+//! Only interior cells (ks <= k/kp <= ke in the sweep direction) are updated.
+template <Coordinates GEOM, typename V1>
+KOKKOS_INLINE_FUNCTION void
+RemapUpdateX3(const OrbitalAdvection<GEOM> &oa, const V1 &v0, const ReconInfo &rp,
+              const ReconInfo &r, const Real vb, const int three_d, const int b,
+              const int n, const int k, const int kp, const int j, const int i,
+              const int ks, const int ke) {
+  const Real flip = (vb < 0.0) ? -1.0 : 1.0;
+  const Real I0 = oa.ComputeI0(r, flip);
+  const auto I1 = oa.ComputeI1(r, flip, vb, I0, three_d);
+  const Real dq =
+      (rp.q - ArtemisUtils::VDot(rp.grad, rp.xc)) * I0 + ArtemisUtils::VDot(rp.grad, I1);
+  if (k >= ks && k <= ke) v0(b, n, k, j, i) += dq / r.vol;
+  if (kp >= ks && kp <= ke) v0(b, n, kp, j, i) -= dq / rp.vol;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn  RemapConsX2
 //! \brief Reconstruction and remap sweep along the advection direction.
 template <Coordinates GEOM, Upwind UDIR, ReconstructionMethod R, typename V1, typename V2>
 KOKKOS_INLINE_FUNCTION void
-RemapCons(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
-          const V1 &v0, const V2 &vg, const int multi_d, const int three_d, const int b,
-          const int k, IndexRange jb, const int i) {
-
-  constexpr bool phi_is_x2 = OrbitalAdvection<GEOM>::phi_is_x2;
+RemapConsX2(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
+            const V1 &v0, const V2 &vg, const int multi_d, const int three_d, const int b,
+            const int k, IndexRange jb, const int i) {
 
   // Extract coordinates at the start of the sweep range for vb computation
   geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, jb.s, i);
@@ -383,19 +400,11 @@ RemapCons(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
 
   // Helper to fill ReconInfo with the correct index permutation
   auto fill_ri = [&](ReconInfo &ri, int n, int jsweep) {
-    if constexpr (phi_is_x2) {
-      ri.template fill<GEOM>(cpars, v0, vg, b, n, k, jsweep, i);
-    } else {
-      ri.template fill<GEOM>(cpars, v0, vg, b, n, jsweep, k, i);
-    }
+    ri.template fill<GEOM>(cpars, v0, vg, b, n, k, jsweep, i);
   };
 
   auto get_recon = [&](const ReconInfo &ri, int n, int jsweep) -> std::array<Real, 3> {
-    if constexpr (phi_is_x2) {
-      return recon(cpars, v0, ri.dx, multi_d, three_d, b, n, k, jsweep, i);
-    } else {
-      return recon(cpars, v0, ri.dx, multi_d, three_d, b, n, jsweep, k, i);
-    }
+    return recon(cpars, v0, ri.dx, multi_d, three_d, b, n, k, jsweep, i);
   };
 
   for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
@@ -417,13 +426,77 @@ RemapCons(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
         rd.grad = get_recon(rd, n, jd);
         oa.ApplyGradSkew(rd);
       }
-      if constexpr (phi_is_x2) {
-        RemapUpdate<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, k, j, j + joff, i, jb.s,
+      RemapUpdateX2<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, k, j, j + joff, i, jb.s,
                           jb.e);
-      } else {
-        RemapUpdate<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, j, k, j + joff, i, jb.s,
-                          jb.e);
+      ru = rc;
+      rc = rd;
+    }
+  }
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn  RemapConsX3
+//! \brief Reconstruction and remap sweep along the advection direction.
+template <Coordinates GEOM, Upwind UDIR, ReconstructionMethod R, typename V1, typename V2>
+KOKKOS_INLINE_FUNCTION void
+RemapConsX3(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
+            const V1 &v0, const V2 &vg, const int multi_d, const int three_d, const int b,
+            IndexRange kb, const int j, const int i) {
+
+  // Extract coordinates at the start of the sweep range for vb computation
+  geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), kb.s, j, i);
+  const auto xc0 = coords.GetCellCenter(vg, b, kb.s, j, i);
+
+  // Compute the signed background velocity at this radial position for sweep direction
+  const Real vb = oa.DeltaPhi(xc0);
+
+  // Integer gymnastics for sweep direction
+  int koff = 1;
+  int kstart = kb.e;
+  int kend = kb.s - koff;
+  if constexpr (UDIR == Upwind::l) {
+    koff = -1;
+    kstart = kb.s;
+    kend = kb.e - koff;
+  }
+
+  const auto compare = (UDIR == Upwind::r) ? [](int k, int end) { return k >= end; }
+                                           : [](int k, int end) { return k <= end; };
+
+  ArtemisUtils::ReconGradient<GEOM, R> recon;
+  ReconInfo rd, rc, ru;
+
+  // Helper to fill ReconInfo with the correct index permutation
+  auto fill_ri = [&](ReconInfo &ri, int n, int ksweep) {
+    ri.template fill<GEOM>(cpars, v0, vg, b, n, ksweep, j, i);
+  };
+
+  auto get_recon = [&](const ReconInfo &ri, int n, int ksweep) -> std::array<Real, 3> {
+    return recon(cpars, v0, ri.dx, multi_d, three_d, b, n, ksweep, j, i);
+  };
+
+  for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+    fill_ri(ru, n, kstart + koff);
+    fill_ri(rc, n, kstart);
+    oa.ApplySkew(ru);
+    oa.ApplySkew(rc);
+    ru.grad = get_recon(ru, n, kstart + koff);
+    rc.grad = get_recon(rc, n, kstart);
+    oa.ApplyGradSkew(ru);
+    oa.ApplyGradSkew(rc);
+
+    // Execute remapping "sweep"
+    for (int k = kstart; compare(k, kend); k -= koff) {
+      const int kd = k - koff;
+      if (compare(kd, kend)) {
+        fill_ri(rd, n, kd);
+        oa.ApplySkew(rd);
+        rd.grad = get_recon(rd, n, kd);
+        oa.ApplyGradSkew(rd);
       }
+      RemapUpdateX3<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, k, k + koff, j, i, kb.s,
+                          kb.e);
+
       ru = rc;
       rc = rd;
     }
@@ -460,11 +533,11 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
           const auto xc0 = coords.GetCellCenter(vg, b, k, jb.s, i);
           const Real vb = oa.DeltaPhi(xc0);
           if (vb < 0.0) {
-            RemapCons<GEOM, Upwind::r, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb,
-                                          i);
+            RemapConsX2<GEOM, Upwind::r, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb,
+                                            i);
           } else if (vb > 0.0) {
-            RemapCons<GEOM, Upwind::l, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb,
-                                          i);
+            RemapConsX2<GEOM, Upwind::l, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb,
+                                            i);
           }
         });
   } else if constexpr (GEOM == Coordinates::spherical3D) {
@@ -477,11 +550,11 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
           const auto xc0 = coords.GetCellCenter(vg, b, kb.s, j, i);
           const Real vb = oa.DeltaPhi(xc0);
           if (vb < 0.0) {
-            RemapCons<GEOM, Upwind::r, R>(oa, cpars, v0, vg, multi_d, three_d, b, j, kb,
-                                          i);
+            RemapConsX3<GEOM, Upwind::r, R>(oa, cpars, v0, vg, multi_d, three_d, b, kb, j,
+                                            i);
           } else if (vb > 0.0) {
-            RemapCons<GEOM, Upwind::l, R>(oa, cpars, v0, vg, multi_d, three_d, b, j, kb,
-                                          i);
+            RemapConsX3<GEOM, Upwind::l, R>(oa, cpars, v0, vg, multi_d, three_d, b, kb, j,
+                                            i);
           }
         });
   } else {

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -331,18 +331,20 @@ struct OrbitalAdvection {
 //----------------------------------------------------------------------------------------
 //! \fn  RemapUpdate
 //! \brief Conservative intersection-remap update using OrbitalAdvection struct.
+//! Only interior cells (js <= j/jp <= je in the sweep direction) are updated.
 template <Coordinates GEOM, typename V1>
 KOKKOS_INLINE_FUNCTION void
 RemapUpdate(const OrbitalAdvection<GEOM> &oa, const V1 &v0, const ReconInfo &rp,
             const ReconInfo &r, const Real vb, const int three_d, const int b,
-            const int n, const int k, const int j, const int jp, const int i) {
+            const int n, const int k, const int j, const int jp, const int i,
+            const int js, const int je) {
   const Real flip = (vb < 0.0) ? -1.0 : 1.0;
   const Real I0 = oa.ComputeI0(r, flip);
   const auto I1 = oa.ComputeI1(r, flip, vb, I0, three_d);
   const Real dq =
       (rp.q - ArtemisUtils::VDot(rp.grad, rp.xc)) * I0 + ArtemisUtils::VDot(rp.grad, I1);
-  v0(b, n, k, j, i) += dq / r.vol;
-  v0(b, n, k, jp, i) -= dq / rp.vol;
+  if (j >= js && j <= je) v0(b, n, k, j, i) += dq / r.vol;
+  if (jp >= js && jp <= je) v0(b, n, k, jp, i) -= dq / rp.vol;
 }
 
 //----------------------------------------------------------------------------------------
@@ -416,9 +418,11 @@ RemapCons(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
         oa.ApplyGradSkew(rd);
       }
       if constexpr (phi_is_x2) {
-        RemapUpdate<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, k, j, j + joff, i);
+        RemapUpdate<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, k, j, j + joff, i, jb.s,
+                          jb.e);
       } else {
-        RemapUpdate<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, j, k, j + joff, i);
+        RemapUpdate<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, j, k, j + joff, i, jb.s,
+                          jb.e);
       }
       ru = rc;
       rc = rd;

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -235,23 +235,26 @@ struct OrbitalAdvection {
 
   KOKKOS_INLINE_FUNCTION void ApplyGradSkew(ReconInfo &ri) const {
     if constexpr (GEOM == Coordinates::cartesian) {
-      ri.grad[0] += dwdt * ri.grad[phi_idx];
+      ri.grad[phi_idx] += dwdt * ri.grad[0];
     } else if constexpr (GEOM == Coordinates::cylindrical) {
       const Real Rc = ri.xc[0];
       const Real dOdR = -1.5 * OmegaKep(Rc) / Rc;
-      ri.grad[0] += dOdR * ri.grad[phi_idx] * scdt;
+      ri.grad[phi_idx] += dOdR * ri.grad[0] * scdt;
     } else {
       const Real rc = ri.xc[0];
       const Real dOdr = -1.5 * OmegaKep(rc) / rc;
-      ri.grad[0] += dOdr * ri.grad[phi_idx] * scdt;
+      ri.grad[phi_idx] += dOdr * ri.grad[0] * scdt;
     }
   }
 
   KOKKOS_INLINE_FUNCTION bool RootInInterval(const Real x1m, const Real x1p,
                                              Real &xroot) const {
     if constexpr (GEOM == Coordinates::cartesian) {
+      xroot = 0.0;
       return x1m * x1p < 0.0;
     } else {
+      if (omega_f <= 0.0 || gm <= 0.0) return false;
+      xroot = std::cbrt(gm / (omega_f * omega_f));
       return (OmegaKep(x1m) - omega_f) * (OmegaKep(x1p) - omega_f) < 0.0;
     }
   }

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -102,13 +102,6 @@ KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real gm, const Real R, const Rea
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn  Real RotatingFrame::PowerInt
-//! \brief Computes the definite integral of a power-law
-KOKKOS_FORCEINLINE_FUNCTION Real PowerInt(const Real lo, const Real hi, const Real n) {
-  return (std::pow(hi, n + 1.0) - std::pow(lo, n + 1.0)) / (n + 1.0);
-}
-
-//----------------------------------------------------------------------------------------
 //! \fn std::array<Real, 3> RotatingFrame::BackgroundVelocity
 //! \brief Returns the background velocity in coordinate basis.
 template <Coordinates GEOM>
@@ -211,112 +204,187 @@ KOKKOS_INLINE_FUNCTION std::array<Real, 3> RotationVelocity(const std::array<Rea
 }
 
 //----------------------------------------------------------------------------------------
+//! \struct OrbitalAdvection
+//! \brief Bundles orbital advection parameters and geometry-dispatched methods.
+template <Coordinates GEOM>
+struct OrbitalAdvection {
+  Real gm, omega_f, qshear, scdt, dwdt;
+  static constexpr bool phi_is_x2 =
+      (GEOM == Coordinates::cartesian || GEOM == Coordinates::cylindrical);
+  static constexpr int phi_idx = phi_is_x2 ? 1 : 2;
+
+  KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real R) const {
+    return std::sqrt(gm / (R * R * R));
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real R, const Real z) const {
+    return OmegaKep(R) * (1.0 - 0.75 * z * z / (R * R));
+  }
+
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3>
+  BackgroundVelocity(const std::array<Real, 3> &xv) const {
+    if constexpr (GEOM == Coordinates::cartesian) {
+      return {0.0, -qshear * omega_f * xv[0], 0.0};
+    } else if constexpr (GEOM == Coordinates::cylindrical) {
+      const Real R = xv[0];
+      const Real z = xv[2];
+      const Real vphi = R * (OmegaKep(R, z) - omega_f);
+      return {0.0, vphi, 0.0};
+    } else if constexpr (GEOM == Coordinates::spherical3D ||
+                         GEOM == Coordinates::spherical2D) {
+      const Real R = xv[0] * std::sin(xv[1]);
+      const Real vphi = R * (OmegaKep(xv[0]) - omega_f);
+      return {0.0, 0.0, vphi};
+    } else if constexpr (GEOM == Coordinates::axisymmetric) {
+      const Real R = xv[0];
+      const Real z = xv[1];
+      const Real vphi = R * (OmegaKep(R, z) - omega_f);
+      return {0.0, 0.0, vphi};
+    }
+    return {0.0, 0.0, 0.0};
+  }
+
+  KOKKOS_INLINE_FUNCTION Real DeltaPhi(const std::array<Real, 3> &xc) const {
+    if constexpr (GEOM == Coordinates::cartesian) {
+      return dwdt * xc[0];
+    } else if constexpr (GEOM == Coordinates::cylindrical) {
+      return (OmegaKep(xc[0], xc[2]) - omega_f) * scdt;
+    } else {
+      return (OmegaKep(xc[0]) - omega_f) * scdt;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION void ApplySkew(ReconInfo &ri) const {
+    ri.xc[phi_idx] += DeltaPhi(ri.xc);
+  }
+
+  KOKKOS_INLINE_FUNCTION void ApplyGradSkew(ReconInfo &ri) const {
+    if constexpr (GEOM == Coordinates::cartesian) {
+      ri.grad[phi_idx] += dwdt * ri.grad[0];
+    } else if constexpr (GEOM == Coordinates::cylindrical) {
+      const Real Rc = ri.xc[0];
+      const Real zc = ri.xc[2];
+      const Real om_k = OmegaKep(Rc);
+      const Real zR2 = zc * zc / (Rc * Rc);
+      const Real dOdR = -1.5 * om_k / Rc * (1.0 - 1.75 * zR2);
+      const Real dOdz = -1.5 * om_k * zc / (Rc * Rc);
+      ri.grad[phi_idx] += (dOdR * ri.grad[0] + dOdz * ri.grad[2]) * scdt;
+    } else {
+      const Real rc = ri.xc[0];
+      const Real dOdr = -1.5 * OmegaKep(rc) / rc;
+      ri.grad[phi_idx] += dOdr * ri.grad[0] * scdt;
+    }
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION Real PowerInt(const Real lo, const Real hi,
+                                            const Real n) const {
+    return (std::pow(hi, n + 1.0) - std::pow(lo, n + 1.0)) / (n + 1.0);
+  }
+  KOKKOS_INLINE_FUNCTION Real ComputeI0(const ReconInfo &r, const Real flip) const {
+    if constexpr (GEOM == Coordinates::cartesian) {
+      return flip * dwdt * r.xc[0] * r.dx[0] * r.dx[2];
+    } else if constexpr (GEOM == Coordinates::cylindrical) {
+      const Real alpha = std::sqrt(gm) * scdt;
+      const Real beta = -0.75 * alpha;
+      const Real omf_dt = omega_f * scdt;
+      const Real Rm = r.bnds.x1[0], Rp = r.bnds.x1[1];
+      const Real zm = r.bnds.x3[0], zp = r.bnds.x3[1];
+      const Real Q0 = zp - zm;
+      const Real Q2 = (zp * zp * zp - zm * zm * zm) / 3.0;
+      return flip *
+             (alpha * PowerInt(Rm, Rp, -0.5) * Q0 + beta * PowerInt(Rm, Rp, -2.5) * Q2 -
+              omf_dt * PowerInt(Rm, Rp, 1.0) * Q0);
+    } else {
+      const Real alpha = std::sqrt(gm) * scdt;
+      const Real omf_dt = omega_f * scdt;
+      const Real rm = r.bnds.x1[0], rp = r.bnds.x1[1];
+      const Real thm = r.bnds.x2[0], thp = r.bnds.x2[1];
+      const Real Sth = std::cos(thm) - std::cos(thp);
+      return flip * Sth *
+             (alpha * PowerInt(rm, rp, 0.5) - omf_dt * PowerInt(rm, rp, 2.0));
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION std::array<Real, 3> ComputeI1(const ReconInfo &r,
+                                                       const Real flip, const Real vb,
+                                                       const Real I0,
+                                                       const int three_d) const {
+    if constexpr (GEOM == Coordinates::cartesian) {
+      const Real dz = r.dx[2];
+      const Real dxcub =
+          r.dx[0] / 3.0 *
+          (SQR(r.bnds.x1[0]) + r.bnds.x1[0] * r.bnds.x1[1] + SQR(r.bnds.x1[1]));
+      const Real y0 = r.bnds.x2[(vb < 0.0)];
+      return {flip * dwdt * dxcub * dz,
+              flip * (0.5 * SQR(dwdt) * dxcub * dz + y0 * dwdt * r.xc[0] * r.dx[0] * dz),
+              three_d * r.xc[2] * I0};
+    } else if constexpr (GEOM == Coordinates::cylindrical) {
+      const Real alpha = std::sqrt(gm) * scdt;
+      const Real beta = -0.75 * alpha;
+      const Real omf_dt = omega_f * scdt;
+      const Real Rm = r.bnds.x1[0], Rp = r.bnds.x1[1];
+      const Real zm = r.bnds.x3[0], zp = r.bnds.x3[1];
+      const Real zp2 = SQR(zp), zm2 = SQR(zm);
+      const Real Q0 = zp - zm;
+      const Real Q1 = 0.5 * (zp2 - zm2);
+      const Real Q2 = (zp * zp2 - zm * zm2) / 3.0;
+      const Real Q3 = 0.25 * (SQR(zp2) - SQR(zm2));
+      const Real Q4 = (std::pow(zp, 5) - std::pow(zm, 5)) / 5.0;
+
+      const Real R05 = PowerInt(Rm, Rp, -0.5);
+      const Real R10 = PowerInt(Rm, Rp, 1.0);
+      const Real R25 = PowerInt(Rm, Rp, -2.5);
+
+      const Real I1R = flip * (alpha * PowerInt(Rm, Rp, 0.5) * Q0 +
+                               beta * PowerInt(Rm, Rp, -1.5) * Q2 -
+                               omf_dt * PowerInt(Rm, Rp, 2.0) * Q0);
+      const Real phi0 = r.bnds.x2[(vb < 0.0)];
+      const Real dphi2_int =
+          0.5 * flip *
+          (SQR(alpha) * PowerInt(Rm, Rp, -2.0) * Q0 +
+           2.0 * alpha * beta * PowerInt(Rm, Rp, -4.0) * Q2 +
+           SQR(beta) * PowerInt(Rm, Rp, -6.0) * Q4 - 2.0 * alpha * omf_dt * R05 * Q0 -
+           2.0 * beta * omf_dt * R25 * Q2 + SQR(omf_dt) * R10 * Q0);
+      const Real I1phi = phi0 * I0 + dphi2_int;
+      const Real I1z = flip * (alpha * R05 * Q1 + beta * R25 * Q3 - omf_dt * R10 * Q1);
+      return {I1R, I1phi, I1z};
+    } else {
+      const Real alpha = std::sqrt(gm) * scdt;
+      const Real omf_dt = omega_f * scdt;
+      const Real rm = r.bnds.x1[0], rp = r.bnds.x1[1];
+      const Real thm = r.bnds.x2[0], thp = r.bnds.x2[1];
+      const Real cthm = std::cos(thm);
+      const Real cthp = std::cos(thp);
+      const Real sthm = std::sin(thm);
+      const Real sthp = std::sin(thp);
+      const Real Sth = cthm - cthp;
+      const Real Tth = (sthp - thp * cthp) - (sthm - thm * cthm);
+
+      const Real I1r =
+          flip * Sth * (alpha * PowerInt(rm, rp, 1.5) - omf_dt * PowerInt(rm, rp, 3.0));
+      const Real I1th = (Sth != 0.0) ? (Tth / Sth) * I0 : r.xc[1] * I0;
+      const Real phi0 = r.bnds.x3[(vb < 0.0)];
+      const Real dphi2_int =
+          0.5 * flip * Sth *
+          (SQR(alpha) * std::log(rp / rm) - 2.0 * alpha * omf_dt * PowerInt(rm, rp, 0.5) +
+           SQR(omf_dt) * PowerInt(rm, rp, 2.0));
+      const Real I1phi = phi0 * I0 + dphi2_int;
+      return {I1r, I1th, I1phi};
+    }
+  }
+};
+
+//----------------------------------------------------------------------------------------
 //! \fn  RemapUpdate
-//! \brief Conservative intersection-remap update.
-//!        Computes overlap volume integrals for the exact intersection
-//!        geometry appropriate to each coordinate system.
+//! \brief Conservative intersection-remap update using OrbitalAdvection struct.
 template <Coordinates GEOM, typename V1>
 KOKKOS_INLINE_FUNCTION void
-RemapUpdate(const V1 &v0, const ReconInfo &rp, const ReconInfo &r, const Real vb,
-            const Real dwdt, const Real gm, const Real omega_f, const Real scdt,
-            const int three_d, const int b, const int n, const int k, const int j,
-            const int jp, const int i) {
-
+RemapUpdate(const OrbitalAdvection<GEOM> &oa, const V1 &v0, const ReconInfo &rp,
+            const ReconInfo &r, const Real vb, const int three_d, const int b,
+            const int n, const int k, const int j, const int jp, const int i) {
   const Real flip = (vb < 0.0) ? -1.0 : 1.0;
-
-  Real I0 = 0.0;
-  std::array<Real, 3> I1 = {0.0, 0.0, 0.0};
-
-  if constexpr (GEOM == Coordinates::cartesian) {
-    // shearing box integrals
-    const Real y0 = r.bnds.x2[(vb < 0.0)];
-    const Real dz = r.dx[2];
-    I0 = flip * dwdt * r.xc[0] * r.dx[0] * dz;
-    const Real dxcub =
-        r.dx[0] / 3.0 *
-        (SQR(r.bnds.x1[0]) + r.bnds.x1[0] * r.bnds.x1[1] + SQR(r.bnds.x1[1]));
-    I1 = {flip * dwdt * dxcub * dz,
-          flip * (0.5 * SQR(dwdt) * dxcub * dz + y0 * dwdt * r.xc[0] * r.dx[0] * dz),
-          three_d * r.xc[2] * I0};
-  } else if constexpr (GEOM == Coordinates::cylindrical) {
-    const Real alpha = std::sqrt(gm) * scdt;
-    const Real beta = -0.75 * alpha;
-    const Real omf_dt = omega_f * scdt;
-
-    const Real Rm = r.bnds.x1[0], Rp = r.bnds.x1[1];
-    const Real zm = r.bnds.x3[0], zp = r.bnds.x3[1];
-
-    const Real P_mhalf = PowerInt(Rm, Rp, -0.5);
-    const Real P_m5half = PowerInt(Rm, Rp, -2.5);
-    const Real P1 = PowerInt(Rm, Rp, 1.0);
-    const Real P_half = PowerInt(Rm, Rp, 0.5);
-    const Real P_m3half = PowerInt(Rm, Rp, -1.5);
-    const Real P2 = PowerInt(Rm, Rp, 2.0);
-
-    const Real zp2 = SQR(zp);
-    const Real zm2 = SQR(zm);
-    const Real Q0 = zp - zm;
-    const Real Q1 = 0.5 * (zp2 - zm2);
-    const Real Q2 = (zp * zp2 - zm * zm2) / 3.0;
-    const Real Q3 = 0.25 * (SQR(zp2) - SQR(zm2));
-
-    // Volume overlap
-    I0 = flip * (alpha * P_mhalf * Q0 + beta * P_m5half * Q2 - omf_dt * P1 * Q0);
-
-    // First moments
-    const Real I1R =
-        flip * (alpha * P_half * Q0 + beta * P_m3half * Q2 - omf_dt * P2 * Q0);
-
-    const Real phi0 = r.bnds.x2[(vb < 0.0)];
-    const Real Q4 = (std::pow(zp, 5) - std::pow(zm, 5)) / 5.0;
-    const Real dphi2_int =
-        0.5 * flip *
-        (SQR(alpha) * PowerInt(Rm, Rp, -2.0) * Q0 +
-         2.0 * alpha * beta * PowerInt(Rm, Rp, -4.0) * Q2 +
-         SQR(beta) * PowerInt(Rm, Rp, -6.0) * Q4 - 2.0 * alpha * omf_dt * P_mhalf * Q0 -
-         2.0 * beta * omf_dt * P_m5half * Q2 + SQR(omf_dt) * P1 * Q0);
-    const Real I1phi = phi0 * I0 + dphi2_int;
-
-    const Real I1z =
-        flip * (alpha * P_mhalf * Q1 + beta * P_m5half * Q3 - omf_dt * P1 * Q1);
-
-    I1 = {I1R, I1phi, I1z};
-  } else {
-    const Real alpha = std::sqrt(gm) * scdt;
-    const Real omf_dt = omega_f * scdt;
-
-    const Real rm = r.bnds.x1[0], rp = r.bnds.x1[1];
-    const Real thm = r.bnds.x2[0], thp = r.bnds.x2[1];
-
-    const Real P_half = PowerInt(rm, rp, 0.5);
-    const Real P2 = PowerInt(rm, rp, 2.0);
-    const Real P_3half = PowerInt(rm, rp, 1.5);
-    const Real P3 = PowerInt(rm, rp, 3.0);
-
-    const Real cthm = std::cos(thm);
-    const Real cthp = std::cos(thp);
-    const Real sthm = std::sin(thm);
-    const Real sthp = std::sin(thp);
-    const Real Sth = cthm - cthp;
-    const Real Tth = (sthp - thp * cthp) - (sthm - thm * cthm);
-
-    // Volume integral
-    I0 = flip * Sth * (alpha * P_half - omf_dt * P2);
-
-    // First moments
-    const Real I1r = flip * Sth * (alpha * P_3half - omf_dt * P3);
-
-    const Real I1th = (Sth != 0.0) ? (Tth / Sth) * I0 : r.xc[1] * I0;
-
-    const Real phi0 = r.bnds.x3[(vb < 0.0)];
-    const Real dphi2_int = 0.5 * flip * Sth *
-                           (SQR(alpha) * PowerInt(rm, rp, -1.0) -
-                            2.0 * alpha * omf_dt * P_half + SQR(omf_dt) * P2);
-    const Real I1phi = phi0 * I0 + dphi2_int;
-
-    I1 = {I1r, I1th, I1phi};
-  }
-  // Final changes
+  const Real I0 = oa.ComputeI0(r, flip);
+  const auto I1 = oa.ComputeI1(r, flip, vb, I0, three_d);
   const Real dq =
       (rp.q - ArtemisUtils::VDot(rp.grad, rp.xc)) * I0 + ArtemisUtils::VDot(rp.grad, I1);
   v0(b, n, k, j, i) += dq / r.vol;
@@ -327,32 +395,19 @@ RemapUpdate(const V1 &v0, const ReconInfo &rp, const ReconInfo &r, const Real vb
 //! \fn  RemapCons
 //! \brief Reconstruction and remap sweep along the advection direction.
 template <Coordinates GEOM, Upwind UDIR, ReconstructionMethod R, typename V1, typename V2>
-KOKKOS_INLINE_FUNCTION void RemapCons(const geometry::CoordParams &cpars, const V1 &v0,
-                                      const V2 &vg, const int multi_d, const int three_d,
-                                      const Real dwdt, const Real gm, const Real omega_f,
-                                      const Real scdt, const int b, const int k,
-                                      IndexRange jb, const int i) {
+KOKKOS_INLINE_FUNCTION void
+RemapCons(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
+          const V1 &v0, const V2 &vg, const int multi_d, const int three_d, const int b,
+          const int k, IndexRange jb, const int i) {
 
-  constexpr bool phi_is_x2 =
-      (GEOM == Coordinates::cartesian || GEOM == Coordinates::cylindrical);
-  constexpr int phi_idx = phi_is_x2 ? 1 : 2;
-  constexpr int rad_idx = 0;
+  constexpr bool phi_is_x2 = OrbitalAdvection<GEOM>::phi_is_x2;
 
   // Extract coordinates at the start of the sweep range for vb computation
   geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, jb.s, i);
   const auto xc0 = coords.GetCellCenter(vg, b, k, jb.s, i);
 
   // Compute the signed background velocity at this radial position for sweep direction
-  Real vb = 0.0;
-  if constexpr (GEOM == Coordinates::cartesian) {
-    vb = dwdt * xc0[0];
-  } else if constexpr (GEOM == Coordinates::cylindrical) {
-    const Real om = OmegaKep(gm, xc0[0], xc0[2]) - omega_f;
-    vb = om * xc0[0];
-  } else if constexpr (GEOM == Coordinates::spherical3D) {
-    const Real om = OmegaKep(gm, xc0[0]) - omega_f;
-    vb = om * xc0[0] * std::sin(xc0[1]);
-  }
+  const Real vb = oa.DeltaPhi(xc0);
 
   // Integer gymnastics for sweep direction
   int joff = 1;
@@ -369,38 +424,6 @@ KOKKOS_INLINE_FUNCTION void RemapCons(const geometry::CoordParams &cpars, const 
 
   ArtemisUtils::ReconGradient<GEOM, R> recon;
   ReconInfo rd, rc, ru;
-
-  // Helper lambda to compute the skew correction for centroids and gradients.
-  auto apply_skew = [&](ReconInfo &ri) {
-    if constexpr (GEOM == Coordinates::cartesian) {
-      ri.xc[phi_idx] += dwdt * ri.xc[rad_idx];
-    } else if constexpr (GEOM == Coordinates::cylindrical) {
-      const Real Rc = ri.xc[0];
-      const Real zc = ri.xc[2];
-      ri.xc[phi_idx] += (OmegaKep(gm, Rc, zc) - omega_f) * scdt;
-    } else {
-      const Real rc = ri.xc[0];
-      ri.xc[phi_idx] += (OmegaKep(gm, rc) - omega_f) * scdt;
-    }
-  };
-
-  auto apply_grad_skew = [&](ReconInfo &ri) {
-    if constexpr (GEOM == Coordinates::cartesian) {
-      ri.grad[phi_idx] += dwdt * ri.grad[rad_idx];
-    } else if constexpr (GEOM == Coordinates::cylindrical) {
-      const Real Rc = ri.xc[0];
-      const Real zc = ri.xc[2];
-      const Real om_k = OmegaKep(gm, Rc);
-      const Real zR2 = zc * zc / (Rc * Rc);
-      const Real dOdR = -1.5 * om_k / Rc * (1.0 - 1.75 * zR2);
-      const Real dOdz = -1.5 * om_k * zc / (Rc * Rc);
-      ri.grad[phi_idx] += (dOdR * ri.grad[0] + dOdz * ri.grad[2]) * scdt;
-    } else {
-      const Real rc = ri.xc[0];
-      const Real dOdr = -1.5 * OmegaKep(gm, rc) / rc;
-      ri.grad[phi_idx] += dOdr * ri.grad[0] * scdt;
-    }
-  };
 
   // Helper to fill ReconInfo with the correct index permutation
   auto fill_ri = [&](ReconInfo &ri, int n, int jsweep) {
@@ -422,28 +445,26 @@ KOKKOS_INLINE_FUNCTION void RemapCons(const geometry::CoordParams &cpars, const 
   for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
     fill_ri(ru, n, jstart + joff);
     fill_ri(rc, n, jstart);
-    apply_skew(ru);
-    apply_skew(rc);
+    oa.ApplySkew(ru);
+    oa.ApplySkew(rc);
     ru.grad = get_recon(ru, n, jstart + joff);
     rc.grad = get_recon(rc, n, jstart);
-    apply_grad_skew(ru);
-    apply_grad_skew(rc);
+    oa.ApplyGradSkew(ru);
+    oa.ApplyGradSkew(rc);
 
     // Execute remapping "sweep"
     for (int j = jstart; compare(j, jend); j -= joff) {
       const int jd = j - joff;
       if (compare(jd, jend)) {
         fill_ri(rd, n, jd);
-        apply_skew(rd);
+        oa.ApplySkew(rd);
         rd.grad = get_recon(rd, n, jd);
-        apply_grad_skew(rd);
+        oa.ApplyGradSkew(rd);
       }
       if constexpr (phi_is_x2) {
-        RemapUpdate<GEOM>(v0, ru, rc, vb, dwdt, gm, omega_f, scdt, three_d, b, n, k, j,
-                          j + joff, i);
+        RemapUpdate<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, k, j, j + joff, i);
       } else {
-        RemapUpdate<GEOM>(v0, ru, rc, vb, dwdt, gm, omega_f, scdt, three_d, b, n, j, k,
-                          j + joff, i);
+        RemapUpdate<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, j, k, j + joff, i);
       }
       ru = rc;
       rc = rd;
@@ -469,6 +490,8 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
   IndexRange jb = u0->GetBoundsJ(IndexDomain::interior);
   IndexRange kb = u0->GetBoundsK(IndexDomain::interior);
 
+  const OrbitalAdvection<GEOM> oa{gm, omega_f, 0.0, scdt, dwdt};
+
   if constexpr ((GEOM == Coordinates::cartesian || GEOM == Coordinates::cylindrical)) {
     // Outer loop over (k, i); inner sweep over j
     parthenon::par_for(
@@ -477,15 +500,13 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
         KOKKOS_LAMBDA(const int &b, const int &k, const int &i) {
           geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, jb.s, i);
           const auto xc0 = coords.GetCellCenter(vg, b, k, jb.s, i);
-          const Real vb = (GEOM == Coordinates::cartesian)
-                              ? (dwdt * 0.5 * (coords.bnds.x1[0] + coords.bnds.x1[1]))
-                              : ((OmegaKep(gm, xc0[0], xc0[2]) - omega_f) * scdt);
+          const Real vb = oa.DeltaPhi(xc0);
           if (vb < 0.0) {
-            RemapCons<GEOM, Upwind::r, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
-                                          omega_f, scdt, b, k, jb, i);
+            RemapCons<GEOM, Upwind::r, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb,
+                                          i);
           } else if (vb > 0.0) {
-            RemapCons<GEOM, Upwind::l, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
-                                          omega_f, scdt, b, k, jb, i);
+            RemapCons<GEOM, Upwind::l, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb,
+                                          i);
           }
         });
   } else if constexpr (GEOM == Coordinates::spherical3D) {
@@ -496,14 +517,13 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
         KOKKOS_LAMBDA(const int &b, const int &j, const int &i) {
           geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), kb.s, j, i);
           const auto xc0 = coords.GetCellCenter(vg, b, kb.s, j, i);
-          const Real Rc = xc0[0];
-          const Real vb = (OmegaKep(gm, Rc) - omega_f) * scdt;
+          const Real vb = oa.DeltaPhi(xc0);
           if (vb < 0.0) {
-            RemapCons<GEOM, Upwind::r, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
-                                          omega_f, scdt, b, j, kb, i);
+            RemapCons<GEOM, Upwind::r, R>(oa, cpars, v0, vg, multi_d, three_d, b, j, kb,
+                                          i);
           } else if (vb > 0.0) {
-            RemapCons<GEOM, Upwind::l, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
-                                          omega_f, scdt, b, j, kb, i);
+            RemapCons<GEOM, Upwind::l, R>(oa, cpars, v0, vg, multi_d, three_d, b, j, kb,
+                                          i);
           }
         });
   } else {

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -30,6 +30,8 @@ using namespace parthenon::package::prelude;
 using ArtemisUtils::PLM;
 using ArtemisUtils::VI;
 
+#define CUB(x) ((x) * (x) * (x))
+
 namespace RotatingFrame {
 
 //----------------------------------------------------------------------------------------
@@ -39,14 +41,18 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 template <Coordinates GEOM>
 Real EstimateTimestepMesh(MeshData<Real> *md);
 
+template <Coordinates GEOM>
 Real EstimateTimestep(parthenon::Mesh *pmesh, const Real dt_ratio);
 
 TaskStatus RotatingFrameForce(MeshData<Real> *md, const Real time, const Real dt);
 
+template <Coordinates GEOM>
 TaskListStatus Advect(Mesh *pmesh, const SimTime &tm);
 
+template <Coordinates GEOM>
 TaskCollection LinearAdvectionStep(Mesh *pmesh, const SimTime &tm, const Real scdt);
 
+template <Coordinates GEOM>
 TaskStatus LagrangeRemap(MeshData<Real> *u0, const Real scdt);
 
 struct ReconInfo {
@@ -58,18 +64,18 @@ struct ReconInfo {
   Real vol;
 
   ReconInfo() = default;
-  template <typename V1, typename V2>
+  template <Coordinates GEOM, typename V1, typename V2>
   KOKKOS_INLINE_FUNCTION ReconInfo(const geometry::CoordParams &cpar, const V1 &v0,
                                    const V2 &vg, const int b, const int n, const int k,
                                    const int j, const int i) {
-    fill(cpar, v0, vg, b, n, k, j, i);
+    fill<GEOM>(cpar, v0, vg, b, n, k, j, i);
   }
 
-  template <typename V1, typename V2>
+  template <Coordinates GEOM, typename V1, typename V2>
   KOKKOS_INLINE_FUNCTION void fill(const geometry::CoordParams &cpar, const V1 &v0,
                                    const V2 &vg, const int b, const int n, const int k,
                                    const int j, const int i) {
-    geometry::Coords<Coordinates::cartesian> coords(cpar, v0.GetCoordinates(b), k, j, i);
+    geometry::Coords<GEOM> coords(cpar, v0.GetCoordinates(b), k, j, i);
     dx = coords.GetCellWidths(vg, b, k, j, i);
     xc = coords.GetCellCenter(vg, b, k, j, i);
     vol = coords.GetVolume(vg, b, k, j, i);
@@ -81,13 +87,51 @@ struct ReconInfo {
 };
 
 //----------------------------------------------------------------------------------------
+//! \fn  Real RotatingFrame::OmegaKep
+//! \brief Returns Keplerian angular velocity at spherical radius R
+KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real gm, const Real R) {
+  return std::sqrt(gm / (R * R * R));
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn  Real RotatingFrame::OmegaKep (R, z)
+//! \brief Returns Keplerian angular velocity at cylindrical position (R, z),
+//!        expanded to leading order in (z/R)^2
+KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real gm, const Real R, const Real z) {
+  return OmegaKep(gm, R) * (1.0 - 0.75 * z * z / (R * R));
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn  Real RotatingFrame::PowerInt
+//! \brief Computes the definite integral of a power-law
+KOKKOS_FORCEINLINE_FUNCTION Real PowerInt(const Real lo, const Real hi, const Real n) {
+  return (std::pow(hi, n + 1.0) - std::pow(lo, n + 1.0)) / (n + 1.0);
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn std::array<Real, 3> RotatingFrame::BackgroundVelocity
-//! \brief Returns signed shear velocity
+//! \brief Returns the background velocity in coordinate basis.
 template <Coordinates GEOM>
 KOKKOS_INLINE_FUNCTION std::array<Real, 3>
-BackgroundVelocity(const Real qshear, const Real omega, const Real x1v) {
+BackgroundVelocity(const Real qshear, const Real omega, const Real gm,
+                   const std::array<Real, 3> &xv) {
   if constexpr (GEOM == Coordinates::cartesian) {
-    return {0.0, -qshear * omega * x1v, 0.0};
+    return {0.0, -qshear * omega * xv[0], 0.0};
+  } else if constexpr (GEOM == Coordinates::cylindrical) {
+    const Real R = xv[0];
+    const Real z = xv[2];
+    const Real vphi = R * (OmegaKep(gm, R, z) - omega);
+    return {0.0, vphi, 0.0};
+  } else if constexpr (GEOM == Coordinates::spherical3D ||
+                       GEOM == Coordinates::spherical2D) {
+    const Real R = xv[0] * std::sin(xv[1]);
+    const Real vphi = R * (OmegaKep(gm, xv[0]) - omega);
+    return {0.0, 0.0, vphi};
+  } else if constexpr (GEOM == Coordinates::axisymmetric) {
+    const Real R = xv[0];
+    const Real z = xv[1];
+    const Real vphi = R * (OmegaKep(gm, R, z) - omega);
+    return {0.0, 0.0, vphi};
   }
   return {0.0, 0.0, 0.0};
 }
@@ -95,10 +139,11 @@ BackgroundVelocity(const Real qshear, const Real omega, const Real x1v) {
 //----------------------------------------------------------------------------------------
 //! \fn std::array<Real, 3> RotatingFrame::StrainRate
 //! \brief Returns the strain rate in a given direction associated with the background
+//!        shear/orbital velocity. Computes (grad(v) + grad(v)^T) (no div(v) term).
 template <Coordinates GEOM, parthenon::CoordinateDirection XDIR>
 KOKKOS_INLINE_FUNCTION std::array<Real, 3> StrainRate(const Real qshear, const Real omega,
+                                                      const Real gm,
                                                       const std::array<Real, 3> &xf) {
-  // We are computing (grad(v) + grad(v)^T) (no div(v) term)
   if constexpr (GEOM == Coordinates::cartesian) {
     if constexpr (XDIR == X1DIR) {
       // { T_1^1 , T_2^1 , T_3^1 }
@@ -106,6 +151,43 @@ KOKKOS_INLINE_FUNCTION std::array<Real, 3> StrainRate(const Real qshear, const R
     } else if constexpr (XDIR == X2DIR) {
       // { T_1^2 , T_2^2 , T_3^2 }
       return {-qshear * omega, 0.0, 0.0};
+    }
+  } else if constexpr (GEOM == Coordinates::cylindrical) {
+    const Real R = xf[0];
+    const Real z = xf[2];
+    const Real om_k = OmegaKep(gm, R);
+    const Real zR2 = z * z / (R * R);
+    const Real rdOdR = -1.5 * om_k * (1.0 - 1.75 * zR2);
+    const Real rdOdz = -1.5 * om_k * z / R;
+    if constexpr (XDIR == X1DIR) {
+      return {0.0, rdOdR, 0.0}; // {T_R^R, T_φ^R, T_z^R}
+    } else if constexpr (XDIR == X2DIR) {
+      return {rdOdR, 0.0, rdOdz}; // {T_R^φ, T_φ^φ, T_z^φ}
+    } else if constexpr (XDIR == X3DIR) {
+      return {0.0, rdOdz, 0.0}; // {T_R^z, T_φ^z, T_z^z}
+    }
+  } else if constexpr (GEOM == Coordinates::axisymmetric) {
+    const Real R = xf[0];
+    const Real z = xf[1];
+    const Real om_k = OmegaKep(gm, R);
+    const Real zR2 = z * z / (R * R);
+    const Real rdOdR = -1.5 * om_k * (1.0 - 1.75 * zR2);
+    const Real rdOdz = -1.5 * om_k * z / R;
+    if constexpr (XDIR == X1DIR) {
+      return {0.0, 0.0, rdOdR}; // {T_R^R, T_z^R, T_φ^R}
+    } else if constexpr (XDIR == X2DIR) {
+      return {0.0, 0.0, rdOdz}; // {T_R^z, T_z^z, T_φ^z}
+    } else if constexpr (XDIR == X3DIR) {
+      return {rdOdR, rdOdz, 0.0}; // {T_R^φ, T_z^φ, T_φ^φ}
+    }
+  } else if constexpr (GEOM == Coordinates::spherical3D ||
+                       GEOM == Coordinates::spherical2D) {
+    const Real r = xf[0];
+    const Real rdOdr = -1.5 * OmegaKep(gm, r);
+    if constexpr (XDIR == X1DIR) {
+      return {0.0, 0.0, rdOdr}; // T_φ^r; φ is x3
+    } else if constexpr (XDIR == X3DIR) {
+      return {rdOdr, 0.0, 0.0}; // T_r^φ
     }
   }
   return {0.0, 0.0, 0.0};
@@ -130,28 +212,111 @@ KOKKOS_INLINE_FUNCTION std::array<Real, 3> RotationVelocity(const std::array<Rea
 
 //----------------------------------------------------------------------------------------
 //! \fn  RemapUpdate
-//! \brief
-template <typename V1>
+//! \brief Conservative intersection-remap update.
+//!        Computes overlap volume integrals for the exact intersection
+//!        geometry appropriate to each coordinate system.
+template <Coordinates GEOM, typename V1>
 KOKKOS_INLINE_FUNCTION void
 RemapUpdate(const V1 &v0, const ReconInfo &rp, const ReconInfo &r, const Real vb,
-            const Real dwdt, const int three_d, const int b, const int n, const int k,
-            const int j, const int jp, const int i) {
-  // Upwind::r is vb < 0
-  const Real fac = dwdt;
-  const Real flip = (vb < 0.0) ? -1 : 1;
-  const Real y0 = r.bnds.x2[(vb < 0.0)];
+            const Real dwdt, const Real gm, const Real omega_f, const Real scdt,
+            const int three_d, const int b, const int n, const int k, const int j,
+            const int jp, const int i) {
 
-  const Real dz = r.dx[2];
-  const Real I0 = flip * dwdt * r.xc[0] * r.dx[0] * dz;
-  const Real dxcub =
-      r.dx[0] / 3. *
-      (SQR(r.bnds.x1[0]) + r.bnds.x1[0] * r.bnds.x1[1] + SQR(r.bnds.x1[1]));
+  const Real flip = (vb < 0.0) ? -1.0 : 1.0;
 
-  const std::array<Real, 3> I1{
-      flip * fac * dxcub * dz,
-      flip * (0.5 * SQR(fac) * dxcub * dz + y0 * dwdt * r.xc[0] * r.dx[0] * dz),
-      three_d * r.xc[2] * I0};
+  Real I0 = 0.0;
+  std::array<Real, 3> I1 = {0.0, 0.0, 0.0};
 
+  if constexpr (GEOM == Coordinates::cartesian) {
+    // shearing box integrals
+    const Real y0 = r.bnds.x2[(vb < 0.0)];
+    const Real dz = r.dx[2];
+    I0 = flip * dwdt * r.xc[0] * r.dx[0] * dz;
+    const Real dxcub =
+        r.dx[0] / 3.0 *
+        (SQR(r.bnds.x1[0]) + r.bnds.x1[0] * r.bnds.x1[1] + SQR(r.bnds.x1[1]));
+    I1 = {flip * dwdt * dxcub * dz,
+          flip * (0.5 * SQR(dwdt) * dxcub * dz + y0 * dwdt * r.xc[0] * r.dx[0] * dz),
+          three_d * r.xc[2] * I0};
+  } else if constexpr (GEOM == Coordinates::cylindrical) {
+    const Real alpha = std::sqrt(gm) * scdt;
+    const Real beta = -0.75 * alpha;
+    const Real omf_dt = omega_f * scdt;
+
+    const Real Rm = r.bnds.x1[0], Rp = r.bnds.x1[1];
+    const Real zm = r.bnds.x3[0], zp = r.bnds.x3[1];
+
+    const Real P_mhalf = PowerInt(Rm, Rp, -0.5);
+    const Real P_m5half = PowerInt(Rm, Rp, -2.5);
+    const Real P1 = PowerInt(Rm, Rp, 1.0);
+    const Real P_half = PowerInt(Rm, Rp, 0.5);
+    const Real P_m3half = PowerInt(Rm, Rp, -1.5);
+    const Real P2 = PowerInt(Rm, Rp, 2.0);
+
+    const Real zp2 = SQR(zp);
+    const Real zm2 = SQR(zm);
+    const Real Q0 = zp - zm;
+    const Real Q1 = 0.5 * (zp2 - zm2);
+    const Real Q2 = (zp * zp2 - zm * zm2) / 3.0;
+    const Real Q3 = 0.25 * (SQR(zp2) - SQR(zm2));
+
+    // Volume overlap
+    I0 = flip * (alpha * P_mhalf * Q0 + beta * P_m5half * Q2 - omf_dt * P1 * Q0);
+
+    // First moments
+    const Real I1R =
+        flip * (alpha * P_half * Q0 + beta * P_m3half * Q2 - omf_dt * P2 * Q0);
+
+    const Real phi0 = r.bnds.x2[(vb < 0.0)];
+    const Real Q4 = (std::pow(zp, 5) - std::pow(zm, 5)) / 5.0;
+    const Real dphi2_int =
+        0.5 * flip *
+        (SQR(alpha) * PowerInt(Rm, Rp, -2.0) * Q0 +
+         2.0 * alpha * beta * PowerInt(Rm, Rp, -4.0) * Q2 +
+         SQR(beta) * PowerInt(Rm, Rp, -6.0) * Q4 - 2.0 * alpha * omf_dt * P_mhalf * Q0 -
+         2.0 * beta * omf_dt * P_m5half * Q2 + SQR(omf_dt) * P1 * Q0);
+    const Real I1phi = phi0 * I0 + dphi2_int;
+
+    const Real I1z =
+        flip * (alpha * P_mhalf * Q1 + beta * P_m5half * Q3 - omf_dt * P1 * Q1);
+
+    I1 = {I1R, I1phi, I1z};
+  } else {
+    const Real alpha = std::sqrt(gm) * scdt;
+    const Real omf_dt = omega_f * scdt;
+
+    const Real rm = r.bnds.x1[0], rp = r.bnds.x1[1];
+    const Real thm = r.bnds.x2[0], thp = r.bnds.x2[1];
+
+    const Real P_half = PowerInt(rm, rp, 0.5);
+    const Real P2 = PowerInt(rm, rp, 2.0);
+    const Real P_3half = PowerInt(rm, rp, 1.5);
+    const Real P3 = PowerInt(rm, rp, 3.0);
+
+    const Real cthm = std::cos(thm);
+    const Real cthp = std::cos(thp);
+    const Real sthm = std::sin(thm);
+    const Real sthp = std::sin(thp);
+    const Real Sth = cthm - cthp;
+    const Real Tth = (sthp - thp * cthp) - (sthm - thm * cthm);
+
+    // Volume integral
+    I0 = flip * Sth * (alpha * P_half - omf_dt * P2);
+
+    // First moments
+    const Real I1r = flip * Sth * (alpha * P_3half - omf_dt * P3);
+
+    const Real I1th = (Sth != 0.0) ? (Tth / Sth) * I0 : r.xc[1] * I0;
+
+    const Real phi0 = r.bnds.x3[(vb < 0.0)];
+    const Real dphi2_int = 0.5 * flip * Sth *
+                           (SQR(alpha) * PowerInt(rm, rp, -1.0) -
+                            2.0 * alpha * omf_dt * P_half + SQR(omf_dt) * P2);
+    const Real I1phi = phi0 * I0 + dphi2_int;
+
+    I1 = {I1r, I1th, I1phi};
+  }
+  // Final changes
   const Real dq =
       (rp.q - ArtemisUtils::VDot(rp.grad, rp.xc)) * I0 + ArtemisUtils::VDot(rp.grad, I1);
   v0(b, n, k, j, i) += dq / r.vol;
@@ -160,18 +325,36 @@ RemapUpdate(const V1 &v0, const ReconInfo &rp, const ReconInfo &r, const Real vb
 
 //----------------------------------------------------------------------------------------
 //! \fn  RemapCons
-//! \brief
-template <Upwind UDIR, ReconstructionMethod R, typename V1, typename V2>
+//! \brief Reconstruction and remap sweep along the advection direction.
+template <Coordinates GEOM, Upwind UDIR, ReconstructionMethod R, typename V1, typename V2>
 KOKKOS_INLINE_FUNCTION void RemapCons(const geometry::CoordParams &cpars, const V1 &v0,
                                       const V2 &vg, const int multi_d, const int three_d,
-                                      const Real dwdt, const int b, const int k,
+                                      const Real dwdt, const Real gm, const Real omega_f,
+                                      const Real scdt, const int b, const int k,
                                       IndexRange jb, const int i) {
-  // Extract coordinates
-  const geometry::Coords<Coordinates::cartesian> coords(cpars, v0.GetCoordinates(b), k,
-                                                        jb.s, i);
-  const Real vb = dwdt * (coords.bnds.x1[0] + coords.bnds.x1[1]) * 0.5;
 
-  // Integer gymnastics
+  constexpr bool phi_is_x2 =
+      (GEOM == Coordinates::cartesian || GEOM == Coordinates::cylindrical);
+  constexpr int phi_idx = phi_is_x2 ? 1 : 2;
+  constexpr int rad_idx = 0;
+
+  // Extract coordinates at the start of the sweep range for vb computation
+  geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, jb.s, i);
+  const auto xc0 = coords.GetCellCenter(vg, b, k, jb.s, i);
+
+  // Compute the signed background velocity at this radial position for sweep direction
+  Real vb = 0.0;
+  if constexpr (GEOM == Coordinates::cartesian) {
+    vb = dwdt * xc0[0];
+  } else if constexpr (GEOM == Coordinates::cylindrical) {
+    const Real om = OmegaKep(gm, xc0[0], xc0[2]) - omega_f;
+    vb = om * xc0[0];
+  } else if constexpr (GEOM == Coordinates::spherical3D) {
+    const Real om = OmegaKep(gm, xc0[0]) - omega_f;
+    vb = om * xc0[0] * std::sin(xc0[1]);
+  }
+
+  // Integer gymnastics for sweep direction
   int joff = 1;
   int jstart = jb.e;
   int jend = jb.s - joff;
@@ -181,38 +364,78 @@ KOKKOS_INLINE_FUNCTION void RemapCons(const geometry::CoordParams &cpars, const 
     jend = jb.e - joff;
   }
 
-  // Reconstruct and advance
-  // NOTE(@adempsey): This reconstructs the conservatives. An alternative is to hold the
-  // density in a separate register and divide the mass-weighted conservatives.
   const auto compare = (UDIR == Upwind::r) ? [](int j, int end) { return j >= end; }
                                            : [](int j, int end) { return j <= end; };
 
-  ArtemisUtils::ReconGradient<Coordinates::cartesian, R> recon;
+  ArtemisUtils::ReconGradient<GEOM, R> recon;
   ReconInfo rd, rc, ru;
+
+  // Helper lambda to compute the skew correction for centroids and gradients.
+  auto apply_skew = [&](ReconInfo &ri) {
+    if constexpr (GEOM == Coordinates::cartesian) {
+      ri.xc[phi_idx] += dwdt * ri.xc[rad_idx];
+    } else {
+      const Real Rc = ri.xc[rad_idx];
+      const Real alpha = std::sqrt(gm) * scdt;
+      const Real dphi_c = alpha * std::pow(Rc, -1.5) - omega_f * scdt;
+      ri.xc[phi_idx] += dphi_c;
+    }
+  };
+
+  auto apply_grad_skew = [&](ReconInfo &ri) {
+    if constexpr (GEOM == Coordinates::cartesian) {
+      ri.grad[phi_idx] += dwdt * ri.grad[rad_idx];
+    } else {
+      const Real Rc = ri.xc[rad_idx];
+      const Real alpha = std::sqrt(gm) * scdt;
+      const Real ddphi_dR = -1.5 * alpha * std::pow(Rc, -2.5);
+      ri.grad[phi_idx] += ddphi_dR * ri.grad[rad_idx];
+    }
+  };
+
+  // Helper to fill ReconInfo with the correct index permutation
+  auto fill_ri = [&](ReconInfo &ri, int n, int jsweep) {
+    if constexpr (phi_is_x2) {
+      ri.template fill<GEOM>(cpars, v0, vg, b, n, k, jsweep, i);
+    } else {
+      ri.template fill<GEOM>(cpars, v0, vg, b, n, jsweep, k, i);
+    }
+  };
+
+  auto get_recon = [&](const ReconInfo &ri, int n, int jsweep) -> std::array<Real, 3> {
+    if constexpr (phi_is_x2) {
+      return recon(cpars, v0, ri.dx, multi_d, three_d, b, n, k, jsweep, i);
+    } else {
+      return recon(cpars, v0, ri.dx, multi_d, three_d, b, n, jsweep, k, i);
+    }
+  };
+
   for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
-    ru.fill(cpars, v0, vg, b, n, k, jstart + joff, i);
-    rc.fill(cpars, v0, vg, b, n, k, jstart, i);
-    // Correct the centroid of the cell due to the motion
-    ru.xc[1] += dwdt * ru.xc[0];
-    rc.xc[1] += dwdt * rc.xc[0];
-    ru.grad = recon(cpars, v0, ru.dx, multi_d, three_d, b, n, k, jstart + joff, i);
-    const auto qu = v0(b, n, k, jstart + joff, i);
-    rc.grad = recon(cpars, v0, rc.dx, multi_d, three_d, b, n, k, jstart, i);
-    const auto qc = v0(b, n, k, jstart, i);
-    // Correct the gradients due to the skew
-    ru.grad[1] += dwdt * ru.grad[0];
-    rc.grad[1] += dwdt * rc.grad[0];
+    fill_ri(ru, n, jstart + joff);
+    fill_ri(rc, n, jstart);
+    apply_skew(ru);
+    apply_skew(rc);
+    ru.grad = get_recon(ru, n, jstart + joff);
+    rc.grad = get_recon(rc, n, jstart);
+    apply_grad_skew(ru);
+    apply_grad_skew(rc);
 
     // Execute remapping "sweep"
     for (int j = jstart; compare(j, jend); j -= joff) {
       const int jd = j - joff;
       if (compare(jd, jend)) {
-        rd.fill(cpars, v0, vg, b, n, k, jd, i);
-        rd.xc[1] += dwdt * rd.xc[0];
-        rd.grad = recon(cpars, v0, rd.dx, multi_d, three_d, b, n, k, jd, i);
-        rd.grad[1] += dwdt * rd.grad[0];
+        fill_ri(rd, n, jd);
+        apply_skew(rd);
+        rd.grad = get_recon(rd, n, jd);
+        apply_grad_skew(rd);
       }
-      RemapUpdate(v0, ru, rc, vb, dwdt, three_d, b, n, k, j, j + joff, i);
+      if constexpr (phi_is_x2) {
+        RemapUpdate<GEOM>(v0, ru, rc, vb, dwdt, gm, omega_f, scdt, three_d, b, n, k, j,
+                          j + joff, i);
+      } else {
+        RemapUpdate<GEOM>(v0, ru, rc, vb, dwdt, gm, omega_f, scdt, three_d, b, n, j, k,
+                          j + joff, i);
+      }
       ru = rc;
       rc = rd;
     }
@@ -221,13 +444,13 @@ KOKKOS_INLINE_FUNCTION void RemapCons(const geometry::CoordParams &cpars, const 
 
 //----------------------------------------------------------------------------------------
 //! \fn  LagrangeRemapImpl
-//! \brief
-template <ReconstructionMethod R, typename V1, typename V2>
+//! \brief Main par_for kernel for the Lagrange remap step.
+template <Coordinates GEOM, ReconstructionMethod R, typename V1, typename V2>
 TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
-                             const Real dwdt) {
+                             const Real dwdt, const Real gm, const Real omega_f,
+                             const Real scdt) {
   PARTHENON_INSTRUMENT
   const int multi_d = u0->GetNDim() >= 2;
-  PARTHENON_REQUIRE(multi_d, "Linear advection does not work in 1D");
   const int three_d = u0->GetNDim() == 3;
 
   const auto &cpars = u0->GetParentPointer()
@@ -236,19 +459,47 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
   IndexRange ib = u0->GetBoundsI(IndexDomain::interior);
   IndexRange jb = u0->GetBoundsJ(IndexDomain::interior);
   IndexRange kb = u0->GetBoundsK(IndexDomain::interior);
-  parthenon::par_for(
-      DEFAULT_LOOP_PATTERN, "LagrangeRemap", parthenon::DevExecSpace(), 0,
-      u0->NumBlocks() - 1, kb.s, kb.e, ib.s, ib.e,
-      KOKKOS_LAMBDA(const int &b, const int &k, const int &i) {
-        geometry::Coords<Coordinates::cartesian> coords(cpars, v0.GetCoordinates(b), k,
-                                                        jb.s, i);
-        const Real vb = dwdt * 0.5 * (coords.bnds.x1[0] + coords.bnds.x1[1]);
-        if (vb < 0.0) {
-          RemapCons<Upwind::r, R>(cpars, v0, vg, multi_d, three_d, dwdt, b, k, jb, i);
-        } else if (vb > 0.0) {
-          RemapCons<Upwind::l, R>(cpars, v0, vg, multi_d, three_d, dwdt, b, k, jb, i);
-        }
-      });
+
+  if constexpr ((GEOM == Coordinates::cartesian || GEOM == Coordinates::cylindrical)) {
+    // Outer loop over (k, i); inner sweep over j
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "LagrangeRemap", parthenon::DevExecSpace(), 0,
+        u0->NumBlocks() - 1, kb.s, kb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int &b, const int &k, const int &i) {
+          geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, jb.s, i);
+          const auto xc0 = coords.GetCellCenter(vg, b, k, jb.s, i);
+          const Real vb = (GEOM == Coordinates::cartesian)
+                              ? (dwdt * 0.5 * (coords.bnds.x1[0] + coords.bnds.x1[1]))
+                              : ((std::sqrt(gm / (CUB(xc0[0]))) - omega_f) * scdt);
+          if (vb < 0.0) {
+            RemapCons<GEOM, Upwind::r, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
+                                          omega_f, scdt, b, k, jb, i);
+          } else if (vb > 0.0) {
+            RemapCons<GEOM, Upwind::l, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
+                                          omega_f, scdt, b, k, jb, i);
+          }
+        });
+  } else if constexpr (GEOM == Coordinates::spherical3D) {
+    // Outer loop over (j, i); inner sweep over k
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "LagrangeRemap", parthenon::DevExecSpace(), 0,
+        u0->NumBlocks() - 1, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int &b, const int &j, const int &i) {
+          geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), kb.s, j, i);
+          const auto xc0 = coords.GetCellCenter(vg, b, kb.s, j, i);
+          const Real Rc = xc0[0];
+          const Real vb = (std::sqrt(gm / (CUB(Rc))) - omega_f) * scdt;
+          if (vb < 0.0) {
+            RemapCons<GEOM, Upwind::r, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
+                                          omega_f, scdt, b, j, kb, i);
+          } else if (vb > 0.0) {
+            RemapCons<GEOM, Upwind::l, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
+                                          omega_f, scdt, b, j, kb, i);
+          }
+        });
+  } else {
+    PARTHENON_FAIL("Unsupported geometry in LagrangeRemapImpl");
+  }
   return TaskStatus::complete;
 }
 } // namespace RotatingFrame

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -30,8 +30,6 @@ using namespace parthenon::package::prelude;
 using ArtemisUtils::PLM;
 using ArtemisUtils::VI;
 
-#define CUB(x) ((x) * (x) * (x))
-
 namespace RotatingFrame {
 
 //----------------------------------------------------------------------------------------
@@ -59,6 +57,7 @@ struct ReconInfo {
   std::array<Real, 3> grad;
   std::array<Real, 3> xc;
   std::array<Real, 3> dx;
+  std::array<Real, 2> aface;
   geometry::BBox bnds;
   Real q;
   Real vol;
@@ -80,6 +79,12 @@ struct ReconInfo {
     xc = coords.GetCellCenter(vg, b, k, j, i);
     vol = coords.GetVolume(vg, b, k, j, i);
     bnds = coords.bnds;
+    if constexpr ((GEOM == Coordinates::cartesian) ||
+                  (GEOM == Coordinates::cylindrical)) {
+      aface = {coords.AreaX2(bnds.x2[0]), coords.AreaX2(bnds.x2[1])};
+    } else {
+      aface = {coords.AreaX3(bnds.x3[0]), coords.AreaX3(bnds.x3[1])};
+    }
 
     q = v0(b, n, k, j, i);
     grad = {0.};
@@ -216,31 +221,38 @@ struct OrbitalAdvection {
     return {0.0, 0.0, 0.0};
   }
 
-  KOKKOS_INLINE_FUNCTION Real DeltaPhi(const std::array<Real, 3> &xc) const {
+  KOKKOS_INLINE_FUNCTION Real DeltaPhi(const Real &x1) const {
     if constexpr (GEOM == Coordinates::cartesian) {
-      return dwdt * xc[0];
-    } else if constexpr (GEOM == Coordinates::cylindrical) {
-      return (OmegaKep(xc[0]) - omega_f) * scdt;
+      return dwdt * x1;
     } else {
-      return (OmegaKep(xc[0]) - omega_f) * scdt;
+      return (OmegaKep(x1) - omega_f) * scdt;
     }
   }
 
   KOKKOS_INLINE_FUNCTION void ApplySkew(ReconInfo &ri) const {
-    ri.xc[phi_idx] += DeltaPhi(ri.xc);
+    ri.xc[phi_idx] += DeltaPhi(ri.xc[0]);
   }
 
   KOKKOS_INLINE_FUNCTION void ApplyGradSkew(ReconInfo &ri) const {
     if constexpr (GEOM == Coordinates::cartesian) {
-      ri.grad[phi_idx] += dwdt * ri.grad[0];
+      ri.grad[0] += dwdt * ri.grad[phi_idx];
     } else if constexpr (GEOM == Coordinates::cylindrical) {
       const Real Rc = ri.xc[0];
       const Real dOdR = -1.5 * OmegaKep(Rc) / Rc;
-      ri.grad[phi_idx] += dOdR * ri.grad[0] * scdt;
+      ri.grad[0] += dOdR * ri.grad[phi_idx] * scdt;
     } else {
       const Real rc = ri.xc[0];
       const Real dOdr = -1.5 * OmegaKep(rc) / rc;
-      ri.grad[phi_idx] += dOdr * ri.grad[0] * scdt;
+      ri.grad[0] += dOdr * ri.grad[phi_idx] * scdt;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION bool RootInInterval(const Real x1m, const Real x1p,
+                                             Real &xroot) const {
+    if constexpr (GEOM == Coordinates::cartesian) {
+      return x1m * x1p < 0.0;
+    } else {
+      return (OmegaKep(x1m) - omega_f) * (OmegaKep(x1p) - omega_f) < 0.0;
     }
   }
 
@@ -329,176 +341,169 @@ struct OrbitalAdvection {
 };
 
 //----------------------------------------------------------------------------------------
-//! \fn  RemapUpdateX2
-//! \brief Conservative intersection-remap update using OrbitalAdvection struct.
-//! Only interior cells (js <= j/jp <= je in the sweep direction) are updated.
-template <Coordinates GEOM, typename V1>
-KOKKOS_INLINE_FUNCTION void
-RemapUpdateX2(const OrbitalAdvection<GEOM> &oa, const V1 &v0, const ReconInfo &rp,
-              const ReconInfo &r, const Real vb, const int three_d, const int b,
-              const int n, const int k, const int j, const int jp, const int i,
-              const int js, const int je) {
-  const Real flip = (vb < 0.0) ? -1.0 : 1.0;
-  const Real I0 = oa.ComputeI0(r, flip);
-  const auto I1 = oa.ComputeI1(r, flip, vb, I0, three_d);
-  const Real dq =
-      (rp.q - ArtemisUtils::VDot(rp.grad, rp.xc)) * I0 + ArtemisUtils::VDot(rp.grad, I1);
-  if (j >= js && j <= je) v0(b, n, k, j, i) += dq / r.vol;
-  if (jp >= js && jp <= je) v0(b, n, k, jp, i) -= dq / rp.vol;
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn  RemapUpdateX3
-//! \brief Conservative intersection-remap update using OrbitalAdvection struct.
-//! Only interior cells (ks <= k/kp <= ke in the sweep direction) are updated.
-template <Coordinates GEOM, typename V1>
-KOKKOS_INLINE_FUNCTION void
-RemapUpdateX3(const OrbitalAdvection<GEOM> &oa, const V1 &v0, const ReconInfo &rp,
-              const ReconInfo &r, const Real vb, const int three_d, const int b,
-              const int n, const int k, const int kp, const int j, const int i,
-              const int ks, const int ke) {
-  const Real flip = (vb < 0.0) ? -1.0 : 1.0;
-  const Real I0 = oa.ComputeI0(r, flip);
-  const auto I1 = oa.ComputeI1(r, flip, vb, I0, three_d);
-  const Real dq =
-      (rp.q - ArtemisUtils::VDot(rp.grad, rp.xc)) * I0 + ArtemisUtils::VDot(rp.grad, I1);
-  if (k >= ks && k <= ke) v0(b, n, k, j, i) += dq / r.vol;
-  if (kp >= ks && kp <= ke) v0(b, n, kp, j, i) -= dq / rp.vol;
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn  RemapConsX2
-//! \brief Reconstruction and remap sweep along the advection direction.
-template <Coordinates GEOM, Upwind UDIR, ReconstructionMethod R, typename V1, typename V2>
-KOKKOS_INLINE_FUNCTION void
-RemapConsX2(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
-            const V1 &v0, const V2 &vg, const int multi_d, const int three_d, const int b,
-            const int k, IndexRange jb, const int i) {
-
-  // Extract coordinates at the start of the sweep range for vb computation
-  geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, jb.s, i);
-  const auto xc0 = coords.GetCellCenter(vg, b, k, jb.s, i);
-
-  // Compute the signed background velocity at this radial position for sweep direction
-  const Real vb = oa.DeltaPhi(xc0);
-
-  // Integer gymnastics for sweep direction
-  int joff = 1;
-  int jstart = jb.e;
-  int jend = jb.s - joff;
-  if constexpr (UDIR == Upwind::l) {
-    joff = -1;
-    jstart = jb.s;
-    jend = jb.e - joff;
+//! Build a geometric slice of a reconstruction cell over a radial sub-interval.
+template <Coordinates GEOM>
+KOKKOS_INLINE_FUNCTION ReconInfo SliceReconInfo(const ReconInfo &r, const Real x1m,
+                                                const Real x1p) {
+  ReconInfo rs = r;
+  rs.bnds.x1[0] = x1m;
+  rs.bnds.x1[1] = x1p;
+  rs.dx[0] = x1p - x1m;
+  if constexpr (GEOM == Coordinates::cartesian) {
+    const Real dx2 = r.bnds.x2[1] - r.bnds.x2[0];
+    const Real dx3 = r.bnds.x3[1] - r.bnds.x3[0];
+    rs.xc[0] = 0.5 * (x1m + x1p);
+    rs.vol = (x1p - x1m) * dx2 * dx3;
+    rs.aface = {(x1p - x1m) * dx3, (x1p - x1m) * dx3};
+  } else if constexpr (GEOM == Coordinates::cylindrical) {
+    const Real dphi = r.bnds.x2[1] - r.bnds.x2[0];
+    const Real dz = r.bnds.x3[1] - r.bnds.x3[0];
+    rs.xc[0] = 2.0 / 3.0 * (SQR(x1m) + x1m * x1p + SQR(x1p)) / (x1m + x1p);
+    rs.vol = 0.5 * (x1m + x1p) * (x1p - x1m) * dphi * dz;
+    rs.aface = {0.5 * (x1m + x1p) * (x1p - x1m) * dz,
+                0.5 * (x1m + x1p) * (x1p - x1m) * dz};
+  } else {
+    const Real dphi = r.bnds.x3[1] - r.bnds.x3[0];
+    const Real sth = std::abs(std::cos(r.bnds.x2[0]) - std::cos(r.bnds.x2[1]));
+    const Real dx2 = r.bnds.x2[1] - r.bnds.x2[0];
+    const Real dr2 = SQR(x1m) + SQR(x1p);
+    rs.xc[0] = 0.75 * (x1m + x1p) * dr2 / (dr2 + x1m * x1p);
+    rs.vol = (SQR(x1m) + x1m * x1p + SQR(x1p)) / 3.0 * (x1p - x1m) * sth * dphi;
+    rs.aface = {0.5 * (x1m + x1p) * (x1p - x1m) * dx2,
+                0.5 * (x1m + x1p) * (x1p - x1m) * dx2};
   }
+  return rs;
+}
 
-  const auto compare = (UDIR == Upwind::r) ? [](int j, int end) { return j >= end; }
-                                           : [](int j, int end) { return j <= end; };
+template <Coordinates GEOM>
+KOKKOS_INLINE_FUNCTION Real ComputeTransferredAmount(const OrbitalAdvection<GEOM> &oa,
+                                                     const ReconInfo &donor,
+                                                     const ReconInfo &receiver,
+                                                     const int sign, const Real x1m,
+                                                     const Real x1p, const int three_d) {
+  if (x1p <= x1m) return 0.0;
+  const auto rs = SliceReconInfo<GEOM>(receiver, x1m, x1p);
+  const Real flip = (sign < 0) ? -1.0 : 1.0;
+  const Real I0 = oa.ComputeI0(rs, flip);
+  const auto I1 = oa.ComputeI1(rs, flip, static_cast<Real>(sign), I0, three_d);
+  return (donor.q - ArtemisUtils::VDot(donor.grad, donor.xc)) * I0 +
+         ArtemisUtils::VDot(donor.grad, I1);
+}
+
+template <Coordinates GEOM, ReconstructionMethod R, typename V1, typename V2>
+KOKKOS_INLINE_FUNCTION void
+BuildFluxLineX2(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
+                const V1 &v0, const V2 &vg, const int multi_d, const int three_d,
+                const int b, const int k, IndexRange jb, const int i) {
+  geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, jb.s, i);
+  const Real x1m = coords.bnds.x1[0];
+  const Real x1p = coords.bnds.x1[1];
+  Real xroot = 0.0;
+  const bool split = oa.RootInInterval(x1m, x1p, xroot);
 
   ArtemisUtils::ReconGradient<GEOM, R> recon;
-  ReconInfo rd, rc, ru;
-
-  // Helper to fill ReconInfo with the correct index permutation
   auto fill_ri = [&](ReconInfo &ri, int n, int jsweep) {
     ri.template fill<GEOM>(cpars, v0, vg, b, n, k, jsweep, i);
+    oa.ApplySkew(ri);
+    ri.grad = recon(cpars, v0, ri.dx, multi_d, three_d, b, n, k, jsweep, i);
+    oa.ApplyGradSkew(ri);
   };
 
-  auto get_recon = [&](const ReconInfo &ri, int n, int jsweep) -> std::array<Real, 3> {
-    return recon(cpars, v0, ri.dx, multi_d, three_d, b, n, k, jsweep, i);
-  };
+  const auto sgn = [](const Real x) { return (x > 0.0) ? 1 : ((x < 0.0) ? -1 : 0); };
+  const int sign_full = sgn(oa.DeltaPhi(0.5 * (x1m + x1p)));
+  const int sign_lo = split ? sgn(oa.DeltaPhi(0.5 * (x1m + xroot))) : sign_full;
+  const int sign_hi = split ? sgn(oa.DeltaPhi(0.5 * (xroot + x1p))) : sign_full;
 
   for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
-    fill_ri(ru, n, jstart + joff);
-    fill_ri(rc, n, jstart);
-    oa.ApplySkew(ru);
-    oa.ApplySkew(rc);
-    ru.grad = get_recon(ru, n, jstart + joff);
-    rc.grad = get_recon(rc, n, jstart);
-    oa.ApplyGradSkew(ru);
-    oa.ApplyGradSkew(rc);
-
-    // Execute remapping "sweep"
-    for (int j = jstart; compare(j, jend); j -= joff) {
-      const int jd = j - joff;
-      if (compare(jd, jend)) {
-        fill_ri(rd, n, jd);
-        oa.ApplySkew(rd);
-        rd.grad = get_recon(rd, n, jd);
-        oa.ApplyGradSkew(rd);
+    ReconInfo rl, rr;
+    fill_ri(rl, n, jb.s - 1);
+    fill_ri(rr, n, jb.s);
+    for (int jf = jb.s; jf <= jb.e + 1; ++jf) {
+      Real dq = 0.0;
+      if (split) {
+        if (sign_lo > 0) {
+          dq += ComputeTransferredAmount(oa, rl, rr, sign_lo, x1m, xroot, three_d);
+        } else if (sign_lo < 0) {
+          dq += sign_lo *
+                ComputeTransferredAmount(oa, rr, rl, sign_lo, x1m, xroot, three_d);
+        }
+        if (sign_hi > 0) {
+          dq += ComputeTransferredAmount(oa, rl, rr, sign_hi, xroot, x1p, three_d);
+        } else if (sign_hi < 0) {
+          dq += sign_hi *
+                ComputeTransferredAmount(oa, rr, rl, sign_hi, xroot, x1p, three_d);
+        }
+      } else if (sign_full > 0) {
+        dq = ComputeTransferredAmount(oa, rl, rr, sign_full, x1m, x1p, three_d);
+      } else if (sign_full < 0) {
+        dq = sign_full *
+             ComputeTransferredAmount(oa, rr, rl, sign_full, x1m, x1p, three_d);
       }
-      RemapUpdateX2<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, k, j, j + joff, i, jb.s,
-                          jb.e);
-      ru = rc;
-      rc = rd;
+      // Construct a flux from the amount exchanged
+      v0.flux(b, X2DIR, n, k, jf, i) = dq / (rr.aface[0] * oa.scdt);
+      if (jf <= jb.e) {
+        rl = rr;
+        fill_ri(rr, n, jf + 1);
+      }
     }
   }
 }
 
-//----------------------------------------------------------------------------------------
-//! \fn  RemapConsX3
-//! \brief Reconstruction and remap sweep along the advection direction.
-template <Coordinates GEOM, Upwind UDIR, ReconstructionMethod R, typename V1, typename V2>
+template <Coordinates GEOM, ReconstructionMethod R, typename V1, typename V2>
 KOKKOS_INLINE_FUNCTION void
-RemapConsX3(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
-            const V1 &v0, const V2 &vg, const int multi_d, const int three_d, const int b,
-            IndexRange kb, const int j, const int i) {
-
-  // Extract coordinates at the start of the sweep range for vb computation
+BuildFluxLineX3(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &cpars,
+                const V1 &v0, const V2 &vg, const int multi_d, const int three_d,
+                const int b, IndexRange kb, const int j, const int i) {
   geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), kb.s, j, i);
-  const auto xc0 = coords.GetCellCenter(vg, b, kb.s, j, i);
-
-  // Compute the signed background velocity at this radial position for sweep direction
-  const Real vb = oa.DeltaPhi(xc0);
-
-  // Integer gymnastics for sweep direction
-  int koff = 1;
-  int kstart = kb.e;
-  int kend = kb.s - koff;
-  if constexpr (UDIR == Upwind::l) {
-    koff = -1;
-    kstart = kb.s;
-    kend = kb.e - koff;
-  }
-
-  const auto compare = (UDIR == Upwind::r) ? [](int k, int end) { return k >= end; }
-                                           : [](int k, int end) { return k <= end; };
+  const Real x1m = coords.bnds.x1[0];
+  const Real x1p = coords.bnds.x1[1];
+  Real xroot = 0.0;
+  const bool split = oa.RootInInterval(x1m, x1p, xroot);
 
   ArtemisUtils::ReconGradient<GEOM, R> recon;
-  ReconInfo rd, rc, ru;
-
-  // Helper to fill ReconInfo with the correct index permutation
   auto fill_ri = [&](ReconInfo &ri, int n, int ksweep) {
     ri.template fill<GEOM>(cpars, v0, vg, b, n, ksweep, j, i);
+    oa.ApplySkew(ri);
+    ri.grad = recon(cpars, v0, ri.dx, multi_d, three_d, b, n, ksweep, j, i);
+    oa.ApplyGradSkew(ri);
   };
 
-  auto get_recon = [&](const ReconInfo &ri, int n, int ksweep) -> std::array<Real, 3> {
-    return recon(cpars, v0, ri.dx, multi_d, three_d, b, n, ksweep, j, i);
-  };
+  const auto sgn = [](const Real x) { return (x > 0.0) ? 1 : ((x < 0.0) ? -1 : 0); };
+  const int sign_full = sgn(oa.DeltaPhi(0.5 * (x1m + x1p)));
+  const int sign_lo = split ? sgn(oa.DeltaPhi(0.5 * (x1m + xroot))) : sign_full;
+  const int sign_hi = split ? sgn(oa.DeltaPhi(0.5 * (xroot + x1p))) : sign_full;
 
   for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
-    fill_ri(ru, n, kstart + koff);
-    fill_ri(rc, n, kstart);
-    oa.ApplySkew(ru);
-    oa.ApplySkew(rc);
-    ru.grad = get_recon(ru, n, kstart + koff);
-    rc.grad = get_recon(rc, n, kstart);
-    oa.ApplyGradSkew(ru);
-    oa.ApplyGradSkew(rc);
-
-    // Execute remapping "sweep"
-    for (int k = kstart; compare(k, kend); k -= koff) {
-      const int kd = k - koff;
-      if (compare(kd, kend)) {
-        fill_ri(rd, n, kd);
-        oa.ApplySkew(rd);
-        rd.grad = get_recon(rd, n, kd);
-        oa.ApplyGradSkew(rd);
+    ReconInfo rl, rr;
+    fill_ri(rl, n, kb.s - 1);
+    fill_ri(rr, n, kb.s);
+    for (int kf = kb.s; kf <= kb.e + 1; ++kf) {
+      Real dq = 0.0;
+      if (split) {
+        if (sign_lo > 0) {
+          dq += ComputeTransferredAmount(oa, rl, rr, sign_lo, x1m, xroot, three_d);
+        } else if (sign_lo < 0) {
+          dq += sign_lo *
+                ComputeTransferredAmount(oa, rr, rl, sign_lo, x1m, xroot, three_d);
+        }
+        if (sign_hi > 0) {
+          dq += ComputeTransferredAmount(oa, rl, rr, sign_hi, xroot, x1p, three_d);
+        } else if (sign_hi < 0) {
+          dq += sign_hi *
+                ComputeTransferredAmount(oa, rr, rl, sign_hi, xroot, x1p, three_d);
+        }
+      } else if (sign_full > 0) {
+        dq = ComputeTransferredAmount(oa, rl, rr, sign_full, x1m, x1p, three_d);
+      } else if (sign_full < 0) {
+        dq = sign_full *
+             ComputeTransferredAmount(oa, rr, rl, sign_full, x1m, x1p, three_d);
       }
-      RemapUpdateX3<GEOM>(oa, v0, ru, rc, vb, three_d, b, n, k, k + koff, j, i, kb.s,
-                          kb.e);
-
-      ru = rc;
-      rc = rd;
+      // Construct a flux from the amount exchanged
+      v0.flux(b, X3DIR, n, kf, j, i) = dq / (rr.aface[0] * oa.scdt);
+      if (kf <= kb.e) {
+        rl = rr;
+        fill_ri(rr, n, kf + 1);
+      }
     }
   }
 }
@@ -523,39 +528,46 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
 
   const OrbitalAdvection<GEOM> oa{gm, omega_f, 0.0, scdt, dwdt};
 
-  if constexpr ((GEOM == Coordinates::cartesian || GEOM == Coordinates::cylindrical)) {
-    // Outer loop over (k, i); inner sweep over j
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "ZeroOAFluxX1", DevExecSpace(), 0, u0->NumBlocks() - 1, kb.s,
+      kb.e, jb.s, jb.e, ib.s, ib.e + 1,
+      KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
+        for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+          v0.flux(b, X1DIR, n, k, j, i) = 0.0;
+        }
+      });
+  if (multi_d) {
     parthenon::par_for(
-        DEFAULT_LOOP_PATTERN, "LagrangeRemap", parthenon::DevExecSpace(), 0,
-        u0->NumBlocks() - 1, kb.s, kb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int &b, const int &k, const int &i) {
-          geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), k, jb.s, i);
-          const auto xc0 = coords.GetCellCenter(vg, b, k, jb.s, i);
-          const Real vb = oa.DeltaPhi(xc0);
-          if (vb < 0.0) {
-            RemapConsX2<GEOM, Upwind::r, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb,
-                                            i);
-          } else if (vb > 0.0) {
-            RemapConsX2<GEOM, Upwind::l, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb,
-                                            i);
+        DEFAULT_LOOP_PATTERN, "ZeroOAFluxX2", DevExecSpace(), 0, u0->NumBlocks() - 1,
+        kb.s, kb.e, jb.s, jb.e + 1, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
+          for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+            v0.flux(b, X2DIR, n, k, j, i) = 0.0;
           }
         });
-  } else if constexpr (GEOM == Coordinates::spherical3D) {
-    // Outer loop over (j, i); inner sweep over k
+  }
+  if (three_d) {
     parthenon::par_for(
-        DEFAULT_LOOP_PATTERN, "LagrangeRemap", parthenon::DevExecSpace(), 0,
-        u0->NumBlocks() - 1, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int &b, const int &j, const int &i) {
-          geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), kb.s, j, i);
-          const auto xc0 = coords.GetCellCenter(vg, b, kb.s, j, i);
-          const Real vb = oa.DeltaPhi(xc0);
-          if (vb < 0.0) {
-            RemapConsX3<GEOM, Upwind::r, R>(oa, cpars, v0, vg, multi_d, three_d, b, kb, j,
-                                            i);
-          } else if (vb > 0.0) {
-            RemapConsX3<GEOM, Upwind::l, R>(oa, cpars, v0, vg, multi_d, three_d, b, kb, j,
-                                            i);
+        DEFAULT_LOOP_PATTERN, "ZeroOAFluxX3", DevExecSpace(), 0, u0->NumBlocks() - 1,
+        kb.s, kb.e + 1, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
+          for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+            v0.flux(b, X3DIR, n, k, j, i) = 0.0;
           }
+        });
+  }
+
+  if constexpr ((GEOM == Coordinates::cartesian || GEOM == Coordinates::cylindrical)) {
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "OARemapFluxX2", DevExecSpace(), 0, u0->NumBlocks() - 1,
+        kb.s, kb.e, ib.s, ib.e, KOKKOS_LAMBDA(const int &b, const int &k, const int &i) {
+          BuildFluxLineX2<GEOM, R>(oa, cpars, v0, vg, multi_d, three_d, b, k, jb, i);
+        });
+  } else if constexpr (GEOM == Coordinates::spherical3D) {
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "OARemapFluxX3", DevExecSpace(), 0, u0->NumBlocks() - 1,
+        jb.s, jb.e, ib.s, ib.e, KOKKOS_LAMBDA(const int &b, const int &j, const int &i) {
+          BuildFluxLineX3<GEOM, R>(oa, cpars, v0, vg, multi_d, three_d, b, kb, j, i);
         });
   } else {
     PARTHENON_FAIL("Unsupported geometry in LagrangeRemapImpl");

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -412,41 +412,64 @@ BuildFluxLineX2(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &c
     oa.ApplyGradSkew(ri);
   };
 
-  const auto sgn = [](const Real x) { return (x > 0.0) ? 1 : ((x < 0.0) ? -1 : 0); };
-  const int sign_full = sgn(oa.DeltaPhi(0.5 * (x1m + x1p)));
-  const int sign_lo = split ? sgn(oa.DeltaPhi(0.5 * (x1m + xroot))) : sign_full;
-  const int sign_hi = split ? sgn(oa.DeltaPhi(0.5 * (xroot + x1p))) : sign_full;
+  const int sign_full = ArtemisUtils::sgn(oa.DeltaPhi(0.5 * (x1m + x1p)));
+  const int sign_lo =
+      split ? ArtemisUtils::sgn(oa.DeltaPhi(0.5 * (x1m + xroot))) : sign_full;
+  const int sign_hi =
+      split ? ArtemisUtils::sgn(oa.DeltaPhi(0.5 * (xroot + x1p))) : sign_full;
 
-  for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
-    ReconInfo rl, rr;
-    fill_ri(rl, n, jb.s - 1);
-    fill_ri(rr, n, jb.s);
-    for (int jf = jb.s; jf <= jb.e + 1; ++jf) {
-      Real dq = 0.0;
-      if (split) {
-        if (sign_lo > 0) {
-          dq += ComputeTransferredAmount(oa, rl, rr, sign_lo, x1m, xroot, three_d);
-        } else if (sign_lo < 0) {
-          dq += sign_lo *
-                ComputeTransferredAmount(oa, rr, rl, sign_lo, x1m, xroot, three_d);
+  if (split) {
+    for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+      ReconInfo rl, rr;
+      fill_ri(rl, n, jb.s - 1);
+      fill_ri(rr, n, jb.s);
+      for (int jf = jb.s; jf <= jb.e + 1; ++jf) {
+        Real dq = 0.0;
+        if (sign_lo != 0) {
+          dq += sign_lo * ComputeTransferredAmount(oa, (sign_lo > 0) ? rl : rr,
+                                                   (sign_lo > 0) ? rr : rl, sign_lo, x1m,
+                                                   xroot, three_d);
         }
-        if (sign_hi > 0) {
-          dq += ComputeTransferredAmount(oa, rl, rr, sign_hi, xroot, x1p, three_d);
-        } else if (sign_hi < 0) {
-          dq += sign_hi *
-                ComputeTransferredAmount(oa, rr, rl, sign_hi, xroot, x1p, three_d);
+        if (sign_hi != 0) {
+          dq += sign_hi * ComputeTransferredAmount(oa, (sign_hi > 0) ? rl : rr,
+                                                   (sign_hi > 0) ? rr : rl, sign_hi,
+                                                   xroot, x1p, three_d);
         }
-      } else if (sign_full > 0) {
-        dq = ComputeTransferredAmount(oa, rl, rr, sign_full, x1m, x1p, three_d);
-      } else if (sign_full < 0) {
-        dq = sign_full *
-             ComputeTransferredAmount(oa, rr, rl, sign_full, x1m, x1p, three_d);
+        v0.flux(b, X2DIR, n, k, jf, i) = dq / (rr.aface[0] * oa.scdt);
+        if (jf <= jb.e) {
+          rl = rr;
+          fill_ri(rr, n, jf + 1);
+        }
       }
-      // Construct a flux from the amount exchanged
-      v0.flux(b, X2DIR, n, k, jf, i) = dq / (rr.aface[0] * oa.scdt);
-      if (jf <= jb.e) {
-        rl = rr;
-        fill_ri(rr, n, jf + 1);
+    }
+  } else if (sign_full > 0) {
+    for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+      ReconInfo rl, rr;
+      fill_ri(rl, n, jb.s - 1);
+      fill_ri(rr, n, jb.s);
+      for (int jf = jb.s; jf <= jb.e + 1; ++jf) {
+        const Real dq =
+            ComputeTransferredAmount(oa, rl, rr, sign_full, x1m, x1p, three_d);
+        v0.flux(b, X2DIR, n, k, jf, i) = dq / (rr.aface[0] * oa.scdt);
+        if (jf <= jb.e) {
+          rl = rr;
+          fill_ri(rr, n, jf + 1);
+        }
+      }
+    }
+  } else if (sign_full < 0) {
+    for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+      ReconInfo rl, rr;
+      fill_ri(rl, n, jb.s - 1);
+      fill_ri(rr, n, jb.s);
+      for (int jf = jb.s; jf <= jb.e + 1; ++jf) {
+        const Real dq = sign_full * ComputeTransferredAmount(oa, rr, rl, sign_full, x1m,
+                                                             x1p, three_d);
+        v0.flux(b, X2DIR, n, k, jf, i) = dq / (rr.aface[0] * oa.scdt);
+        if (jf <= jb.e) {
+          rl = rr;
+          fill_ri(rr, n, jf + 1);
+        }
       }
     }
   }
@@ -471,41 +494,64 @@ BuildFluxLineX3(const OrbitalAdvection<GEOM> &oa, const geometry::CoordParams &c
     oa.ApplyGradSkew(ri);
   };
 
-  const auto sgn = [](const Real x) { return (x > 0.0) ? 1 : ((x < 0.0) ? -1 : 0); };
-  const int sign_full = sgn(oa.DeltaPhi(0.5 * (x1m + x1p)));
-  const int sign_lo = split ? sgn(oa.DeltaPhi(0.5 * (x1m + xroot))) : sign_full;
-  const int sign_hi = split ? sgn(oa.DeltaPhi(0.5 * (xroot + x1p))) : sign_full;
+  const int sign_full = ArtemisUtils::sgn(oa.DeltaPhi(0.5 * (x1m + x1p)));
+  const int sign_lo =
+      split ? ArtemisUtils::sgn(oa.DeltaPhi(0.5 * (x1m + xroot))) : sign_full;
+  const int sign_hi =
+      split ? ArtemisUtils::sgn(oa.DeltaPhi(0.5 * (xroot + x1p))) : sign_full;
 
-  for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
-    ReconInfo rl, rr;
-    fill_ri(rl, n, kb.s - 1);
-    fill_ri(rr, n, kb.s);
-    for (int kf = kb.s; kf <= kb.e + 1; ++kf) {
-      Real dq = 0.0;
-      if (split) {
-        if (sign_lo > 0) {
-          dq += ComputeTransferredAmount(oa, rl, rr, sign_lo, x1m, xroot, three_d);
-        } else if (sign_lo < 0) {
-          dq += sign_lo *
-                ComputeTransferredAmount(oa, rr, rl, sign_lo, x1m, xroot, three_d);
+  if (split) {
+    for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+      ReconInfo rl, rr;
+      fill_ri(rl, n, kb.s - 1);
+      fill_ri(rr, n, kb.s);
+      for (int kf = kb.s; kf <= kb.e + 1; ++kf) {
+        Real dq = 0.0;
+        if (sign_lo != 0) {
+          dq += sign_lo * ComputeTransferredAmount(oa, (sign_lo > 0) ? rl : rr,
+                                                   (sign_lo > 0) ? rr : rl, sign_lo, x1m,
+                                                   xroot, three_d);
         }
-        if (sign_hi > 0) {
-          dq += ComputeTransferredAmount(oa, rl, rr, sign_hi, xroot, x1p, three_d);
-        } else if (sign_hi < 0) {
-          dq += sign_hi *
-                ComputeTransferredAmount(oa, rr, rl, sign_hi, xroot, x1p, three_d);
+        if (sign_hi != 0) {
+          dq += sign_hi * ComputeTransferredAmount(oa, (sign_hi > 0) ? rl : rr,
+                                                   (sign_hi > 0) ? rr : rl, sign_hi,
+                                                   xroot, x1p, three_d);
         }
-      } else if (sign_full > 0) {
-        dq = ComputeTransferredAmount(oa, rl, rr, sign_full, x1m, x1p, three_d);
-      } else if (sign_full < 0) {
-        dq = sign_full *
-             ComputeTransferredAmount(oa, rr, rl, sign_full, x1m, x1p, three_d);
+        v0.flux(b, X3DIR, n, kf, j, i) = dq / (rr.aface[0] * oa.scdt);
+        if (kf <= kb.e) {
+          rl = rr;
+          fill_ri(rr, n, kf + 1);
+        }
       }
-      // Construct a flux from the amount exchanged
-      v0.flux(b, X3DIR, n, kf, j, i) = dq / (rr.aface[0] * oa.scdt);
-      if (kf <= kb.e) {
-        rl = rr;
-        fill_ri(rr, n, kf + 1);
+    }
+  } else if (sign_full > 0) {
+    for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+      ReconInfo rl, rr;
+      fill_ri(rl, n, kb.s - 1);
+      fill_ri(rr, n, kb.s);
+      for (int kf = kb.s; kf <= kb.e + 1; ++kf) {
+        const Real dq =
+            ComputeTransferredAmount(oa, rl, rr, sign_full, x1m, x1p, three_d);
+        v0.flux(b, X3DIR, n, kf, j, i) = dq / (rr.aface[0] * oa.scdt);
+        if (kf <= kb.e) {
+          rl = rr;
+          fill_ri(rr, n, kf + 1);
+        }
+      }
+    }
+  } else if (sign_full < 0) {
+    for (int n = v0.GetLowerBound(b); n <= v0.GetUpperBound(b); ++n) {
+      ReconInfo rl, rr;
+      fill_ri(rl, n, kb.s - 1);
+      fill_ri(rr, n, kb.s);
+      for (int kf = kb.s; kf <= kb.e + 1; ++kf) {
+        const Real dq = sign_full * ComputeTransferredAmount(oa, rr, rl, sign_full, x1m,
+                                                             x1p, three_d);
+        v0.flux(b, X3DIR, n, kf, j, i) = dq / (rr.aface[0] * oa.scdt);
+        if (kf <= kb.e) {
+          rl = rr;
+          fill_ri(rr, n, kf + 1);
+        }
       }
     }
   }

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -94,14 +94,6 @@ KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real gm, const Real R) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn  Real RotatingFrame::OmegaKep (R, z)
-//! \brief Returns Keplerian angular velocity at cylindrical position (R, z),
-//!        expanded to leading order in (z/R)^2
-KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real gm, const Real R, const Real z) {
-  return OmegaKep(gm, R) * (1.0 - 0.75 * z * z / (R * R));
-}
-
-//----------------------------------------------------------------------------------------
 //! \fn std::array<Real, 3> RotatingFrame::BackgroundVelocity
 //! \brief Returns the background velocity in coordinate basis.
 template <Coordinates GEOM>
@@ -112,8 +104,7 @@ BackgroundVelocity(const Real qshear, const Real omega, const Real gm,
     return {0.0, -qshear * omega * xv[0], 0.0};
   } else if constexpr (GEOM == Coordinates::cylindrical) {
     const Real R = xv[0];
-    const Real z = xv[2];
-    const Real vphi = R * (OmegaKep(gm, R, z) - omega);
+    const Real vphi = R * (OmegaKep(gm, R) - omega);
     return {0.0, vphi, 0.0};
   } else if constexpr (GEOM == Coordinates::spherical3D ||
                        GEOM == Coordinates::spherical2D) {
@@ -122,8 +113,7 @@ BackgroundVelocity(const Real qshear, const Real omega, const Real gm,
     return {0.0, 0.0, vphi};
   } else if constexpr (GEOM == Coordinates::axisymmetric) {
     const Real R = xv[0];
-    const Real z = xv[1];
-    const Real vphi = R * (OmegaKep(gm, R, z) - omega);
+    const Real vphi = R * (OmegaKep(gm, R) - omega);
     return {0.0, 0.0, vphi};
   }
   return {0.0, 0.0, 0.0};
@@ -147,31 +137,19 @@ KOKKOS_INLINE_FUNCTION std::array<Real, 3> StrainRate(const Real qshear, const R
     }
   } else if constexpr (GEOM == Coordinates::cylindrical) {
     const Real R = xf[0];
-    const Real z = xf[2];
-    const Real om_k = OmegaKep(gm, R);
-    const Real zR2 = z * z / (R * R);
-    const Real rdOdR = -1.5 * om_k * (1.0 - 1.75 * zR2);
-    const Real rdOdz = -1.5 * om_k * z / R;
+    const Real rdOdR = -1.5 * OmegaKep(gm, R);
     if constexpr (XDIR == X1DIR) {
       return {0.0, rdOdR, 0.0}; // {T_R^R, T_φ^R, T_z^R}
     } else if constexpr (XDIR == X2DIR) {
-      return {rdOdR, 0.0, rdOdz}; // {T_R^φ, T_φ^φ, T_z^φ}
-    } else if constexpr (XDIR == X3DIR) {
-      return {0.0, rdOdz, 0.0}; // {T_R^z, T_φ^z, T_z^z}
+      return {rdOdR, 0.0, 0.0}; // {T_R^φ, T_φ^φ, T_z^φ}
     }
   } else if constexpr (GEOM == Coordinates::axisymmetric) {
     const Real R = xf[0];
-    const Real z = xf[1];
-    const Real om_k = OmegaKep(gm, R);
-    const Real zR2 = z * z / (R * R);
-    const Real rdOdR = -1.5 * om_k * (1.0 - 1.75 * zR2);
-    const Real rdOdz = -1.5 * om_k * z / R;
+    const Real rdOdR = -1.5 * OmegaKep(gm, R);
     if constexpr (XDIR == X1DIR) {
       return {0.0, 0.0, rdOdR}; // {T_R^R, T_z^R, T_φ^R}
-    } else if constexpr (XDIR == X2DIR) {
-      return {0.0, 0.0, rdOdz}; // {T_R^z, T_z^z, T_φ^z}
     } else if constexpr (XDIR == X3DIR) {
-      return {rdOdR, rdOdz, 0.0}; // {T_R^φ, T_z^φ, T_φ^φ}
+      return {rdOdR, 0.0, 0.0}; // {T_R^φ, T_z^φ, T_φ^φ}
     }
   } else if constexpr (GEOM == Coordinates::spherical3D ||
                        GEOM == Coordinates::spherical2D) {
@@ -217,18 +195,13 @@ struct OrbitalAdvection {
     return std::sqrt(gm / (R * R * R));
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION Real OmegaKep(const Real R, const Real z) const {
-    return OmegaKep(R) * (1.0 - 0.75 * z * z / (R * R));
-  }
-
   KOKKOS_INLINE_FUNCTION std::array<Real, 3>
   BackgroundVelocity(const std::array<Real, 3> &xv) const {
     if constexpr (GEOM == Coordinates::cartesian) {
       return {0.0, -qshear * omega_f * xv[0], 0.0};
     } else if constexpr (GEOM == Coordinates::cylindrical) {
       const Real R = xv[0];
-      const Real z = xv[2];
-      const Real vphi = R * (OmegaKep(R, z) - omega_f);
+      const Real vphi = R * (OmegaKep(R) - omega_f);
       return {0.0, vphi, 0.0};
     } else if constexpr (GEOM == Coordinates::spherical3D ||
                          GEOM == Coordinates::spherical2D) {
@@ -237,8 +210,7 @@ struct OrbitalAdvection {
       return {0.0, 0.0, vphi};
     } else if constexpr (GEOM == Coordinates::axisymmetric) {
       const Real R = xv[0];
-      const Real z = xv[1];
-      const Real vphi = R * (OmegaKep(R, z) - omega_f);
+      const Real vphi = R * (OmegaKep(R) - omega_f);
       return {0.0, 0.0, vphi};
     }
     return {0.0, 0.0, 0.0};
@@ -248,7 +220,7 @@ struct OrbitalAdvection {
     if constexpr (GEOM == Coordinates::cartesian) {
       return dwdt * xc[0];
     } else if constexpr (GEOM == Coordinates::cylindrical) {
-      return (OmegaKep(xc[0], xc[2]) - omega_f) * scdt;
+      return (OmegaKep(xc[0]) - omega_f) * scdt;
     } else {
       return (OmegaKep(xc[0]) - omega_f) * scdt;
     }
@@ -263,12 +235,8 @@ struct OrbitalAdvection {
       ri.grad[phi_idx] += dwdt * ri.grad[0];
     } else if constexpr (GEOM == Coordinates::cylindrical) {
       const Real Rc = ri.xc[0];
-      const Real zc = ri.xc[2];
-      const Real om_k = OmegaKep(Rc);
-      const Real zR2 = zc * zc / (Rc * Rc);
-      const Real dOdR = -1.5 * om_k / Rc * (1.0 - 1.75 * zR2);
-      const Real dOdz = -1.5 * om_k * zc / (Rc * Rc);
-      ri.grad[phi_idx] += (dOdR * ri.grad[0] + dOdz * ri.grad[2]) * scdt;
+      const Real dOdR = -1.5 * OmegaKep(Rc) / Rc;
+      ri.grad[phi_idx] += dOdR * ri.grad[0] * scdt;
     } else {
       const Real rc = ri.xc[0];
       const Real dOdr = -1.5 * OmegaKep(rc) / rc;
@@ -285,15 +253,11 @@ struct OrbitalAdvection {
       return flip * dwdt * r.xc[0] * r.dx[0] * r.dx[2];
     } else if constexpr (GEOM == Coordinates::cylindrical) {
       const Real alpha = std::sqrt(gm) * scdt;
-      const Real beta = -0.75 * alpha;
       const Real omf_dt = omega_f * scdt;
       const Real Rm = r.bnds.x1[0], Rp = r.bnds.x1[1];
-      const Real zm = r.bnds.x3[0], zp = r.bnds.x3[1];
-      const Real Q0 = zp - zm;
-      const Real Q2 = (zp * zp * zp - zm * zm * zm) / 3.0;
-      return flip *
-             (alpha * PowerInt(Rm, Rp, -0.5) * Q0 + beta * PowerInt(Rm, Rp, -2.5) * Q2 -
-              omf_dt * PowerInt(Rm, Rp, 1.0) * Q0);
+      const Real Q0 = r.bnds.x3[1] - r.bnds.x3[0];
+      return flip * Q0 *
+             (alpha * PowerInt(Rm, Rp, -0.5) - omf_dt * PowerInt(Rm, Rp, 1.0));
     } else {
       const Real alpha = std::sqrt(gm) * scdt;
       const Real omf_dt = omega_f * scdt;
@@ -320,33 +284,23 @@ struct OrbitalAdvection {
               three_d * r.xc[2] * I0};
     } else if constexpr (GEOM == Coordinates::cylindrical) {
       const Real alpha = std::sqrt(gm) * scdt;
-      const Real beta = -0.75 * alpha;
       const Real omf_dt = omega_f * scdt;
       const Real Rm = r.bnds.x1[0], Rp = r.bnds.x1[1];
       const Real zm = r.bnds.x3[0], zp = r.bnds.x3[1];
-      const Real zp2 = SQR(zp), zm2 = SQR(zm);
       const Real Q0 = zp - zm;
-      const Real Q1 = 0.5 * (zp2 - zm2);
-      const Real Q2 = (zp * zp2 - zm * zm2) / 3.0;
-      const Real Q3 = 0.25 * (SQR(zp2) - SQR(zm2));
-      const Real Q4 = (std::pow(zp, 5) - std::pow(zm, 5)) / 5.0;
+      const Real Q1 = 0.5 * (SQR(zp) - SQR(zm));
 
       const Real R05 = PowerInt(Rm, Rp, -0.5);
       const Real R10 = PowerInt(Rm, Rp, 1.0);
-      const Real R25 = PowerInt(Rm, Rp, -2.5);
 
-      const Real I1R = flip * (alpha * PowerInt(Rm, Rp, 0.5) * Q0 +
-                               beta * PowerInt(Rm, Rp, -1.5) * Q2 -
-                               omf_dt * PowerInt(Rm, Rp, 2.0) * Q0);
+      const Real I1R =
+          flip * Q0 * (alpha * PowerInt(Rm, Rp, 0.5) - omf_dt * PowerInt(Rm, Rp, 2.0));
       const Real phi0 = r.bnds.x2[(vb < 0.0)];
-      const Real dphi2_int =
-          0.5 * flip *
-          (SQR(alpha) * PowerInt(Rm, Rp, -2.0) * Q0 +
-           2.0 * alpha * beta * PowerInt(Rm, Rp, -4.0) * Q2 +
-           SQR(beta) * PowerInt(Rm, Rp, -6.0) * Q4 - 2.0 * alpha * omf_dt * R05 * Q0 -
-           2.0 * beta * omf_dt * R25 * Q2 + SQR(omf_dt) * R10 * Q0);
+      const Real dphi2_int = 0.5 * flip * Q0 *
+                             (SQR(alpha) * PowerInt(Rm, Rp, -2.0) -
+                              2.0 * alpha * omf_dt * R05 + SQR(omf_dt) * R10);
       const Real I1phi = phi0 * I0 + dphi2_int;
-      const Real I1z = flip * (alpha * R05 * Q1 + beta * R25 * Q3 - omf_dt * R10 * Q1);
+      const Real I1z = flip * (alpha * R05 * Q1 - omf_dt * R10 * Q1);
       return {I1R, I1phi, I1z};
     } else {
       const Real alpha = std::sqrt(gm) * scdt;

--- a/src/rotating_frame/rotating_frame.hpp
+++ b/src/rotating_frame/rotating_frame.hpp
@@ -374,22 +374,31 @@ KOKKOS_INLINE_FUNCTION void RemapCons(const geometry::CoordParams &cpars, const 
   auto apply_skew = [&](ReconInfo &ri) {
     if constexpr (GEOM == Coordinates::cartesian) {
       ri.xc[phi_idx] += dwdt * ri.xc[rad_idx];
+    } else if constexpr (GEOM == Coordinates::cylindrical) {
+      const Real Rc = ri.xc[0];
+      const Real zc = ri.xc[2];
+      ri.xc[phi_idx] += (OmegaKep(gm, Rc, zc) - omega_f) * scdt;
     } else {
-      const Real Rc = ri.xc[rad_idx];
-      const Real alpha = std::sqrt(gm) * scdt;
-      const Real dphi_c = alpha * std::pow(Rc, -1.5) - omega_f * scdt;
-      ri.xc[phi_idx] += dphi_c;
+      const Real rc = ri.xc[0];
+      ri.xc[phi_idx] += (OmegaKep(gm, rc) - omega_f) * scdt;
     }
   };
 
   auto apply_grad_skew = [&](ReconInfo &ri) {
     if constexpr (GEOM == Coordinates::cartesian) {
       ri.grad[phi_idx] += dwdt * ri.grad[rad_idx];
+    } else if constexpr (GEOM == Coordinates::cylindrical) {
+      const Real Rc = ri.xc[0];
+      const Real zc = ri.xc[2];
+      const Real om_k = OmegaKep(gm, Rc);
+      const Real zR2 = zc * zc / (Rc * Rc);
+      const Real dOdR = -1.5 * om_k / Rc * (1.0 - 1.75 * zR2);
+      const Real dOdz = -1.5 * om_k * zc / (Rc * Rc);
+      ri.grad[phi_idx] += (dOdR * ri.grad[0] + dOdz * ri.grad[2]) * scdt;
     } else {
-      const Real Rc = ri.xc[rad_idx];
-      const Real alpha = std::sqrt(gm) * scdt;
-      const Real ddphi_dR = -1.5 * alpha * std::pow(Rc, -2.5);
-      ri.grad[phi_idx] += ddphi_dR * ri.grad[rad_idx];
+      const Real rc = ri.xc[0];
+      const Real dOdr = -1.5 * OmegaKep(gm, rc) / rc;
+      ri.grad[phi_idx] += dOdr * ri.grad[0] * scdt;
     }
   };
 
@@ -470,7 +479,7 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
           const auto xc0 = coords.GetCellCenter(vg, b, k, jb.s, i);
           const Real vb = (GEOM == Coordinates::cartesian)
                               ? (dwdt * 0.5 * (coords.bnds.x1[0] + coords.bnds.x1[1]))
-                              : ((std::sqrt(gm / (CUB(xc0[0]))) - omega_f) * scdt);
+                              : ((OmegaKep(gm, xc0[0], xc0[2]) - omega_f) * scdt);
           if (vb < 0.0) {
             RemapCons<GEOM, Upwind::r, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
                                           omega_f, scdt, b, k, jb, i);
@@ -488,7 +497,7 @@ TaskStatus LagrangeRemapImpl(MeshData<Real> *u0, const V1 &v0, const V2 &vg,
           geometry::Coords<GEOM> coords(cpars, v0.GetCoordinates(b), kb.s, j, i);
           const auto xc0 = coords.GetCellCenter(vg, b, kb.s, j, i);
           const Real Rc = xc0[0];
-          const Real vb = (std::sqrt(gm / (CUB(Rc))) - omega_f) * scdt;
+          const Real vb = (OmegaKep(gm, Rc) - omega_f) * scdt;
           if (vb < 0.0) {
             RemapCons<GEOM, Upwind::r, R>(cpars, v0, vg, multi_d, three_d, dwdt, gm,
                                           omega_f, scdt, b, j, kb, i);

--- a/src/rotating_frame/rotating_frame_impl.hpp
+++ b/src/rotating_frame/rotating_frame_impl.hpp
@@ -28,7 +28,8 @@ namespace RotatingFrame {
 //! \fn  TaskStatus ShearingBoxImpl
 //! \brief Calculate the shearing box frame body forces
 TaskStatus ShearingBoxImpl(MeshData<Real> *md, const Real om0, const Real qshear,
-                           const bool do_gas, const bool do_dust, const Real dt) {
+                           const bool do_oa, const bool do_gas, const bool do_dust,
+                           const Real dt) {
   PARTHENON_INSTRUMENT
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
@@ -50,6 +51,7 @@ TaskStatus ShearingBoxImpl(MeshData<Real> *md, const Real om0, const Real qshear
   const Real qom = qshear * om0;
   const Real two_om = 2.0 * om0;
   const Real qm2_om = qom - two_om;
+  const Real two_q_om2 = 2.0 * qshear * SQR(om0);
   const Real g3_over_x3 = (three_d) * (-SQR(om0));
 
   const auto &cpars =
@@ -62,7 +64,9 @@ TaskStatus ShearingBoxImpl(MeshData<Real> *md, const Real om0, const Real qshear
         // Evaluate vertical gravity
         geometry::Coords<Coordinates::cartesian> coords(cpars, vmesh.GetCoordinates(b), k,
                                                         j, i);
+        const Real x1 = coords.x1v();
         const Real g3 = g3_over_x3 * coords.x3v();
+        const Real gx1 = two_q_om2 * x1;
 
         if (do_gas) {
           for (int n = 0; n < vmesh.GetSize(b, gas::prim::density()); ++n) {
@@ -71,11 +75,13 @@ TaskStatus ShearingBoxImpl(MeshData<Real> *md, const Real om0, const Real qshear
             const Real &v2 = vmesh(b, gas::prim::velocity(VI(n, 1)), k, j, i);
             const Real &v3 = vmesh(b, gas::prim::velocity(VI(n, 2)), k, j, i);
             const Real rdt = dd * dt;
-            vmesh(b, gas::cons::momentum(VI(n, 0)), k, j, i) += rdt * two_om * v2;
-            vmesh(b, gas::cons::momentum(VI(n, 1)), k, j, i) += rdt * qm2_om * v1;
+            const Real src1 = do_oa ? (two_om * v2) : (two_om * v2 + gx1);
+            const Real src2 = do_oa ? (qm2_om * v1) : (-two_om * v1);
+            const Real src_e = do_oa ? (qom * v1 * v2 + v3 * g3) : (v1 * gx1 + v3 * g3);
+            vmesh(b, gas::cons::momentum(VI(n, 0)), k, j, i) += rdt * src1;
+            vmesh(b, gas::cons::momentum(VI(n, 1)), k, j, i) += rdt * src2;
             vmesh(b, gas::cons::momentum(VI(n, 2)), k, j, i) += rdt * g3;
-            vmesh(b, gas::cons::total_energy(n), k, j, i) +=
-                rdt * (qom * v1 * v2 + v3 * g3);
+            vmesh(b, gas::cons::total_energy(n), k, j, i) += rdt * src_e;
           }
         }
 
@@ -85,8 +91,10 @@ TaskStatus ShearingBoxImpl(MeshData<Real> *md, const Real om0, const Real qshear
             const Real &v1 = vmesh(b, dust::prim::velocity(VI(n, 0)), k, j, i);
             const Real &v2 = vmesh(b, dust::prim::velocity(VI(n, 1)), k, j, i);
             const Real rdt = dd * dt;
-            vmesh(b, dust::cons::momentum(VI(n, 0)), k, j, i) += rdt * two_om * v2;
-            vmesh(b, dust::cons::momentum(VI(n, 1)), k, j, i) += rdt * qm2_om * v1;
+            const Real src1 = do_oa ? (two_om * v2) : (two_om * v2 + gx1);
+            const Real src2 = do_oa ? (qm2_om * v1) : (-two_om * v1);
+            vmesh(b, dust::cons::momentum(VI(n, 0)), k, j, i) += rdt * src1;
+            vmesh(b, dust::cons::momentum(VI(n, 1)), k, j, i) += rdt * src2;
             vmesh(b, dust::cons::momentum(VI(n, 2)), k, j, i) += rdt * g3;
           }
         }

--- a/src/rotating_frame/rotating_frame_impl.hpp
+++ b/src/rotating_frame/rotating_frame_impl.hpp
@@ -99,11 +99,20 @@ TaskStatus ShearingBoxImpl(MeshData<Real> *md, const Real om0, const Real qshear
 //! \fn  TaskStatus RotatingFrameImpl
 //! \brief Calculate the rotating frame body forces
 template <Coordinates GEOM>
-TaskStatus RotatingFrameImpl(MeshData<Real> *md, const Real om0, const bool do_gas,
-                             const bool do_dust, const Real dt) {
+TaskStatus RotatingFrameImpl(MeshData<Real> *md, const Real om0, const bool do_oa,
+                             const Real gm, const bool do_gas, const bool do_dust,
+                             const Real dt) {
   PARTHENON_INSTRUMENT
   // Adds the rotating frame terms to the azimuthal momentum equation and the energy
   // equation. Note that in comments in this function, R is always the cylindrical radius.
+  //
+  // When orbital advection is active, the stored primitive velocity is
+  //   v_stored = v_full - v_bg(R)
+  // where v_bg = R*(OmegaKep(R) - omega_f) in the phi direction. The Riemann solver
+  // transports the stored momentum, so we must correct for the missing background
+  // angular momentum flux: d(rho*v_stored)/dt -= (1/V) * div(F_rho * v_bg).
+  // The RF part (omega_f * R) uses the RFWeights formulation; the OA part uses
+  // face-centered v_bg directly.
 
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
@@ -146,9 +155,47 @@ TaskStatus RotatingFrameImpl(MeshData<Real> *md, const Real om0, const bool do_g
         const auto &ax2 = coords.GetFaceAreaX2(vg, b, k, j, i);
         const auto &ax3 = coords.GetFaceAreaX3(vg, b, k, j, i);
         const Real vol = coords.GetVolume(vg, b, k, j, i);
+
+        // Compute face-centered OA background angular velocity (OmegaKep - omega_f)
+        // for the orbital advection transport correction.
+        // Face coordinates give us R at each face.
+        Real oa_lbg_x1m = 0.0, oa_lbg_x1p = 0.0;
+        Real oa_lbg_x2m = 0.0, oa_lbg_x2p = 0.0;
+        Real oa_lbg_x3m = 0.0, oa_lbg_x3p = 0.0;
+        if (do_oa) {
+          const Real Rc = xcyl[0];
+          const Real lbg_c = Rc * Rc * (OmegaKep(gm, xv[0]) - om0);
+
+          // x1 faces
+          const auto xf1m = coords.FaceCenX1(geometry::CellFace::lower);
+          const auto xf1p = coords.FaceCenX1(geometry::CellFace::upper);
+          const Real Rf1m = coords.ConvertToCyl(xf1m)[0];
+          const Real Rf1p = coords.ConvertToCyl(xf1p)[0];
+          oa_lbg_x1m = lbg_c - Rf1m * Rf1m * (OmegaKep(gm, xf1m[0]) - om0);
+          oa_lbg_x1p = Rf1p * Rf1p * (OmegaKep(gm, xf1p[0]) - om0) - lbg_c;
+
+          if (multi_d) {
+            const auto xf2m = coords.FaceCenX2(geometry::CellFace::lower);
+            const auto xf2p = coords.FaceCenX2(geometry::CellFace::upper);
+            const Real Rf2m = coords.ConvertToCyl(xf2m)[0];
+            const Real Rf2p = coords.ConvertToCyl(xf2p)[0];
+            oa_lbg_x2m = lbg_c - Rf2m * Rf2m * (OmegaKep(gm, xf2m[0]) - om0);
+            oa_lbg_x2p = Rf2p * Rf2p * (OmegaKep(gm, xf2p[0]) - om0) - lbg_c;
+          }
+          if (three_d) {
+            const auto xf3m = coords.FaceCenX3(geometry::CellFace::lower);
+            const auto xf3p = coords.FaceCenX3(geometry::CellFace::upper);
+            const Real Rf3m = coords.ConvertToCyl(xf3m)[0];
+            const Real Rf3p = coords.ConvertToCyl(xf3p)[0];
+            oa_lbg_x3m = lbg_c - Rf3m * Rf3m * (OmegaKep(gm, xf3m[0]) - om0);
+            oa_lbg_x3p = Rf3p * Rf3p * (OmegaKep(gm, xf3p[0]) - om0) - lbg_c;
+          }
+        }
+
         if (do_gas) {
           for (int n = 0; n < vf.GetSize(b, gas::cons::density()); ++n) {
 
+            // Rotating frame angular momentum transport correction (omega * R^2 part)
             const Real divf =
                 (vf.flux(b, X1DIR, gas::cons::density(n), k, j, i) * ax1[0] * bx1[0] +
                  vf.flux(b, X1DIR, gas::cons::density(n), k, j, i + 1) * ax1[1] *
@@ -162,12 +209,31 @@ TaskStatus RotatingFrameImpl(MeshData<Real> *md, const Real om0, const bool do_g
                      vf.flux(b, X3DIR, gas::cons::density(n), k + three_d, j, i) *
                          ax3[1] * bx3[1]);
 
-            // dUphi/dt = - f . phi_hat where f = div.F phi_hat,cyl
-            vf(b, gas::cons::momentum(VI(n, 0)), k, j, i) -= omdt * (divf / vol) * ex1[1];
-            vf(b, gas::cons::momentum(VI(n, 1)), k, j, i) -= omdt * (divf / vol) * ex2[1];
-            vf(b, gas::cons::momentum(VI(n, 2)), k, j, i) -= omdt * (divf / vol) * ex3[1];
+            // OA angular momentum transport correction
+            // div(F_rho * l_bg) using face-centered l_bg
+            Real oa_divfl = 0.0;
+            if (do_oa) {
+              oa_divfl =
+                  (vf.flux(b, X1DIR, gas::cons::density(n), k, j, i) * ax1[0] *
+                       oa_lbg_x1m +
+                   vf.flux(b, X1DIR, gas::cons::density(n), k, j, i + 1) * ax1[1] *
+                       oa_lbg_x1p) +
+                  multi_d * (vf.flux(b, X2DIR, gas::cons::density(n), k, j, i) * ax2[0] *
+                                 oa_lbg_x2m +
+                             vf.flux(b, X2DIR, gas::cons::density(n), k, j + multi_d, i) *
+                                 ax2[1] * oa_lbg_x2p) +
+                  three_d * (vf.flux(b, X3DIR, gas::cons::density(n), k, j, i) * ax3[0] *
+                                 oa_lbg_x3m +
+                             vf.flux(b, X3DIR, gas::cons::density(n), k + three_d, j, i) *
+                                 ax3[1] * oa_lbg_x3p);
+            }
 
-            // average or area weighted? (Fm + Fp)/2 or (Ap*Fp + Am*Fm)/(Am + Ap)
+            const Real mom_src = dt / vol * (om0 * divf + oa_divfl);
+            vf(b, gas::cons::momentum(VI(n, 0)), k, j, i) -= mom_src * ex1[1];
+            vf(b, gas::cons::momentum(VI(n, 1)), k, j, i) -= mom_src * ex2[1];
+            vf(b, gas::cons::momentum(VI(n, 2)), k, j, i) -= mom_src * ex3[1];
+
+            // Energy correction: only the rotating frame centrifugal work
             const Real fx[3] = {
                 0.5 * (vf.flux(b, X1DIR, gas::cons::density(n), k, j, i) +
                        vf.flux(b, X1DIR, gas::cons::density(n), k, j, i + 1)),
@@ -185,6 +251,7 @@ TaskStatus RotatingFrameImpl(MeshData<Real> *md, const Real om0, const bool do_g
         }
         if (do_dust) {
           for (int n = 0; n < vf.GetSize(b, dust::cons::density()); ++n) {
+            // Rotating frame correction
             const Real divf =
                 (vf.flux(b, X1DIR, dust::cons::density(n), k, j, i) * ax1[0] * bx1[0] +
                  vf.flux(b, X1DIR, dust::cons::density(n), k, j, i + 1) * ax1[1] *
@@ -198,12 +265,30 @@ TaskStatus RotatingFrameImpl(MeshData<Real> *md, const Real om0, const bool do_g
                            vf.flux(b, X3DIR, dust::cons::density(n), k + three_d, j, i) *
                                ax3[1] * bx3[1]);
 
-            vf(b, dust::cons::momentum(VI(n, 0)), k, j, i) -=
-                omdt * (divf / vol) * ex1[1];
-            vf(b, dust::cons::momentum(VI(n, 1)), k, j, i) -=
-                omdt * (divf / vol) * ex2[1];
-            vf(b, dust::cons::momentum(VI(n, 2)), k, j, i) -=
-                omdt * (divf / vol) * ex3[1];
+            // OA correction for dust
+            Real oa_divfl = 0.0;
+            if (do_oa) {
+              oa_divfl =
+                  (vf.flux(b, X1DIR, dust::cons::density(n), k, j, i) * ax1[0] *
+                       oa_lbg_x1m +
+                   vf.flux(b, X1DIR, dust::cons::density(n), k, j, i + 1) * ax1[1] *
+                       oa_lbg_x1p) +
+                  multi_d *
+                      (vf.flux(b, X2DIR, dust::cons::density(n), k, j, i) * ax2[0] *
+                           oa_lbg_x2m +
+                       vf.flux(b, X2DIR, dust::cons::density(n), k, j + multi_d, i) *
+                           ax2[1] * oa_lbg_x2p) +
+                  three_d *
+                      (vf.flux(b, X3DIR, dust::cons::density(n), k, j, i) * ax3[0] *
+                           oa_lbg_x3m +
+                       vf.flux(b, X3DIR, dust::cons::density(n), k + three_d, j, i) *
+                           ax3[1] * oa_lbg_x3p);
+            }
+
+            const Real mom_src = dt / vol * (om0 * divf + oa_divfl);
+            vf(b, dust::cons::momentum(VI(n, 0)), k, j, i) -= mom_src * ex1[1];
+            vf(b, dust::cons::momentum(VI(n, 1)), k, j, i) -= mom_src * ex2[1];
+            vf(b, dust::cons::momentum(VI(n, 2)), k, j, i) -= mom_src * ex3[1];
           }
         }
       });

--- a/src/utils/artemis_utils.hpp
+++ b/src/utils/artemis_utils.hpp
@@ -28,6 +28,14 @@ KOKKOS_FORCEINLINE_FUNCTION
 static int VI(const int n, const int d) { return n * 3 + d; }
 
 //----------------------------------------------------------------------------------------
+//! \fn int ArtemisUtils::sgn
+//! \brief Returns the sign (-1,0,1) of the value
+template <typename T>
+KOKKOS_FORCEINLINE_FUNCTION int sgn(const T x) {
+  return (x > T{0}) ? 1 : ((x < T{0}) ? -1 : 0);
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn Real ArtemisUtils::VDot(const Real a[3], const Real b[3])
 //! \brief Returns dot product of input vectors a and b
 template <typename V1, typename V2>

--- a/src/utils/diffusion/momentum_diffusion.hpp
+++ b/src/utils/diffusion/momentum_diffusion.hpp
@@ -707,7 +707,11 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
                                                         multi_d, three_d, qshear, om0,
                                                         gm_bg, vprim, vg, flx);
 
-              // 2. Viscosity values. No barrier
+              // 2. Compute div(u) on this pencil
+              VelocityDivergence<GEOM, FLUID_TYPE>(mbr, cpars, b, n, k, j, il, iu,
+                                                   multi_d, three_d, vprim, vg, divu_jm1);
+
+              // 3. Viscosity values. No barrier
               DiffusionCoeff<DIFF, GEOM, FLUID_TYPE> diffcoeff;
               diffcoeff.evaluate(dp, mbr, b, n, k, j, il, iu, vprim, eos_d, mu_jm1);
 

--- a/src/utils/diffusion/momentum_diffusion.hpp
+++ b/src/utils/diffusion/momentum_diffusion.hpp
@@ -610,7 +610,7 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
   if (do_oa || do_rf) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
     qshear = rframe_pkg->template Param<Real>("qshear");
-    om0 = rframe_pkg->template Param<Real>("omega");
+    om0 = do_rf ? rframe_pkg->template Param<Real>("omega") : 0.0;
     gm_bg = rframe_pkg->template Param<Real>("gm");
   }
   const auto &cpars =

--- a/src/utils/diffusion/momentum_diffusion.hpp
+++ b/src/utils/diffusion/momentum_diffusion.hpp
@@ -35,8 +35,8 @@ KOKKOS_INLINE_FUNCTION void
 StrainTensorFace(parthenon::team_mbr_t const &member, const geometry::CoordParams &cpars,
                  const int b, const int n, const int k, const int j, const int il,
                  const int iu, const int multi_d, const int three_d, const Real qshear,
-                 const Real om0, const SparsePack &vprim, const SparsePackGeom &vg,
-                 const parthenon::ScratchPad2D<Real> &flx) {
+                 const Real om0, const Real gm_bg, const SparsePack &vprim,
+                 const SparsePackGeom &vg, const parthenon::ScratchPad2D<Real> &flx) {
   // Fill the flx array with the strain tensor on the specified face
   //
   //
@@ -352,7 +352,7 @@ StrainTensorFace(parthenon::team_mbr_t const &member, const geometry::CoordParam
 
     // Add any strain rate due to the background shear velocity.
     // Uses the analytic expression at the face center
-    const auto Eb = RotatingFrame::StrainRate<GEOM, XDIR>(qshear, om0, xf);
+    const auto Eb = RotatingFrame::StrainRate<GEOM, XDIR>(qshear, om0, gm_bg, xf);
     flx(0, i) += Eb[0];
     flx(1, i) += Eb[1];
     flx(2, i) += Eb[2];
@@ -602,12 +602,16 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
   auto pm = md->GetParentPointer();
   auto eos_d = pkg->template Param<EOS>("eos_d");
 
-  Real qshear = 0.0, om0 = 0.0;
-  const bool do_shear = pm->packages.Get("artemis")->template Param<bool>("do_shear");
-  if (do_shear) {
+  Real qshear = 0.0, om0 = 0.0, gm_bg = 0.0;
+  const bool do_oa =
+      pm->packages.Get("artemis")->template Param<bool>("do_orbital_advection");
+  const bool do_rf =
+      pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame");
+  if (do_oa || do_rf) {
     auto &rframe_pkg = pm->packages.Get("rotating_frame");
     qshear = rframe_pkg->template Param<Real>("qshear");
     om0 = rframe_pkg->template Param<Real>("omega");
+    gm_bg = rframe_pkg->template Param<Real>("gm");
   }
   const auto &cpars =
       pm->packages.Get("artemis")->template Param<geometry::CoordParams>("coord_params");
@@ -648,8 +652,8 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
 
           // 1. Compute the strain tensor at i-1/2
           StrainTensorFace<GEOM, FLUID_TYPE, X1DIR>(mbr, cpars, b, n, k, j, il, iu,
-                                                    multi_d, three_d, qshear, om0, vprim,
-                                                    vg, flx);
+                                                    multi_d, three_d, qshear, om0, gm_bg,
+                                                    vprim, vg, flx);
 
           // 2. Compute div(u) on this pencil
           VelocityDivergence<GEOM, FLUID_TYPE>(mbr, cpars, b, n, k, j, il - 1, iu,
@@ -701,10 +705,7 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
               // 1. Compute the momentum fluxes at j+1/2
               StrainTensorFace<GEOM, FLUID_TYPE, X2DIR>(mbr, cpars, b, n, k, j, il, iu,
                                                         multi_d, three_d, qshear, om0,
-                                                        vprim, vg, flx);
-              // 2. Compute div(u) on this pencil
-              VelocityDivergence<GEOM, FLUID_TYPE>(mbr, cpars, b, n, k, j, il, iu,
-                                                   multi_d, three_d, vprim, vg, divu_jm1);
+                                                        gm_bg, vprim, vg, flx);
 
               // 2. Viscosity values. No barrier
               DiffusionCoeff<DIFF, GEOM, FLUID_TYPE> diffcoeff;
@@ -755,7 +756,7 @@ TaskStatus MomentumFluxImpl(MeshData<Real> *md, DiffCoeffParams dp, PKG &pkg,
               // 1. Compute the momentum fluxes at k-1/2
               StrainTensorFace<GEOM, FLUID_TYPE, X3DIR>(mbr, cpars, b, n, k, j, il, iu,
                                                         multi_d, three_d, qshear, om0,
-                                                        vprim, vg, flx);
+                                                        gm_bg, vprim, vg, flx);
               // 2. Compute div(u) on this pencil
               VelocityDivergence<GEOM, FLUID_TYPE>(mbr, cpars, b, n, k, j, il, iu,
                                                    multi_d, three_d, vprim, vg, divu_km1);

--- a/src/utils/fluxes/fluid_fluxes.hpp
+++ b/src/utils/fluxes/fluid_fluxes.hpp
@@ -294,10 +294,11 @@ TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FAC
         [[maybe_unused]] Real omf_ = omf;
         [[maybe_unused]] Real qshear_ = qshear;
         [[maybe_unused]] Real gm_ = gm;
+        [[maybe_unused]] bool do_oa_ = do_oa;
         if constexpr (F != Fluid::radiation) {
           const auto &xv = coords.GetCellCenter(vg, b, k, j, i);
           rfv = RotatingFrame::RotationVelocity<G>(xv, omf_);
-          if (do_oa) {
+          if (do_oa_) {
             const auto bgv = RotatingFrame::BackgroundVelocity<G>(qshear_, omf_, gm_, xv);
             for (int d = 0; d < 3; d++)
               rfv[d] += bgv[d];

--- a/src/utils/fluxes/fluid_fluxes.hpp
+++ b/src/utils/fluxes/fluid_fluxes.hpp
@@ -251,7 +251,8 @@ TaskStatus CalculateFluxesImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, FLUX vflx,
 template <Coordinates G, Fluid F, Closure C, typename PKG, typename PRIM, typename CONS,
           typename FACE, typename GEO>
 TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FACE vface,
-                          GEO vg, const Real omf, const Real dt) {
+                          GEO vg, const Real omf, const bool do_oa, const Real gm,
+                          const Real qshear, const Real dt) {
   PARTHENON_INSTRUMENT
   // Indexing and geometry
   const auto ib = md->GetBoundsI(IndexDomain::interior);
@@ -291,9 +292,16 @@ TaskStatus FluxSourceImpl(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FAC
         // Get the rotational velocity
         std::array<Real, 3> rfv{0.0};
         [[maybe_unused]] Real omf_ = omf;
+        [[maybe_unused]] Real qshear_ = qshear;
+        [[maybe_unused]] Real gm_ = gm;
         if constexpr (F != Fluid::radiation) {
           const auto &xv = coords.GetCellCenter(vg, b, k, j, i);
           rfv = RotatingFrame::RotationVelocity<G>(xv, omf_);
+          if (do_oa) {
+            const auto bgv = RotatingFrame::BackgroundVelocity<G>(qshear_, omf_, gm_, xv);
+            for (int d = 0; d < 3; d++)
+              rfv[d] += bgv[d];
+          }
         }
 
         // Timestep weighted by dx
@@ -516,28 +524,44 @@ TaskStatus FluxSource(MeshData<Real> *md, PKG &pkg, PRIM vp, CONS vcons, FACE vf
                       GEO vg, const Real dt) {
   auto pm = md->GetParentPointer();
 
-  // Extract rotating frame omega
+  // Extract rotating frame and orbital advection parameters
   Real omf = 0.0;
-  if (pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame")) {
+  bool do_oa = false;
+  Real gm = 0.0;
+  Real qshear = 0.0;
+  const bool do_rf =
+      pm->packages.Get("artemis")->template Param<bool>("do_rotating_frame");
+  const bool do_orbital =
+      pm->packages.Get("artemis")->template Param<bool>("do_orbital_advection");
+  if (do_rf || do_orbital) {
     auto &rf_pkg = pm->packages.Get("rotating_frame");
-    omf = rf_pkg->template Param<Real>("omega");
+    omf = do_rf ? rf_pkg->template Param<Real>("omega") : 0.0;
+    do_oa = rf_pkg->template Param<bool>("do_orbital_advection");
+    gm = rf_pkg->template Param<Real>("gm");
+    qshear = rf_pkg->template Param<Real>("qshear");
   }
 
   // Call FluxSourceImpl given
   typedef Coordinates G;
   const auto sys = pkg->template Param<Coordinates>("coords");
   if (sys == G::cartesian) {
-    return FluxSourceImpl<G::cartesian, F, C>(md, pkg, vp, vcons, vface, vg, omf, dt);
+    return FluxSourceImpl<G::cartesian, F, C>(md, pkg, vp, vcons, vface, vg, omf, do_oa,
+                                              gm, qshear, dt);
   } else if (sys == G::spherical3D) {
-    return FluxSourceImpl<G::spherical3D, F, C>(md, pkg, vp, vcons, vface, vg, omf, dt);
+    return FluxSourceImpl<G::spherical3D, F, C>(md, pkg, vp, vcons, vface, vg, omf, do_oa,
+                                                gm, qshear, dt);
   } else if (sys == G::spherical1D) {
-    return FluxSourceImpl<G::spherical1D, F, C>(md, pkg, vp, vcons, vface, vg, omf, dt);
+    return FluxSourceImpl<G::spherical1D, F, C>(md, pkg, vp, vcons, vface, vg, omf, do_oa,
+                                                gm, qshear, dt);
   } else if (sys == G::spherical2D) {
-    return FluxSourceImpl<G::spherical2D, F, C>(md, pkg, vp, vcons, vface, vg, omf, dt);
+    return FluxSourceImpl<G::spherical2D, F, C>(md, pkg, vp, vcons, vface, vg, omf, do_oa,
+                                                gm, qshear, dt);
   } else if (sys == G::cylindrical) {
-    return FluxSourceImpl<G::cylindrical, F, C>(md, pkg, vp, vcons, vface, vg, omf, dt);
+    return FluxSourceImpl<G::cylindrical, F, C>(md, pkg, vp, vcons, vface, vg, omf, do_oa,
+                                                gm, qshear, dt);
   } else if (sys == G::axisymmetric) {
-    return FluxSourceImpl<G::axisymmetric, F, C>(md, pkg, vp, vcons, vface, vg, omf, dt);
+    return FluxSourceImpl<G::axisymmetric, F, C>(md, pkg, vp, vcons, vface, vg, omf,
+                                                 do_oa, gm, qshear, dt);
   } else {
     PARTHENON_FAIL("Coordinate type not recognized!");
   }

--- a/tst/scripts/nbody/nbody.py
+++ b/tst/scripts/nbody/nbody.py
@@ -63,10 +63,19 @@ def analyze():
     os.makedirs(artemis.get_fig_dir(), exist_ok=True)
     analyze_status = True
 
-    time, r, phi, z, [d, u, v, w, T], _ = analysis.load_level(
+    time, x, phi, z, [d, u, v, w, T], logx = analysis.load_level(
         "final", base="{}.out1".format(_file_id), dir=artemis.get_data_dir()
     )
-    rc = 0.5 * (r[1:] + r[:-1])
+    if logx:
+        r = np.exp(x)
+    else:
+        r = x
+
+    rc = (2.0 / 3.0) * (r[1:] ** 3 - r[:-1] ** 3) / (r[1:] ** 2 - r[:-1] ** 2)
+    if logx:
+        xc = np.log(rc)
+    else:
+        xc = rc
     pc = 0.5 * (phi[1:] + phi[:-1])
 
     h = 0.05
@@ -87,8 +96,12 @@ def analyze():
     axes[0].set_ylim(np.pi - 0.8, np.pi + 0.8)
 
     # Indices for the inner and outer evalulation rings
-    ii = np.argwhere(rc >= 1 - 0.1)[0][0]
-    io = np.argwhere(rc >= 1 + 0.1)[0][0]
+    if logx:
+        ii = np.argwhere(xc >= np.log(1 - 0.1))[0][0]
+        io = np.argwhere(xc >= np.log(1 + 0.1))[0][0]
+    else:
+        ii = np.argwhere(rc >= 1 - 0.1)[0][0]
+        io = np.argwhere(rc >= 1 + 0.1)[0][0]
 
     # the azimuthal locations of the spirals approximated as
     # where the max occurs


### PR DESCRIPTION
## Background

This extends our linear advection machinery to work in spherical and cylindrical coordinates where the background velocity is assumed to be keplerian. 

To keep the overlap integrals analytic, we make the approximation that in cylindrical/axisymmetric coordinates the radius in the keplerian Omega is the cylindrical R but in spherical is the spherical r. 

This was done with the help of GPT (I still need to put the AI statement in the files).

This more or less works, but it's not quite ready yet.

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
- [ ] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was created in part or in whole by generative AI`