### PR TITLE
Fix bulkmod bug

### DIFF
--- a/src/utils/fluxes/reconstruction/reconstruction.hpp
+++ b/src/utils/fluxes/reconstruction/reconstruction.hpp
@@ -84,7 +84,7 @@ post_recon(const EOS &eos, const Real dfloor, const Real siefloor,
                                  Real &dL = ql(IDN, ipl);
                                  Real &pL = ql(IPR, ipl);
                                  Real &eL = ql(ISE, ipl);
-                                 Real &bL = qr(IBL, ipl);
+                                 Real &bL = ql(IBL, ipl);
                                  Real &dR = qr(IDN, i);
                                  Real &pR = qr(IPR, i);
                                  Real &eR = qr(ISE, i);

--- a/src/utils/fluxes/riemann/llf.hpp
+++ b/src/utils/fluxes/riemann/llf.hpp
@@ -99,7 +99,7 @@ struct RiemannSolver<RSolver::llf, FLUID_TYPE, CTYPE,
             if constexpr (FLUID_TYPE == Fluid::gas) {
               wl_ipr = wl(IPR, i);
               wl_ise = wl(ISE, i);
-              wl_ibl = wr(IBL, i);
+              wl_ibl = wl(IBL, i);
               wr_ipr = wr(IPR, i);
               wr_ise = wr(ISE, i);
               wr_ibl = wr(IBL, i);


### PR DESCRIPTION
## Background

Two bugs:

- In recon fixup, but we've probably never hit this since you'd have to have c^2 and P < 0
- In LLF

## Description of Changes

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files
- [ ] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was created in part or in whole by generative AI`