### PR TITLE
Draft: More robust restart detection

### DIFF
--- a/doc/src/running.rst
+++ b/doc/src/running.rst
@@ -220,8 +220,7 @@ Return codes
 ^^^^^^^^^^^^
 
 When using batch submissions, it is possible to set up a self-restarting job.
-The easiest way to do this is to take advantage of SLURM interrupt signals and the |code| return code.
-|code|
+The easiest way to do this is to take advantage of SLURM interrupt signals and the ``DO-NOT-RESTART` file that |code| writes.
 
 An example CPU batch submission script, ``run.sh``, would look like:
 
@@ -233,7 +232,6 @@ An example CPU batch submission script, ``run.sh``, would look like:
   #SBATCH --ntasks-per-node=128
   #SBATCH -t 16:00:00
 
-  set -o pipefail
 
   if [ ! -f name.final.rst ]; then
     echo "Starting fresh"
@@ -243,19 +241,10 @@ An example CPU batch submission script, ``run.sh``, would look like:
     srun -n $SLURM_NPROCS artemis -r name.final.rst -t 15:50:00
   fi
 
-  EXITCODE=$?
-
-  set +o pipefail
-
-  if [[ $EXITCODE -eq 2 ]]; then
+  if [[ ! -f DO-NOT-RESTART ]];
    echo "Resubmitting"
    sbatch run.sh
   fi
 
 This stops |code| 10 minutes before the job ends.
-If the simulation has completed by then, |code| will return ``0``.
-Instead if it hasn't reached its end time yet, it will return ``2``.
-And if the simulation crashed for some reason, it will return ``1``.
-If the return code is ``2``, the batch script will resubmit itself.
-
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,8 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
+#include <filesystem>
+#include <fstream>
 // Parthenon includes
 #include <defs.hpp>
 #include <parthenon_manager.hpp>
@@ -137,6 +139,9 @@ int ArtemisFinalize(const DriverStatus status, const bool quick_exit,
   } else if (status == DriverStatus::timeout) {
     if (Globals::my_rank == 0) std::cout << "artemis driver timed out!" << std::endl;
     ret = 2;
+    // remove the DO-NOT-RESTART file
+    // every proc does this, so the first one wins
+    std::filesystem::remove("DO-NOT-RESTART");
   } else {
     PARTHENON_WARN("artemis driver returned with an unknown code!");
   }
@@ -173,6 +178,16 @@ int main(int argc, char *argv[]) {
     pman.ParthenonFinalize();
     return 1;
   }
+
+  // Check for restart and create the DO-NOT-RESTART file
+  if (std::filesystem::exists("DO-NOT-RESTART")) {
+    PARTHENON_REQUIRE(!Globals::is_restart,
+                      "Trying to restart but DO-NOT-RESTART file exists!");
+  } else {
+    std::ofstream file("DO-NOT-RESTART");
+    file.close();
+  }
+
   // Redefine parthenon defaults
   pman.app_input->ProcessPackages = ProcessPackages;
 

--- a/tst/scripts/utils/artemis.py
+++ b/tst/scripts/utils/artemis.py
@@ -136,6 +136,10 @@ def run(nproc, input_filename, arguments, restart=None):
         run_command += ["--oversubscribe"]
     run_command += ["-n", str(nproc), os.path.join(artemis_exe_dir, "artemis")]
     if restart is not None:
+        try:
+            os.remove(os.path.join(artemis_outputs_dir, "DO-NOT-RESTART"))
+        except:
+            pass
         run_command += ["-r", os.path.join(artemis_data_dir, restart)]
     run_command += ["-i", os.path.join(artemis_inputs_dir, input_filename)]
     run_command += ["-d", artemis_data_dir]


### PR DESCRIPTION
Before, we were checking the actual return code of artemis to determine if we should restart or not. This can run into an issue in slurm where once `srun` detects that one process has exited it will send `SIGTERM` to all remaining processes which causes them to return with code 143 instead of the artemis value. 

Because of this, I have added a file detection based scheme that on startup touches a file called `DO-NOT-RESTART`. The only way to remove this file is for the driver to return with `timeout` at which point the code removes the file. If you try to restart the code and this file is present, it will fatal. Automatic resubmission should check for the existence of that file before restarting. I have updated the docs to reflect this.

I have tested this by hand and it works as expected.

Closes #131 
## Background

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
- [ ] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was created in part or in whole by generative AI`