### PR TITLE
pgen fixes, blast initial location

### DIFF
--- a/src/pgen/blast.hpp
+++ b/src/pgen/blast.hpp
@@ -191,12 +191,12 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         for (int n = 0; n < 3; n++) {
           xcart[n] -= xc[n];
         }
-        coords.bnds.x1[0] -= xc[0];
-        coords.bnds.x1[1] -= xc[0];
-        coords.bnds.x2[0] -= xc[1];
-        coords.bnds.x2[1] -= xc[1];
-        coords.bnds.x3[0] -= xc[2];
-        coords.bnds.x3[1] -= xc[2];
+        coords.bnds.x1[0] -= pars.x0[0];
+        coords.bnds.x1[1] -= pars.x0[0];
+        coords.bnds.x2[0] -= pars.x0[1];
+        coords.bnds.x2[1] -= pars.x0[1];
+        coords.bnds.x3[0] -= pars.x0[2];
+        coords.bnds.x3[1] -= pars.x0[2];
 
         if (pars.type == 1) { // spherical
           // Intersection volume

--- a/src/pgen/blast.hpp
+++ b/src/pgen/blast.hpp
@@ -191,6 +191,12 @@ inline void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         for (int n = 0; n < 3; n++) {
           xcart[n] -= xc[n];
         }
+        coords.bnds.x1[0] -= xc[0];
+        coords.bnds.x1[1] -= xc[0];
+        coords.bnds.x2[0] -= xc[1];
+        coords.bnds.x2[1] -= xc[1];
+        coords.bnds.x3[0] -= xc[2];
+        coords.bnds.x3[1] -= xc[2];
 
         if (pars.type == 1) { // spherical
           // Intersection volume

--- a/src/pgen/blast.hpp
+++ b/src/pgen/blast.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
## Background
Noticed that in blast problems, changes in initial blast location were not being accounted for. 

## Description of Changes
Adjusted pgen/blast.hpp to properly account for initial blast location when computing cell boundaries.

## Checklist

- [x] New features are documented
- [x] (@lanl.gov employees) Update copyright on changed files
- [x] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was created in part or in whole by generative AI`