### PR TITLE
Ignore dirty submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "external/parthenon"]
-	path = external/parthenon
-	url = https://github.com/parthenon-hpc-lab/parthenon.git
+  path = external/parthenon
+  url = https://github.com/parthenon-hpc-lab/parthenon.git
   ignore = dirty
 [submodule "external/singularity-eos"]
-	path = external/singularity-eos
-	url = https://github.com/lanl/singularity-eos.git
+  path = external/singularity-eos
+  url = https://github.com/lanl/singularity-eos.git
   ignore = dirty
 [submodule "external/rebound"]
-	path = external/rebound
-	url = https://github.com/hannorein/rebound
+  path = external/rebound
+  url = https://github.com/hannorein/rebound
   ignore = dirty
 [submodule "external/singularity-opac"]
-	path = external/singularity-opac
-	url = https://github.com/lanl/singularity-opac.git
+  path = external/singularity-opac
+  url = https://github.com/lanl/singularity-opac.git
   ignore = dirty
 [submodule "external/jaybenne"]
-	path = external/jaybenne
-	url = https://github.com/lanl/jaybenne.git
+  path = external/jaybenne
+  url = https://github.com/lanl/jaybenne.git
   ignore = dirty
 [submodule "external/Catch2"]
-	path = external/Catch2
-	url = https://github.com/catchorg/Catch2.git
+  path = external/Catch2
+  url = https://github.com/catchorg/Catch2.git
   ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,24 @@
 [submodule "external/parthenon"]
 	path = external/parthenon
 	url = https://github.com/parthenon-hpc-lab/parthenon.git
+  ignore = dirty
 [submodule "external/singularity-eos"]
 	path = external/singularity-eos
 	url = https://github.com/lanl/singularity-eos.git
+  ignore = dirty
 [submodule "external/rebound"]
 	path = external/rebound
 	url = https://github.com/hannorein/rebound
+  ignore = dirty
 [submodule "external/singularity-opac"]
 	path = external/singularity-opac
 	url = https://github.com/lanl/singularity-opac.git
+  ignore = dirty
 [submodule "external/jaybenne"]
 	path = external/jaybenne
 	url = https://github.com/lanl/jaybenne.git
+  ignore = dirty
 [submodule "external/Catch2"]
 	path = external/Catch2
 	url = https://github.com/catchorg/Catch2.git
+  ignore = dirty


### PR DESCRIPTION
## Background

I don't know why we didn't do this a long time ago. This will get rid of the submodules showing up in `git status` or `git diff` if there was no change to them other than any things that changed from building the code.

We could go one step further and do `ignore = untracked` to ignore untracked files that may have been added, but that sounds more dangerous.


## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
- [ ] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was created in part or in whole by generative AI`